### PR TITLE
Repackage all of the annotation processors into 'processor' subpackages.

### DIFF
--- a/factory/src/main/java/com/google/auto/factory/processor/AutoFactoryDeclaration.java
+++ b/factory/src/main/java/com/google/auto/factory/processor/AutoFactoryDeclaration.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.google.auto.factory;
+package com.google.auto.factory.processor;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -36,6 +36,7 @@ import javax.lang.model.util.Elements;
 import javax.lang.model.util.SimpleAnnotationValueVisitor6;
 import javax.lang.model.util.SimpleTypeVisitor6;
 
+import com.google.auto.factory.AutoFactory;
 import com.google.common.base.Optional;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSet;

--- a/factory/src/main/java/com/google/auto/factory/processor/AutoFactoryProcessor.java
+++ b/factory/src/main/java/com/google/auto/factory/processor/AutoFactoryProcessor.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.google.auto.factory;
+package com.google.auto.factory.processor;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -36,6 +36,8 @@ import javax.lang.model.util.ElementFilter;
 import javax.lang.model.util.Elements;
 import javax.tools.Diagnostic.Kind;
 
+import com.google.auto.factory.AutoFactory;
+import com.google.auto.factory.Provided;
 import com.google.auto.service.AutoService;
 import com.google.common.base.Function;
 import com.google.common.base.Optional;

--- a/factory/src/main/java/com/google/auto/factory/processor/AutoFactoryProcessorModule.java
+++ b/factory/src/main/java/com/google/auto/factory/processor/AutoFactoryProcessorModule.java
@@ -13,19 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.google.auto.factory;
+package com.google.auto.factory.processor;
 
-import static com.google.auto.factory.AutoFactoryDeclaration.Factory.isValidIdentifier;
-import static org.truth0.Truth.ASSERT;
+import dagger.Module;
 
-import org.junit.Test;
-
-public class AutoFactoryDeclarationTest {
-  @Test public void identifiers() {
-    ASSERT.that(isValidIdentifier("String")).isTrue();
-    ASSERT.that(isValidIdentifier("9CantStartWithNumber")).isFalse();
-    ASSERT.that(isValidIdentifier("enum")).isFalse();
-    ASSERT.that(isValidIdentifier("goto")).isFalse();
-    ASSERT.that(isValidIdentifier("InvalidCharacter!")).isFalse();
-  }
-}
+/**
+ * The Dagger module that declares all of the bindings for {@link AutoFactoryProcessor}.
+ *
+ * @author Gregory Kick
+ */
+@Module(addsTo = ProcessorModule.class, injects = AutoFactoryProcessor.class)
+final class AutoFactoryProcessorModule { }

--- a/factory/src/main/java/com/google/auto/factory/processor/Elements2.java
+++ b/factory/src/main/java/com/google/auto/factory/processor/Elements2.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.google.auto.factory;
+package com.google.auto.factory.processor;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;

--- a/factory/src/main/java/com/google/auto/factory/processor/FactoryDescriptor.java
+++ b/factory/src/main/java/com/google/auto/factory/processor/FactoryDescriptor.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.google.auto.factory;
+package com.google.auto.factory.processor;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 

--- a/factory/src/main/java/com/google/auto/factory/processor/FactoryDescriptorGenerator.java
+++ b/factory/src/main/java/com/google/auto/factory/processor/FactoryDescriptorGenerator.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.google.auto.factory;
+package com.google.auto.factory.processor;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -33,6 +33,8 @@ import javax.lang.model.element.VariableElement;
 import javax.lang.model.util.ElementKindVisitor6;
 import javax.lang.model.util.Elements;
 
+import com.google.auto.factory.AutoFactory;
+import com.google.auto.factory.Provided;
 import com.google.common.base.Function;
 import com.google.common.base.Functions;
 import com.google.common.base.Predicate;

