### PR TITLE
Add Android Parcelable support

### DIFF
--- a/value/pom.xml
+++ b/value/pom.xml
@@ -55,6 +55,12 @@
       <artifactId>asm</artifactId>
       <version>4.1</version>
     </dependency>
+    <dependency>
+      <groupId>com.google.android</groupId>
+      <artifactId>android</artifactId>
+      <version>4.1.1.4</version>
+      <optional>true</optional>
+    </dependency>
     <!-- test dependencies -->
     <dependency>
       <groupId>com.google.guava</groupId>

--- a/value/src/main/java/com/google/auto/value/processor/AutoValueTemplateVars.java
+++ b/value/src/main/java/com/google/auto/value/processor/AutoValueTemplateVars.java
@@ -44,6 +44,9 @@ class AutoValueTemplateVars extends TemplateVars {
   /** The text of the serialVersionUID constant, or empty if there is none. */
   String serialVersionUID;
 
+  /** Whether to generate a Parcelable creator. */
+  Boolean parcelable;
+
   /**
    * The package of the class with the {@code @AutoValue} annotation and its generated subclass.
    */
@@ -86,9 +89,6 @@ class AutoValueTemplateVars extends TemplateVars {
 
       // Imports
       "$[imports:i||import $[i];\n]",
-
-      // @Generated annotation
-      "@javax.annotation.Generated(\"com.google.auto.value.processor.AutoValueProcessor\")",
 
       // Class declaration
       "final class $[subclass]$[formalTypes] extends $[origClass]$[actualTypes] {",
@@ -148,6 +148,32 @@ class AutoValueTemplateVars extends TemplateVars {
 
       // serialVersionUID
       "$[serialVersionUID?\n\n  private static final long serialVersionUID = $[serialVersionUID];]",
+
+          // parcelable
+      "$[parcelable?\n\n",
+      "  public static final android.os.Parcelable.Creator<$[origClass]> CREATOR = new android.os.Parcelable.Creator<$[origClass]>() {",
+      "    @Override public $[origClass] createFromParcel(android.os.Parcel in) {",
+      "      return new $[subclass](in);",
+      "    }",
+      "    @Override public $[origClass][] newArray(int size) {",
+      "      return new $[origClass][size];",
+      "    }",
+      "  };",
+      "",
+      "  private final static java.lang.ClassLoader CL = $[subclass].class.getClassLoader();",
+      "",
+      "  private $[subclass](android.os.Parcel in) {",
+      "    this(\n      $[props:p|,\n      |($[p.castType]) in.readValue(CL)]);",
+      "  }",
+      "",
+      "  @Override public void writeToParcel(android.os.Parcel dest, int flags) {",
+      "$[props:p||    dest.writeValue($[p]);\n]",
+      "  }",
+      "",
+      "  @Override public int describeContents() {",
+      "    return 0;",
+      "  }",
+      "]",
 
       "}"
       // CHECKSTYLE:ON


### PR DESCRIPTION
A couple of weeks ago I [forked](https://github.com/frankiesardo/android-auto-value) `auto-value` to add support for Android Parcelables. Now I discovered than one of the main reasons for the fork, namely running `auto-value` at compile time without including its dependencies inside the apk, can work with the original artefact in Android Studio with a combination of both `provided` scope and `android-apt` plugin.

Since that is a workable solution I see no reason why Parcelable support could not be merged inside this repository. Would you be interested in a PR with android as an optional dependency or is it somehow out of scope for this library?

