### PR TITLE
Fix incorrect AutoValue-generated code if a class inherits the same abst...

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -8,12 +8,6 @@
     <module name="FileLength"/>
     <module name="FileTabCharacter"/>
 
-    <!-- Trailing spaces -->
-    <module name="RegexpSingleline">
-        <property name="format" value="\s+$"/>
-        <property name="message" value="Line has trailing spaces."/>
-    </module>
-
     <!-- Space after 'for' and 'if' -->
     <module name="RegexpSingleline">
         <property name="format" value="^\s*(for|if)[^ ]"/>

--- a/value/src/it/functional/src/test/java/com/google/auto/value/AutoValueTest.java
+++ b/value/src/it/functional/src/test/java/com/google/auto/value/AutoValueTest.java
@@ -660,9 +660,21 @@ public class AutoValueTest extends TestCase {
     int answer();
   }
 
-  public void testComplexInheritance() throws Exception {
+  public void testComplexInheritance() {
     ComplexInheritance complex = ComplexInheritance.create("fred");
     assertEquals("fred", complex.name());
     assertEquals(42, complex.answer());
+  }
+
+  @AutoValue
+  public static abstract class InheritTwice implements A, B {
+    public static InheritTwice create(int answer) {
+      return new AutoValue_AutoValueTest_InheritTwice(answer);
+    }
+  }
+
+  public void testInheritTwice() {
+    InheritTwice inheritTwice = InheritTwice.create(42);
+    assertEquals(42, inheritTwice.answer());
   }
 }

--- a/value/src/test/java/com/google/auto/value/processor/CompilationErrorsTest.java
+++ b/value/src/test/java/com/google/auto/value/processor/CompilationErrorsTest.java
@@ -39,6 +39,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.io.Files;
 
+
 /**
  * @author emcmanus@google.com (Éamonn McManus)
  */
@@ -311,7 +312,11 @@ public class CompilationErrorsTest extends TestCase {
     // when that is enabled.
     Set<Diagnostic.Kind> diagnosticKinds = EnumSet.noneOf(Diagnostic.Kind.class);
     for (Diagnostic<?> diagnostic : diagnosticCollector.getDiagnostics()) {
-      if (diagnostic.getKind() == Diagnostic.Kind.NOTE) {
+      boolean ignore = (diagnostic.getKind() == Diagnostic.Kind.NOTE
+          || (diagnostic.getKind() == Diagnostic.Kind.WARNING
+              && diagnostic.getMessage(null).contains(
+                  "No processor claimed any of these annotations")));
+      if (ignore) {
         System.out.println(diagnostic);
       } else {
         diagnosticKinds.add(diagnostic.getKind());


### PR DESCRIPTION
...ract method from two different interfaces.

Ignore stupid compiler warnings about 'No processor claimed any of these annotations.'
Remove the checkstyle rule that forbids trailing space.
