### PR TITLE
Scope has no effect in dependency management section.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,6 @@
         <groupId>com.google.code.findbugs</groupId>
         <artifactId>jsr305</artifactId>
         <version>1.3.9</version>
-        <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>com.google.guava</groupId>
@@ -88,38 +87,32 @@
         <groupId>com.squareup.dagger</groupId>
         <artifactId>dagger-compiler</artifactId>
         <version>1.2.0</version>
-        <optional>true</optional>
       </dependency>
       <dependency>
         <groupId>javax.inject</groupId>
         <artifactId>javax.inject</artifactId>
         <version>1</version>
-        <scope>provided</scope>
       </dependency>
       <!-- test dependencies -->
       <dependency>
         <groupId>com.google.testing.compile</groupId>
         <artifactId>compile-testing</artifactId>
         <version>0.3</version>
-        <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava-testlib</artifactId>
         <version>15.0</version>
-        <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
         <version>4.11</version>
-        <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.truth0</groupId>
         <artifactId>truth</artifactId>
         <version>0.13</version>
-        <scope>test</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
The scope must be provided on the actual dependency declaration of a module. The scope in dependency management can lead to a false sense of security due to perceived effect.