--- a/factory/src/main/java/com/google/auto/factory/processor/FactoryWriter.java
+++ b/factory/src/main/java/com/google/auto/factory/processor/FactoryWriter.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.google.auto.factory;
+package com.google.auto.factory.processor;
 
 import static javax.lang.model.element.Modifier.FINAL;
 import static javax.lang.model.element.Modifier.PRIVATE;

--- a/factory/src/main/java/com/google/auto/factory/processor/ImplemetationMethodDescriptor.java
+++ b/factory/src/main/java/com/google/auto/factory/processor/ImplemetationMethodDescriptor.java
@@ -13,10 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.google.auto.factory;
-
-import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.base.Preconditions.checkState;
+package com.google.auto.factory.processor;
 
 import java.util.Set;
 
@@ -26,37 +23,19 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
 
-/**
- * A value object representing a factory method to be generated.
- *
- * @author Gregory Kick
- */
-final class FactoryMethodDescriptor {
-  private final AutoFactoryDeclaration declaration;
+final class ImplemetationMethodDescriptor {
   private final String factoryName;
   private final String name;
   private final String returnType;
   private final boolean publicMethod;
-  private final boolean override;
   private final ImmutableSet<Parameter> passedParameters;
-  private final ImmutableSet<Parameter> providedParameters;
-  private final ImmutableSet<Parameter> creationParameters;
 
-  private FactoryMethodDescriptor(Builder builder) {
-    this.declaration = builder.declaration;
+  private ImplemetationMethodDescriptor(Builder builder) {
     this.factoryName = builder.factoryName.get();
     this.name = builder.name.get();
     this.returnType = builder.returnType.get();
     this.publicMethod = builder.publicMethod;
-    this.override = builder.override;
     this.passedParameters = ImmutableSet.copyOf(builder.passedParameters);
-    this.providedParameters = ImmutableSet.copyOf(builder.providedParameters);
-    this.creationParameters = ImmutableSet.copyOf(builder.creationParameters);
-    checkState(creationParameters.equals(Sets.union(passedParameters, providedParameters)));
-  }
-
-  AutoFactoryDeclaration declaration() {
-    return declaration;
   }
 
   String factoryName() {
@@ -71,24 +50,12 @@ final class FactoryMethodDescriptor {
     return returnType;
   }
 
-  public boolean publicMethod() {
+  boolean publicMethod() {
     return publicMethod;
-  }
-
-  public boolean override() {
-    return override;
   }
 
   ImmutableSet<Parameter> passedParameters() {
     return passedParameters;
-  }
-
-  ImmutableSet<Parameter> providedParameters() {
-    return providedParameters;
-  }
-
-  ImmutableSet<Parameter> creationParameters() {
-    return creationParameters;
   }
 
   @Override
@@ -97,25 +64,17 @@ final class FactoryMethodDescriptor {
         .add("factoryName", factoryName)
         .add("name", name)
         .add("returnType", returnType)
-        .add("passed", passedParameters)
-        .add("provided", providedParameters)
+        .add("publicMethod", publicMethod)
+        .add("passedParameters", passedParameters)
         .toString();
   }
 
   static final class Builder {
-    private final AutoFactoryDeclaration declaration;
     private Optional<String> factoryName = Optional.absent();
     private Optional<String> name = Optional.absent();
     private Optional<String> returnType = Optional.absent();
     private boolean publicMethod = false;
-    private boolean override = false;
     private final Set<Parameter> passedParameters = Sets.newLinkedHashSet();
-    private final Set<Parameter> providedParameters = Sets.newLinkedHashSet();
-    private final Set<Parameter> creationParameters = Sets.newLinkedHashSet();
-
-    Builder(AutoFactoryDeclaration declaration) {
-      this.declaration = checkNotNull(declaration);
-    }
 
     Builder factoryName(String factoryName) {
       this.factoryName = Optional.of(factoryName);
@@ -141,28 +100,13 @@ final class FactoryMethodDescriptor {
       return this;
     }
 
-    Builder override() {
-      this.override = true;
-      return this;
-    }
-
     Builder passedParameters(Iterable<Parameter> passedParameters) {
       Iterables.addAll(this.passedParameters, passedParameters);
       return this;
     }
 
-    Builder providedParameters(Iterable<Parameter> providedParameters) {
-      Iterables.addAll(this.providedParameters, providedParameters);
-      return this;
-    }
-
-    Builder creationParameters(Iterable<Parameter> creationParameters) {
-      Iterables.addAll(this.creationParameters, creationParameters);
-      return this;
-    }
-
-    FactoryMethodDescriptor build() {
-      return new FactoryMethodDescriptor(this);
+    ImplemetationMethodDescriptor build() {
+      return new ImplemetationMethodDescriptor(this);
     }
   }
 }

--- a/factory/src/main/java/com/google/auto/factory/processor/Key.java
+++ b/factory/src/main/java/com/google/auto/factory/processor/Key.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.google.auto.factory;
+package com.google.auto.factory.processor;
 
 import com.google.common.base.Objects;
 import com.google.common.base.Optional;

--- a/factory/src/main/java/com/google/auto/factory/processor/Mirrors.java
+++ b/factory/src/main/java/com/google/auto/factory/processor/Mirrors.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.google.auto.factory;
+package com.google.auto.factory.processor;
 
 import java.lang.annotation.Annotation;
 import java.util.Map;

--- a/factory/src/main/java/com/google/auto/factory/processor/Parameter.java
+++ b/factory/src/main/java/com/google/auto/factory/processor/Parameter.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.google.auto.factory;
+package com.google.auto.factory.processor;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;

--- a/factory/src/main/java/com/google/auto/factory/processor/ProcessorModule.java
+++ b/factory/src/main/java/com/google/auto/factory/processor/ProcessorModule.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.google.auto.factory;
+package com.google.auto.factory.processor;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 

--- a/factory/src/main/java/com/google/auto/factory/processor/ProvidedChecker.java
+++ b/factory/src/main/java/com/google/auto/factory/processor/ProvidedChecker.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.google.auto.factory;
+package com.google.auto.factory.processor;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static javax.tools.Diagnostic.Kind.ERROR;
@@ -24,6 +24,9 @@ import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.VariableElement;
 import javax.lang.model.util.ElementKindVisitor6;
+
+import com.google.auto.factory.AutoFactory;
+import com.google.auto.factory.Provided;
 
 final class ProvidedChecker {
   private final Messager messager;

--- a/factory/src/main/java/com/google/auto/factory/processor/package-info.java
+++ b/factory/src/main/java/com/google/auto/factory/processor/package-info.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2013 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+/**
+ * This package contains the annotation processor that implements the
+ * {@link com.google.auto.factory.AutoFactory} API.
+ */
+package com.google.auto.factory.processor;

--- a/factory/src/test/java/com/google/auto/factory/processor/AutoFactoryDeclarationTest.java
+++ b/factory/src/test/java/com/google/auto/factory/processor/AutoFactoryDeclarationTest.java
@@ -13,14 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.google.auto.factory;
+package com.google.auto.factory.processor;
 
-import dagger.Module;
+import static com.google.auto.factory.processor.AutoFactoryDeclaration.Factory.isValidIdentifier;
+import static org.truth0.Truth.ASSERT;
 
-/**
- * The Dagger module that declares all of the bindings for {@link AutoFactoryProcessor}.
- *
- * @author Gregory Kick
- */
-@Module(addsTo = ProcessorModule.class, injects = AutoFactoryProcessor.class)
-final class AutoFactoryProcessorModule { }
+import org.junit.Test;
+
+public class AutoFactoryDeclarationTest {
+  @Test public void identifiers() {
+    ASSERT.that(isValidIdentifier("String")).isTrue();
+    ASSERT.that(isValidIdentifier("9CantStartWithNumber")).isFalse();
+    ASSERT.that(isValidIdentifier("enum")).isFalse();
+    ASSERT.that(isValidIdentifier("goto")).isFalse();
+    ASSERT.that(isValidIdentifier("InvalidCharacter!")).isFalse();
+  }
+}

--- a/factory/src/test/java/com/google/auto/factory/processor/AutoFactoryProcessorTest.java
+++ b/factory/src/test/java/com/google/auto/factory/processor/AutoFactoryProcessorTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.google.auto.factory;
+package com.google.auto.factory.processor;
 
 import static com.google.testing.compile.JavaSourceSubjectFactory.javaSource;
 import static com.google.testing.compile.JavaSourcesSubjectFactory.javaSources;
@@ -23,6 +23,7 @@ import javax.tools.JavaFileObject;
 
 import org.junit.Test;
 
+import com.google.auto.factory.processor.AutoFactoryProcessor;
 import com.google.common.collect.ImmutableSet;
 import com.google.testing.compile.JavaFileObjects;
 

--- a/factory/src/test/resources/tests/ConstructorAnnotatedFactory.java
+++ b/factory/src/test/resources/tests/ConstructorAnnotatedFactory.java
@@ -19,7 +19,7 @@ import javax.annotation.Generated;
 import javax.inject.Inject;
 import javax.inject.Provider;
 
-@Generated("com.google.auto.factory.AutoFactoryProcessor")
+@Generated("com.google.auto.factory.processor.AutoFactoryProcessor")
 final class ConstructorAnnotatedFactory {
   private final Provider<Object> objProvider;
   

--- a/factory/src/test/resources/tests/CustomNamedFactory.java
+++ b/factory/src/test/resources/tests/CustomNamedFactory.java
@@ -18,7 +18,7 @@ package tests;
 import javax.annotation.Generated;
 import javax.inject.Inject;
 
-@Generated("com.google.auto.factory.AutoFactoryProcessor")
+@Generated("com.google.auto.factory.processor.AutoFactoryProcessor")
 final class CustomNamedFactory {
   @Inject CustomNamedFactory() {}
   

--- a/factory/src/test/resources/tests/MixedDepsImplementingInterfacesFactory.java
+++ b/factory/src/test/resources/tests/MixedDepsImplementingInterfacesFactory.java
@@ -27,7 +27,7 @@ import tests.MixedDepsImplementingInterfaces.MarkerB;
 /**
  * @author Gregory Kick
  */
-@Generated("com.google.auto.factory.AutoFactoryProcessor")
+@Generated("com.google.auto.factory.processor.AutoFactoryProcessor")
 final class MixedDepsImplementingInterfacesFactory
     implements FromInt, FromObject, MarkerA, MarkerB {
   private final Provider<String> sProvider;

--- a/factory/src/test/resources/tests/PublicClassFactory.java
+++ b/factory/src/test/resources/tests/PublicClassFactory.java
@@ -18,7 +18,7 @@ package tests;
 import javax.annotation.Generated;
 import javax.inject.Inject;
 
-@Generated("com.google.auto.factory.AutoFactoryProcessor")
+@Generated("com.google.auto.factory.processor.AutoFactoryProcessor")
 public final class PublicClassFactory {
   @Inject public PublicClassFactory() {}
   

--- a/factory/src/test/resources/tests/SimpleClassFactory.java
+++ b/factory/src/test/resources/tests/SimpleClassFactory.java
@@ -18,7 +18,7 @@ package tests;
 import javax.annotation.Generated;
 import javax.inject.Inject;
 
-@Generated("com.google.auto.factory.AutoFactoryProcessor")
+@Generated("com.google.auto.factory.processor.AutoFactoryProcessor")
 final class SimpleClassFactory {
   @Inject SimpleClassFactory() {}
   

--- a/factory/src/test/resources/tests/SimpleClassImplementingMarkerFactory.java
+++ b/factory/src/test/resources/tests/SimpleClassImplementingMarkerFactory.java
@@ -19,7 +19,7 @@ import javax.annotation.Generated;
 import javax.inject.Inject;
 import java.util.RandomAccess;
 
-@Generated("com.google.auto.factory.AutoFactoryProcessor")
+@Generated("com.google.auto.factory.processor.AutoFactoryProcessor")
 final class SimpleClassImplementingMarkerFactory implements RandomAccess {
   @Inject SimpleClassImplementingMarkerFactory() {}
   

--- a/factory/src/test/resources/tests/SimpleClassImplementingSimpleInterfaceFactory.java
+++ b/factory/src/test/resources/tests/SimpleClassImplementingSimpleInterfaceFactory.java
@@ -19,7 +19,7 @@ import javax.annotation.Generated;
 import javax.inject.Inject;
 import tests.SimpleClassImplementingSimpleInterface.SimpleInterface;
 
-@Generated("com.google.auto.factory.AutoFactoryProcessor")
+@Generated("com.google.auto.factory.processor.AutoFactoryProcessor")
 final class SimpleClassImplementingSimpleInterfaceFactory implements SimpleInterface {
   @Inject SimpleClassImplementingSimpleInterfaceFactory() {}
   

--- a/factory/src/test/resources/tests/SimpleClassMixedDepsFactory.java
+++ b/factory/src/test/resources/tests/SimpleClassMixedDepsFactory.java
@@ -19,7 +19,7 @@ import javax.annotation.Generated;
 import javax.inject.Inject;
 import javax.inject.Provider;
 
-@Generated("com.google.auto.factory.AutoFactoryProcessor")
+@Generated("com.google.auto.factory.processor.AutoFactoryProcessor")
 final class SimpleClassMixedDepsFactory {
   private final Provider<String> providedDepAProvider;
   

--- a/factory/src/test/resources/tests/SimpleClassPassedDepsFactory.java
+++ b/factory/src/test/resources/tests/SimpleClassPassedDepsFactory.java
@@ -18,7 +18,7 @@ package tests;
 import javax.annotation.Generated;
 import javax.inject.Inject;
 
-@Generated("com.google.auto.factory.AutoFactoryProcessor")
+@Generated("com.google.auto.factory.processor.AutoFactoryProcessor")
 final class SimpleClassPassedDepsFactory {
   @Inject SimpleClassPassedDepsFactory() {}
   

--- a/factory/src/test/resources/tests/SimpleClassProvidedDepsFactory.java
+++ b/factory/src/test/resources/tests/SimpleClassProvidedDepsFactory.java
@@ -19,7 +19,7 @@ import javax.annotation.Generated;
 import javax.inject.Inject;
 import javax.inject.Provider;
 
-@Generated("com.google.auto.factory.AutoFactoryProcessor")
+@Generated("com.google.auto.factory.processor.AutoFactoryProcessor")
 final class SimpleClassProvidedDepsFactory {
   private final Provider<String> providedDepAProvider;
   private final Provider<String> providedDepBProvider;

--- a/service/src/main/java/com/google/auto/service/processor/AutoServiceProcessor.java
+++ b/service/src/main/java/com/google/auto/service/processor/AutoServiceProcessor.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.google.auto.service;
+package com.google.auto.service.processor;
 
 import java.io.File;
 import java.io.IOException;
@@ -44,6 +44,7 @@ import javax.tools.Diagnostic.Kind;
 import javax.tools.FileObject;
 import javax.tools.StandardLocation;
 
+import com.google.auto.service.AutoService;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;

--- a/service/src/main/java/com/google/auto/service/processor/ServicesFiles.java
+++ b/service/src/main/java/com/google/auto/service/processor/ServicesFiles.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.google.auto.service;
+package com.google.auto.service.processor;
 
 import static com.google.common.base.Charsets.UTF_8;
 

--- a/service/src/main/java/com/google/auto/service/processor/package-info.java
+++ b/service/src/main/java/com/google/auto/service/processor/package-info.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2013 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+/**
+ * This package contains the annotation processor that implements the
+ * {@link com.google.auto.service.AutoService} API.
+ */
+package com.google.auto.service.processor;

--- a/service/src/main/resources/META-INF/services/javax.annotation.processing.Processor
+++ b/service/src/main/resources/META-INF/services/javax.annotation.processing.Processor
@@ -1,1 +1,1 @@
-com.google.auto.service.AutoServiceProcessor
+com.google.auto.service.processor.AutoServiceProcessor

--- a/service/src/test/java/com/google/auto/service/processor/AutoServiceProcessorTest.java
+++ b/service/src/test/java/com/google/auto/service/processor/AutoServiceProcessorTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.google.auto.service;
+package com.google.auto.service.processor;
 
 import static com.google.testing.compile.JavaSourcesSubjectFactory.javaSources;
 import static org.truth0.Truth.ASSERT;
@@ -24,6 +24,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+import com.google.auto.service.processor.AutoServiceProcessor;
 import com.google.testing.compile.JavaFileObjects;
 
 /**

--- a/value/src/main/java/com/google/auto/value/processor/AbstractMethodExtractor.java
+++ b/value/src/main/java/com/google/auto/value/processor/AbstractMethodExtractor.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.google.auto.value;
+package com.google.auto.value.processor;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;

--- a/value/src/main/java/com/google/auto/value/processor/AbstractMethodLister.java
+++ b/value/src/main/java/com/google/auto/value/processor/AbstractMethodLister.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.google.auto.value;
+package com.google.auto.value.processor;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/value/src/main/java/com/google/auto/value/processor/AutoValueProcessor.java
+++ b/value/src/main/java/com/google/auto/value/processor/AutoValueProcessor.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.google.auto.value;
+package com.google.auto.value.processor;
 
 import java.io.IOException;
 import java.io.Writer;
@@ -49,6 +49,7 @@ import javax.tools.Diagnostic;
 import javax.tools.JavaFileObject;
 
 import com.google.auto.service.AutoService;
+import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableSet;
 
 /**

--- a/value/src/main/java/com/google/auto/value/processor/EclipseHack.java
+++ b/value/src/main/java/com/google/auto/value/processor/EclipseHack.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.google.auto.value;
+package com.google.auto.value.processor;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -43,7 +43,7 @@ import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
 import javax.tools.Diagnostic;
 
-import com.google.auto.value.AutoValueProcessor.Property;
+import com.google.auto.value.processor.AutoValueProcessor.Property;
 
 /**
  * Works around an Eclipse bug where methods are sorted into alphabetical order before being given

--- a/value/src/main/java/com/google/auto/value/processor/JavaTokenizer.java
+++ b/value/src/main/java/com/google/auto/value/processor/JavaTokenizer.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.google.auto.value;
+package com.google.auto.value.processor;
 
 import java.io.IOException;
 import java.io.Reader;

--- a/value/src/main/java/com/google/auto/value/processor/Template.java
+++ b/value/src/main/java/com/google/auto/value/processor/Template.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.google.auto.value;
+package com.google.auto.value.processor;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;

--- a/value/src/main/java/com/google/auto/value/processor/package-info.java
+++ b/value/src/main/java/com/google/auto/value/processor/package-info.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2013 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+/**
+ * This package contains the annotation processor that implements the
+ * {@link com.google.auto.value.AutoValue} API.
+ */
+package com.google.auto.value.processor;

--- a/value/src/test/java/com/google/auto/value/processor/CompilationErrorsTest.java
+++ b/value/src/test/java/com/google/auto/value/processor/CompilationErrorsTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.google.auto.value;
+package com.google.auto.value.processor;
 
 import java.io.File;
 import java.io.IOException;
@@ -33,6 +33,7 @@ import javax.tools.ToolProvider;
 
 import junit.framework.TestCase;
 
+import com.google.auto.value.processor.AutoValueProcessor;
 import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;


### PR DESCRIPTION
This makes for a clearer separation between the API and the implementation.
