### PR TITLE
Test on as many JDKs as Travis supports.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,12 @@ language: java
 install: mvn -f build-pom.xml install clean --fail-never --quiet -DskipTests=true -Dinvoker.skip=true
 script: mvn -f build-pom.xml verify
 
+jdk:
+  - oraclejdk8
+  - oraclejdk7
+  - openjdk7
+  - openjdk6
+
 notifications:
   email: cgruber@google.com
 


### PR DESCRIPTION
Add automated testing under JDK 6 and 8.  We definitely want to support people running under 6 for those constrained to do so for annotation development environments (though the processors won't run under android, their dev environments might).   And we want Java 8 for forward compatibility. 