### PR TITLE
Fix typo in AutoValue's CompilationTest that meant the expected code was incorrect.

### DIFF
--- a/value/src/test/java/com/google/auto/value/processor/CompilationTest.java
+++ b/value/src/test/java/com/google/auto/value/processor/CompilationTest.java
@@ -63,7 +63,7 @@ public class CompilationTest extends TestCase {
         "final class AutoValue_Baz extends Baz {",
         "  private final int buh;",
         "",
-        "  Auto_Baz(int buh) {",
+        "  AutoValue_Baz(int buh) {",
         "    this.buh = buh;",
         "  }",
         "",


### PR DESCRIPTION
This may signify a bug in compile-testing, since .generatesSources should not have matched.  The error was only detected on a Mac 1.6 JVM as well which is disturbing.

---

Created by MOE: http://code.google.com/p/moe-java
MOE_MIGRATED_REVID=69505432
