### PR TITLE
Fix build for macs that have the mac JDK layout vs. standard JDK layout

### DIFF
--- a/generator/pom.xml
+++ b/generator/pom.xml
@@ -57,7 +57,7 @@
       <artifactId>tools</artifactId>
       <version>1.6.0</version>
       <scope>system</scope>
-      <systemPath>${java.home}/../lib/tools.jar</systemPath>
+      <systemPath>${toolsjar}</systemPath>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -108,4 +108,30 @@
       </plugin>
     </plugins>
   </build>
+  <profiles>
+    <profile>
+        <id>default-profile</id>
+        <activation>
+            <activeByDefault>true</activeByDefault>
+            <file>
+                <exists>${java.home}/../lib/tools.jar</exists>
+            </file>
+        </activation>
+        <properties>
+            <toolsjar>${java.home}/../lib/tools.jar</toolsjar>
+        </properties>
+    </profile>
+    <profile>
+        <id>mac-profile</id>
+        <activation>
+            <activeByDefault>false</activeByDefault>
+            <file>
+                <exists>${java.home}/../Classes/classes.jar</exists>
+            </file>
+        </activation>
+        <properties>
+            <toolsjar>${java.home}/../Classes/classes.jar</toolsjar>
+        </properties>
+    </profile>
+</profiles>
 </project>

--- a/src-subject/pom.xml
+++ b/src-subject/pom.xml
@@ -34,7 +34,7 @@
 			<artifactId>tools</artifactId>
 			<version>1.6.0</version>
 			<scope>system</scope>
-			<systemPath>${java.home}/../lib/tools.jar</systemPath>
+			<systemPath>${toolsjar}</systemPath>
 		</dependency>
 		<dependency>
 			<groupId>com.google.code.findbugs</groupId>


### PR DESCRIPTION
Add two profiles activated on the presence of tools.jar or classes.jar to support standard and mac JDK layouts.
