### PR TITLE
Open-source `@AutoAnnotation`

### DIFF
--- a/value/src/main/java/com/google/auto/value/AutoAnnotation.java
+++ b/value/src/main/java/com/google/auto/value/AutoAnnotation.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2014 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.auto.value;
+
+import java.lang.annotation.Annotation;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.reflect.AnnotatedElement;
+
+/**
+ * Annotation that causes an implementation of an annotation interface to be generated. The
+ * annotation is applied to a method whose return type is an annotation interface. The method can
+ * then create and return an instance of the generated class that conforms to the specification of
+ * {@link Annotation}, in particular as regards {@link Annotation#equals equals} and
+ * {@link Annotation#hashCode hashCode}. These instances behave essentially the same as instances
+ * returned by {@link AnnotatedElement#getAnnotation}.
+ *
+ * <p>For example, suppose you have an annotation like this:
+ * <pre>
+ * package com.google.inject.name;
+ *
+ * public &#64;interface Named {
+ *   String value();
+ * }</pre>
+ *
+ * <p>You could write a method like this to construct implementations of the interface:
+ * <pre>
+ * package com.example;
+ *
+ * public class Names {
+ *   &#64;AutoAnnotation public static Named named(String value) {
+ *     return new AutoAnnotation_Names_named(value);
+ *   }
+ * }</pre>
+ *
+ * <p>Because the annotated method is called {@code Names.named}, the generated class is called
+ * {@code AutoAnnotation_Names_named} in the same package. If the annotated method were in a nested
+ * class, for example {@code Outer.Names.named}, then the generated class would be called
+ * {@code AutoAnnotation_Outer_Names_named}. The generated class is package-private and it is not
+ * expected that it will be referenced outside the {@code @AutoAnnotation} method.
+ *
+ * <p>The names and types of the parameters in the annotated method must be the same as the names
+ * and types of the annotation elements, except that elements which have default values can be
+ * omitted. The parameters do not need to be in any particular order.
+ *
+ * <p>The annotated method does not need to be public. It can have any visibility, including
+ * private. This means the method can be a private implementation called by a public method with a
+ * different API, for example using a builder.
+ *
+ * <p>It is a compile-time error if more than one method with the same name in the same class is
+ * annotated {@code @AutoAnnotation}.
+ *
+ * <p>The constructor of the generated class has the same parameters as the {@code @AutoAnnotation}
+ * method. It will throw {@code NullPointerException} if any parameter is null. In order to
+ * guarantee that the constructed object is immutable, the constructor will clone each array
+ * parameter corresponding to an array-valued annotation member, and the implementation of each such
+ * member will also return a clone of the array.
+ *
+ * @author emcmanus@google.com (Éamonn McManus)
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.SOURCE)
+public @interface AutoAnnotation {
+}

--- a/value/src/main/java/com/google/auto/value/processor/AnnotationDefaults.java
+++ b/value/src/main/java/com/google/auto/value/processor/AnnotationDefaults.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright (C) 2014 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.auto.value.processor;
+
+import java.util.List;
+
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.AnnotationValue;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.VariableElement;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.SimpleAnnotationValueVisitor6;
+import javax.tools.Diagnostic;
+
+/**
+ * Handling of default values for annotation members.
+ *
+ * @author emcmanus@google.com (Éamonn McManus)
+ */
+class AnnotationDefaults {
+  private final ProcessingEnvironment processingEnv;
+  private final TypeSimplifier typeSimplifier;
+  private final ExecutableElement annotatedMethod;
+
+  AnnotationDefaults(
+      ProcessingEnvironment processingEnv,
+      TypeSimplifier typeSimplifier,
+      ExecutableElement annotatedMethod) {
+    this.processingEnv = processingEnv;
+    this.typeSimplifier = typeSimplifier;
+    this.annotatedMethod = annotatedMethod;
+  }
+
+  /**
+   * Visitor that produces a string representation of an annotation value, suitable for inclusion
+   * in a Java source file as the initializer of a variable of the appropriate type.
+   */
+  private class SourceFormVisitor extends SimpleAnnotationValueVisitor6<StringBuilder, Void> {
+    private final StringBuilder sb;
+    private final ExecutableElement memberMethod;
+
+    SourceFormVisitor(StringBuilder sb, ExecutableElement memberMethod) {
+      this.sb = sb;
+      this.memberMethod = memberMethod;
+    }
+
+    @Override
+    protected StringBuilder defaultAction(Object value, Void p) {
+      return sb.append(value);
+    }
+
+    @Override
+    public StringBuilder visitAnnotation(AnnotationMirror a, Void p) {
+      processingEnv.getMessager().printMessage(
+          Diagnostic.Kind.ERROR,
+          "@AutoAnnotation cannot yet supply a default value for annotation-valued member '"
+              + memberMethod.getSimpleName() + "'",
+          annotatedMethod);
+      return sb.append("null");
+    }
+
+    @Override
+    public StringBuilder visitArray(List<? extends AnnotationValue> values, Void p) {
+      sb.append('{');
+      String sep = "";
+      for (AnnotationValue value : values) {
+        sb.append(sep);
+        visit(value);
+        sep = ", ";
+      }
+      return sb.append('}');
+    }
+
+    @Override
+    public StringBuilder visitChar(char c, Void p) {
+      return appendQuoted(sb, c);
+    }
+
+    @Override
+    public StringBuilder visitLong(long i, Void p) {
+      return sb.append(i).append('L');
+    }
+
+    @Override
+    public StringBuilder visitDouble(double d, Void p) {
+      if (Double.isNaN(d)) {
+        return sb.append("Double.NaN");
+      } else if (d == Double.POSITIVE_INFINITY) {
+        return sb.append("Double.POSITIVE_INFINITY");
+      } else if (d == Double.NEGATIVE_INFINITY) {
+        return sb.append("Double.NEGATIVE_INFINITY");
+      } else {
+        return sb.append(d);
+      }
+    }
+
+    @Override
+    public StringBuilder visitFloat(float f, Void p) {
+      if (Float.isNaN(f)) {
+        return sb.append("Float.NaN");
+      } else if (f == Float.POSITIVE_INFINITY) {
+        return sb.append("Float.POSITIVE_INFINITY");
+      } else if (f == Float.NEGATIVE_INFINITY) {
+        return sb.append("Float.NEGATIVE_INFINITY");
+      } else {
+        return sb.append(f).append('F');
+      }
+    }
+
+    @Override
+    public StringBuilder visitEnumConstant(VariableElement c, Void p) {
+      return sb.append(typeSimplifier.simplify(c.asType())).append('.').append(c.getSimpleName());
+    }
+
+    @Override
+    public StringBuilder visitString(String s, Void p) {
+      return appendQuoted(sb, s);
+    }
+
+    @Override
+    public StringBuilder visitType(TypeMirror classConstant, Void p) {
+      return sb.append(typeSimplifier.simplify(classConstant)).append(".class");
+    }
+  }
+
+  /**
+   * Returns a string representation of the default value of the given annotation member, suitable
+   * for inclusion in a Java source file as the initializer of a variable of the appropriate type.
+   */
+  String sourceForm(ExecutableElement memberMethod) {
+    AnnotationValue defaultValue = memberMethod.getDefaultValue();
+    TypeMirror type = memberMethod.getReturnType();
+    StringBuilder sb = new StringBuilder();
+    SourceFormVisitor visitor = new SourceFormVisitor(sb, memberMethod);
+    visitor.visit(defaultValue);
+    return sb.toString();
+  }
+
+  private static StringBuilder appendQuoted(StringBuilder sb, String s) {
+    sb.append('"');
+    for (int i = 0; i < s.length(); i++) {
+      appendEscaped(sb, s.charAt(i));
+    }
+    return sb.append('"');
+  }
+
+  private static StringBuilder appendQuoted(StringBuilder sb, char c) {
+    sb.append('\'');
+    appendEscaped(sb, c);
+    return sb.append('\'');
+  }
+
+  private static void appendEscaped(StringBuilder sb, char c) {
+    switch (c) {
+    case '\\':
+    case '"':
+    case '\'':
+      sb.append('\\').append(c);
+      break;
+    case '\n':
+      sb.append("\\n");
+      break;
+    case '\r':
+      sb.append("\\r");
+      break;
+    case '\t':
+      sb.append("\\t");
+      break;
+    default:
+      if (c < 0x20) {
+        sb.append(String.format("\\%03o", (int) c));
+      } else if (c < 0x7f || Character.isLetter(c)) {
+        sb.append(c);
+      } else {
+        sb.append(String.format("\\u%04x", (int) c));
+      }
+      break;
+    }
+  }
+}

--- a/value/src/main/java/com/google/auto/value/processor/AutoAnnotationProcessor.java
+++ b/value/src/main/java/com/google/auto/value/processor/AutoAnnotationProcessor.java
@@ -1,0 +1,482 @@
+/*
+ * Copyright (C) 2014 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.auto.value.processor;
+
+import com.google.auto.common.SuperficialValidation;
+import com.google.auto.service.AutoService;
+import com.google.auto.value.AutoAnnotation;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.primitives.Primitives;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.annotation.Generated;
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.Processor;
+import javax.annotation.processing.RoundEnvironment;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.AnnotationValue;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.Modifier;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.VariableElement;
+import javax.lang.model.type.ArrayType;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.PrimitiveType;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.ElementFilter;
+import javax.lang.model.util.Types;
+import javax.tools.Diagnostic;
+import javax.tools.JavaFileObject;
+
+/**
+ * Javac annotation processor (compiler plugin) to generate annotation implementations. User code
+ * never references this class.
+ *
+ * @author emcmanus@google.com (Éamonn McManus)
+ */
+@AutoService(Processor.class)
+public class AutoAnnotationProcessor extends AbstractProcessor {
+  public AutoAnnotationProcessor() {}
+
+  @Override
+  public Set<String> getSupportedAnnotationTypes() {
+    return ImmutableSet.of(AutoAnnotation.class.getName());
+  }
+
+  @Override
+  public SourceVersion getSupportedSourceVersion() {
+    return SourceVersion.latestSupported();
+  }
+
+  /**
+   * Issue a compilation error. This method does not throw an exception, since we want to
+   * continue processing and perhaps report other errors.
+   */
+  private void reportError(Element e, String msg, Object... msgParams) {
+    String formattedMessage = String.format(msg, msgParams);
+    processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, formattedMessage, e);
+  }
+
+  /**
+   * Issue a compilation error and return an exception that, when thrown, will cause the processing
+   * of this class to be abandoned. This does not prevent the processing of other classes.
+   */
+  private AbortProcessingException abortWithError(String msg, Element e) {
+    reportError(e, msg);
+    return new AbortProcessingException();
+  }
+
+  private Types typeUtils;
+
+  @Override
+  public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+    typeUtils = processingEnv.getTypeUtils();
+    boolean claimed = (annotations.size() == 1
+        && annotations.iterator().next().getQualifiedName().toString().equals(
+            AutoAnnotation.class.getName()));
+    if (claimed) {
+      process(roundEnv);
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  private void process(RoundEnvironment roundEnv) {
+    Collection<? extends Element> annotatedElements =
+        roundEnv.getElementsAnnotatedWith(AutoAnnotation.class);
+    List<ExecutableElement> methods = ElementFilter.methodsIn(annotatedElements);
+    if (!SuperficialValidation.validateElements(methods) || methodsAreOverloaded(methods)) {
+      return;
+    }
+    for (ExecutableElement method : methods) {
+      try {
+        processMethod(method);
+      } catch (AbortProcessingException e) {
+        // We abandoned this type, but continue with the next.
+      } catch (RuntimeException e) {
+        // Don't propagate this exception, which will confusingly crash the compiler.
+        // Instead, report a compiler error with the stack trace.
+        String trace = Throwables.getStackTraceAsString(e);
+        reportError(method, "@AutoAnnotation processor threw an exception: %s", trace);
+      }
+    }
+  }
+
+  private void processMethod(ExecutableElement method) {
+    if (!method.getModifiers().contains(Modifier.STATIC)) {
+      throw abortWithError("@AutoAnnotation method must be static", method);
+    }
+
+    TypeElement annotationElement = getAnnotationReturnType(method);
+    TypeMirror annotationTypeMirror = annotationElement.asType();
+
+    Set<Class<?>> wrapperTypesUsedInCollections = wrapperTypesUsedInCollections(method);
+
+    ImmutableMap<String, ExecutableElement> memberMethods = getMemberMethods(annotationElement);
+    Set<TypeMirror> memberTypes = getMemberTypes(memberMethods.values());
+    Set<TypeMirror> referencedTypes = getReferencedTypes(
+        annotationTypeMirror, method, memberTypes, wrapperTypesUsedInCollections);
+    TypeElement methodClass = (TypeElement) method.getEnclosingElement();
+    String pkg = TypeSimplifier.packageNameOf(methodClass);
+    TypeSimplifier typeSimplifier = new TypeSimplifier(
+        typeUtils, pkg, referencedTypes, annotationTypeMirror);
+
+    AnnotationDefaults annotationDefaults =
+        new AnnotationDefaults(processingEnv, typeSimplifier, method);
+    ImmutableMap<String, AnnotationValue> defaultValues = getDefaultValues(annotationElement);
+    ImmutableMap<String, Member> members =
+        getMembers(memberMethods, typeSimplifier, annotationDefaults);
+    ImmutableMap<String, Parameter> parameters =
+        getParameters(annotationElement, method, members, typeSimplifier);
+    validateParameters(annotationElement, method, members, parameters, defaultValues);
+
+    String generatedClassName = generatedClassName(method);
+
+    AutoAnnotationTemplateVars vars = new AutoAnnotationTemplateVars();
+    vars.annotationFullName = annotationElement.toString();
+    vars.annotationName = typeSimplifier.simplify(annotationElement.asType());
+    vars.className = generatedClassName;
+    vars.imports = typeSimplifier.typesToImport();
+    vars.generated = typeSimplifier.simplify(getTypeMirror(Generated.class));
+    vars.arrays = typeSimplifier.simplify(getTypeMirror(Arrays.class));
+    vars.members = members;
+    vars.params = parameters;
+    vars.pkg = pkg;
+    vars.wrapperTypesUsedInCollections = wrapperTypesUsedInCollections;
+    String text = vars.toText();
+    text = Reformatter.fixup(text);
+    writeSourceFile(pkg + "." + generatedClassName, text, methodClass);
+  }
+
+  private boolean methodsAreOverloaded(List<ExecutableElement> methods) {
+    boolean overloaded = false;
+    Set<String> classNames = new HashSet<String>();
+    for (ExecutableElement method : methods) {
+      if (!classNames.add(generatedClassName(method))) {
+        overloaded = true;
+        reportError(method, "@AutoAnnotation methods cannot be overloaded");
+      }
+    }
+    return overloaded;
+  }
+
+  private String generatedClassName(ExecutableElement method) {
+    TypeElement type = (TypeElement) method.getEnclosingElement();
+    String name = type.getSimpleName().toString();
+    while (type.getEnclosingElement() instanceof TypeElement) {
+      type = (TypeElement) type.getEnclosingElement();
+      name = type.getSimpleName() + "_" + name;
+    }
+    return "AutoAnnotation_" + name + "_" + method.getSimpleName();
+  }
+
+  private TypeElement getAnnotationReturnType(ExecutableElement method) {
+    TypeMirror returnTypeMirror = method.getReturnType();
+    if (returnTypeMirror.getKind() == TypeKind.DECLARED) {
+      Element returnTypeElement = typeUtils.asElement(method.getReturnType());
+      if (returnTypeElement.getKind() == ElementKind.ANNOTATION_TYPE) {
+        return (TypeElement) returnTypeElement;
+      }
+    }
+    throw abortWithError("Return type of @AutoAnnotation method must be an annotation type, not "
+        + returnTypeMirror, method);
+  }
+
+  private ImmutableMap<String, ExecutableElement> getMemberMethods(TypeElement annotationElement) {
+    ImmutableMap.Builder<String, ExecutableElement> members = ImmutableMap.builder();
+    for (ExecutableElement member :
+        ElementFilter.methodsIn(annotationElement.getEnclosedElements())) {
+      String name = member.getSimpleName().toString();
+      members.put(name, member);
+    }
+    return members.build();
+  }
+
+  private ImmutableMap<String, Member> getMembers(
+      ImmutableMap<String, ExecutableElement> memberMethods,
+      TypeSimplifier typeSimplifier,
+      AnnotationDefaults annotationDefaults) {
+    ImmutableMap.Builder<String, Member> members = ImmutableMap.builder();
+    for (Map.Entry<String, ExecutableElement> entry : memberMethods.entrySet()) {
+      ExecutableElement memberMethod = entry.getValue();
+      String name = memberMethod.getSimpleName().toString();
+      members.put(name, new Member(memberMethod, typeSimplifier, annotationDefaults));
+    }
+    return members.build();
+  }
+
+  private ImmutableMap<String, AnnotationValue> getDefaultValues(TypeElement annotationElement) {
+    ImmutableMap.Builder<String, AnnotationValue> defaultValues = ImmutableMap.builder();
+    for (ExecutableElement member :
+        ElementFilter.methodsIn(annotationElement.getEnclosedElements())) {
+      String name = member.getSimpleName().toString();
+      AnnotationValue defaultValue = member.getDefaultValue();
+      if (defaultValue != null) {
+        defaultValues.put(name, defaultValue);
+      }
+    }
+    return defaultValues.build();
+  }
+
+  private Set<TypeMirror> getMemberTypes(Collection<ExecutableElement> memberMethods) {
+    Set<TypeMirror> types = new TypeMirrorSet();
+    for (ExecutableElement memberMethod : memberMethods) {
+      types.add(memberMethod.getReturnType());
+    }
+    return types;
+  }
+
+  private ImmutableMap<String, Parameter> getParameters(
+      TypeElement annotationElement,
+      ExecutableElement method,
+      Map<String, Member> members,
+      TypeSimplifier typeSimplifier) {
+    ImmutableMap.Builder<String, Parameter> parameters = ImmutableMap.builder();
+    boolean error = false;
+    for (VariableElement parameter : method.getParameters()) {
+      String name = parameter.getSimpleName().toString();
+      Member member = members.get(name);
+      if (member == null) {
+        reportError(parameter,
+            "@AutoAnnotation method parameter '%s' must have the same name as a member of %s",
+            name, annotationElement);
+        error = true;
+      } else {
+        TypeMirror parameterType = parameter.asType();
+        TypeMirror memberType = member.getTypeMirror();
+        if (compatibleTypes(parameterType, memberType)) {
+          parameters.put(name, new Parameter(parameterType, typeSimplifier));
+        } else {
+          reportError(parameter,
+              "@AutoAnnotation method parameter '%s' has type %s but %s.%s has type %s",
+              name, parameterType, annotationElement, name, memberType);
+          error = true;
+        }
+      }
+    }
+    if (error) {
+      throw new AbortProcessingException();
+    }
+    return parameters.build();
+  }
+
+  private void validateParameters(
+      TypeElement annotationElement,
+      ExecutableElement method,
+      ImmutableMap<String, Member> members,
+      ImmutableMap<String, Parameter> parameters,
+      ImmutableMap<String, AnnotationValue> defaultValues) {
+    boolean error = false;
+    for (String memberName : members.keySet()) {
+      if (!parameters.containsKey(memberName) && !defaultValues.containsKey(memberName)) {
+        reportError(method,
+            "@AutoAnnotation method needs a parameter with name '%s' and type %s"
+                + " corresponding to %s.%s, which has no default value",
+            memberName, members.get(memberName).getType(), annotationElement, memberName);
+        error = true;
+      }
+    }
+    if (error) {
+      throw new AbortProcessingException();
+    }
+  }
+
+  /**
+   * Returns true if {@code parameterType} can be used to provide the value of an annotation member
+   * of type {@code memberType}. They must either be the same type, or the member type must be an
+   * array and the parameter type must be a collection of a compatible type.
+   */
+  private boolean compatibleTypes(TypeMirror parameterType, TypeMirror memberType) {
+    if (typeUtils.isAssignable(parameterType, memberType)) {
+      // parameterType assignable to memberType, which in the restricted world of annotations
+      // means they are the same type, or maybe memberType is an annotation type and parameterType
+      // is a subtype of that annotation interface (why would you do that?).
+      return true;
+    }
+    // They're not the same, but we could still consider them compatible if for example
+    // parameterType is List<Integer> and memberType is int[]. We accept any type that is assignable
+    // to Collection<Integer> (in this example).
+    if (memberType.getKind() != TypeKind.ARRAY) {
+      return false;
+    }
+    TypeMirror arrayElementType = ((ArrayType) memberType).getComponentType();
+    TypeMirror wrappedArrayElementType = arrayElementType.getKind().isPrimitive()
+        ? typeUtils.boxedClass((PrimitiveType) arrayElementType).asType()
+        : arrayElementType;
+    TypeElement javaUtilCollection =
+        processingEnv.getElementUtils().getTypeElement(Collection.class.getCanonicalName());
+    DeclaredType collectionOfElement =
+        typeUtils.getDeclaredType(javaUtilCollection, wrappedArrayElementType);
+    return typeUtils.isAssignable(parameterType, collectionOfElement);
+  }
+
+  /**
+   * Returns the wrapper types ({@code Integer.class} etc) that are used in collection parameters
+   * like {@code List<Integer>}. This is needed because we will emit a helper method for each such
+   * type, for example to convert {@code Collection<Integer>} into {@code int[]}.
+   */
+  private Set<Class<?>> wrapperTypesUsedInCollections(ExecutableElement method) {
+    TypeElement javaUtilCollection =
+        processingEnv.getElementUtils().getTypeElement(Collection.class.getName());
+    ImmutableSet.Builder<Class<?>> usedInCollections = ImmutableSet.builder();
+    for (Class<?> wrapper : Primitives.allWrapperTypes()) {
+      DeclaredType collectionOfWrapper =
+          typeUtils.getDeclaredType(javaUtilCollection, getTypeMirror(wrapper));
+      for (VariableElement parameter : method.getParameters()) {
+        if (typeUtils.isAssignable(parameter.asType(), collectionOfWrapper)) {
+          usedInCollections.add(wrapper);
+          break;
+        }
+      }
+    }
+    return usedInCollections.build();
+  }
+
+  private Set<TypeMirror> getReferencedTypes(
+      TypeMirror annotation,
+      ExecutableElement method,
+      Set<TypeMirror> memberTypes,
+      Set<Class<?>> wrapperTypesUsedInCollections) {
+    Set<TypeMirror> types = new TypeMirrorSet();
+    types.add(annotation);
+    types.add(getTypeMirror(Generated.class));
+    for (VariableElement parameter : method.getParameters()) {
+      // Method parameter types are usually the same as annotation member types, but in the case of
+      // List<Integer> for int[] we are referencing List.
+      types.add(parameter.asType());
+    }
+    types.addAll(memberTypes);
+    if (containsArrayType(types)) {
+      // If there are array properties then we will be referencing java.util.Arrays.
+      types.add(getTypeMirror(Arrays.class));
+    }
+    if (!wrapperTypesUsedInCollections.isEmpty()) {
+      // If there is at least one parameter whose type is a collection of a primitive wrapper type
+      // (for example List<Integer>) then we will be referencing java util.Collection.
+      types.add(getTypeMirror(Collection.class));
+    }
+    return types;
+  }
+
+  private TypeMirror getTypeMirror(Class<?> c) {
+    return processingEnv.getElementUtils().getTypeElement(c.getName()).asType();
+  }
+
+  private static boolean containsArrayType(Set<TypeMirror> types) {
+    for (TypeMirror type : types) {
+      if (type.getKind() == TypeKind.ARRAY) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private void writeSourceFile(String className, String text, TypeElement originatingType) {
+    try {
+      JavaFileObject sourceFile =
+          processingEnv.getFiler().createSourceFile(className, originatingType);
+      Writer writer = sourceFile.openWriter();
+      try {
+        writer.write(text);
+      } finally {
+        writer.close();
+      }
+    } catch (IOException e) {
+      processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR,
+          "Could not write generated class " + className + ": " + e);
+    }
+  }
+
+  public static class Member {
+    private final ExecutableElement method;
+    private final TypeSimplifier typeSimplifier;
+    private final AnnotationDefaults annotationDefaults;
+
+    Member(
+        ExecutableElement method,
+        TypeSimplifier typeSimplifier,
+        AnnotationDefaults annotationDefaults) {
+      this.method = method;
+      this.typeSimplifier = typeSimplifier;
+      this.annotationDefaults = annotationDefaults;
+    }
+
+    @Override
+    public String toString() {
+      return method.getSimpleName().toString();
+    }
+
+    public String getType() {
+      return typeSimplifier.simplify(getTypeMirror());
+    }
+
+    public String getComponentType() {
+      Preconditions.checkState(getTypeMirror().getKind() == TypeKind.ARRAY);
+      ArrayType arrayType = (ArrayType) getTypeMirror();
+      return typeSimplifier.simplify(arrayType.getComponentType());
+    }
+
+    public TypeMirror getTypeMirror() {
+      return method.getReturnType();
+    }
+
+    public TypeKind getKind() {
+      return getTypeMirror().getKind();
+    }
+
+    public String getDefaultValue() {
+      AnnotationValue defaultValue = method.getDefaultValue();
+      if (defaultValue == null) {
+        return null;
+      } else {
+        return annotationDefaults.sourceForm(method);
+      }
+    }
+  }
+
+  public static class Parameter {
+    private final String typeName;
+    private final TypeKind kind;
+
+    Parameter(TypeMirror type, TypeSimplifier typeSimplifier) {
+      this.typeName = typeSimplifier.simplify(type);
+      this.kind = type.getKind();
+    }
+
+    public String getType() {
+      return typeName;
+    }
+
+    public TypeKind getKind() {
+      return kind;
+    }
+  }
+}

--- a/value/src/main/java/com/google/auto/value/processor/AutoAnnotationTemplateVars.java
+++ b/value/src/main/java/com/google/auto/value/processor/AutoAnnotationTemplateVars.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2014 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.auto.value.processor;
+
+import org.apache.velocity.runtime.parser.node.SimpleNode;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedSet;
+
+/**
+ * The variables to substitute into the autoannotation.vm template.
+ *
+ * @author emcmanus@google.com (Éamonn McManus)
+ */
+@SuppressWarnings("unused")  // the fields in this class are only read via reflection
+class AutoAnnotationTemplateVars extends TemplateVars {
+  /**
+   * The members of the annotation being implemented.
+   */
+  Map<String, AutoAnnotationProcessor.Member> members;
+
+  /**
+   * The parameters in the {@code @AutoAnnotation} method, which are also the constructor parameters
+   * in the generated class.
+   */
+  Map<String, AutoAnnotationProcessor.Parameter> params;
+
+  /**
+   * The fully-qualified names of the classes to be imported in the generated class.
+   */
+  SortedSet<String> imports;
+
+  /**
+   * The spelling of the javax.annotation.Generated class: Generated or javax.annotation.Generated.
+   */
+  String generated;
+
+  /** The spelling of the java.util.Arrays class: Arrays or java.util.Arrays. */
+  String arrays;
+
+  /**
+   * The package of the class containing the {@code @AutoAnnotation} annotation, which is also the
+   * package where the annotation implementation will be generated.
+   */
+  String pkg;
+
+  /**
+   * The simple name of the generated class, like {@code AutoAnnotation_Foo_bar}.
+   */
+  String className;
+
+  /**
+   * The name of the annotation interface as it can be referenced in the generated code.
+   */
+  String annotationName;
+
+  /**
+   * The fully-qualified name of the annotation interface.
+   */
+  String annotationFullName;
+
+  /**
+   * The wrapper types (like {@code Integer.class}) that are referenced in collection parameters
+   * (like {@code List<Integer>}).
+   */
+  Set<Class<?>> wrapperTypesUsedInCollections;
+
+  private static final SimpleNode TEMPLATE = parsedTemplateForResource("autoannotation.vm");
+
+  @Override
+  SimpleNode parsedTemplate() {
+    return TEMPLATE;
+  }
+}

--- a/value/src/main/java/com/google/auto/value/processor/autoannotation.vm
+++ b/value/src/main/java/com/google/auto/value/processor/autoannotation.vm
@@ -1,0 +1,347 @@
+## Template for each generated AutoAnnotation_Foo_bar class.
+## This template uses the Apache Velocity Template Language (VTL).
+## The variables ($pkg, $props, and so on) are defined by the fields of AutoAnnotationTemplateVars.
+##
+## Comments, like this one, begin with ##. The comment text extends up to and including the newline
+## character at the end of the line. So comments also serve to join a line to the next one.
+## Velocity deletes a newline after a directive (#if, #foreach, #end etc) so ## is not needed there.
+## That does mean that we sometimes need an extra blank line after such a directive.
+##
+## A post-processing step will remove unwanted spaces and blank lines, but will not join two lines.
+
+#if (!$pkg.empty)
+package $pkg;
+#end
+
+#foreach ($i in $imports)
+import $i;
+#end
+
+@${generated}("com.google.auto.value.processor.AutoAnnotationProcessor")
+final class $className implements $annotationName {
+
+## Fields
+
+#foreach ($m in $members)
+  #if ($params.containsKey($m.toString()))
+
+  private final $m.type $m;
+
+  #else
+
+  private static final $m.type $m = $m.defaultValue;
+
+  #end
+#end
+
+## Constructor
+
+  $className(
+#foreach ($p in $params.keySet())
+
+      $params[$p].type $members[$p] #if ($foreach.hasNext) , #end
+#end ) {
+#foreach ($p in $params.keySet())
+  #if (!$members[$p].kind.primitive)
+
+    if ($p == null) {
+      throw new NullPointerException("Null $p");
+    }
+
+  #end
+
+  #if ($members[$p].kind == "ARRAY")
+    #if ($params[$p].kind == "ARRAY")
+
+    this.$p = ${p}.clone();
+
+    #elseif ($members[$p].typeMirror.componentType.kind.primitive)
+
+    this.$p = ${members[$p].typeMirror.componentType}ArrayFromCollection($p);
+
+    #else
+
+    this.$p = ${p}.toArray(new ${members[$p].componentType}[${p}.size()]);
+
+    #end
+  #else
+
+    this.$p = $p;
+
+  #end
+#end
+
+  }
+
+## annotationType method (defined by the Annotation interface)
+
+  @Override
+  public Class<? extends $annotationName> annotationType() {
+    return ${annotationName}.class;
+  }
+
+## Member getters
+
+#foreach ($m in $members)
+
+  @Override
+  public ${m.type} ${m}() {
+
+  #if ($m.kind == "ARRAY")
+
+    return ${m}.clone();
+
+  #else
+
+    return ${m};
+
+  #end
+
+  }
+
+#end
+
+## toString
+
+#macro (appendMemberString $m)
+  #if ($m.type == "String" || $m.type == "java.lang.String")
+    #set ($appendQuotedStringMethod = "true")
+
+    appendQuoted(sb, $m) ##
+  #elseif ($m.type == "char")
+    #set ($appendQuotedCharMethod = "true")
+
+    appendQuoted(sb, $m) ##
+  #elseif ($m.type == "String[]" || $m.type == "java.lang.String[]")
+    #set ($appendQuotedStringArrayMethod = "true")
+
+    appendQuoted(sb, $m) ##
+  #elseif ($m.type == "char[]")
+    #set ($appendQuotedCharArrayMethod = "true")
+
+    appendQuoted(sb, $m) ##
+  #elseif ($m.kind == "ARRAY")
+
+    sb.append(${arrays}.toString($m)) ##
+  #else
+
+    sb.append($m) ##
+  #end
+#end
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder("@$annotationFullName(");
+
+  #foreach ($p in $params.keySet())
+
+    #if ($params.size() > 1 || $params.keySet().iterator().next() != "value")
+
+    sb.append("$p=");
+    #end
+
+    #appendMemberString($members[$p]);
+
+    #if ($foreach.hasNext)
+
+    sb.append(", ");
+    #end
+
+  #end
+
+    return sb.append(')').toString();
+  }
+
+## equals
+
+#macro (memberEqualsThatExpression $m)
+  #if ($m.kind == "FLOAT")
+    Float.floatToIntBits($m) == Float.floatToIntBits(that.${m}()) ##
+  #elseif ($m.kind == "DOUBLE")
+    Double.doubleToLongBits($m) == Double.doubleToLongBits(that.${m}()) ##
+  #elseif ($m.kind.primitive)
+    $m == that.${m}() ##
+  #elseif ($m.kind == "ARRAY")
+    #if ($params.containsKey($m.toString()))
+    ${arrays}.equals($m,
+        (that instanceof $className)
+            ? (($className) that).$m
+            : that.${m}()) ##
+    #else ## default value, so if |that| is also a $className then it has the same constant value
+    that instanceof $className || ${arrays}.equals($m, that.${m}())
+    #end
+  #else
+    ${m}.equals(that.${m}()) ##
+  #end
+#end
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == this) {
+      return true;
+    }
+    if (o instanceof $annotationName) {
+
+  #if ($members.isEmpty())
+
+      return true;
+
+  #else
+
+      $annotationName that = ($annotationName) o;
+      return ##
+           #foreach ($m in $members)
+           (#memberEqualsThatExpression ($m))##
+             #if ($foreach.hasNext)
+
+           && ##
+             #end
+           #end
+           ;
+  #end
+
+    }
+    return false;
+  }
+
+## hashCode
+
+#macro (memberHashCodeExpression $m)
+  #if ($m.kind == "LONG")
+    (int) (($m >>> 32) ^ $m) ##
+  #elseif ($m.kind == "FLOAT")
+    Float.floatToIntBits($m) ##
+  #elseif ($m.kind == "DOUBLE")
+    (int) ((Double.doubleToLongBits($m) >>> 32) ^ Double.doubleToLongBits($m)) ##
+  #elseif ($m.kind == "BOOLEAN")
+    $m ? 1231 : 1237 ##
+  #elseif ($m.kind.primitive)
+    $m ##
+  #elseif ($m.kind == "ARRAY")
+    ${arrays}.hashCode($m) ##
+  #else
+    ${m}.hashCode() ##
+  #end
+#end
+
+  @Override
+  public int hashCode() {
+  #if ($members.isEmpty())
+
+    return 0;
+
+  #else
+
+    return
+    #foreach ($m in $members)
+
+        ((127 * ${m.toString().hashCode()}) ^ (#memberHashCodeExpression($m))) ##
+        #if ($foreach.hasNext) + #end
+    #end
+        ;
+    #foreach ($m in $members)
+
+    // ${m.toString().hashCode()} is "${m}".hashCode()
+    #end
+
+  #end
+
+  }
+
+## support functions
+
+#foreach ($w in $wrapperTypesUsedInCollections)
+  #set ($prim = $w.getField("TYPE").get(""))
+
+  private static ${prim}[] ${prim}ArrayFromCollection(Collection<${w.simpleName}> c) {
+    ${prim}[] a = new ${prim}[c.size()];
+    int i = 0;
+    for (${prim} x : c) {
+      a[i++] = x;
+    }
+    return a;
+  }
+#end
+
+#if ($appendQuotedStringArrayMethod)
+  #set ($appendQuotedStringMethod = "true")
+
+  private static void appendQuoted(StringBuilder sb, String[] strings) {
+    sb.append('[');
+    String sep = "";
+    for (String s : strings) {
+      sb.append(sep);
+      sep = ", ";
+      appendQuoted(sb, s);
+    }
+    sb.append(']');
+  }
+#end
+
+#if ($appendQuotedCharArrayMethod)
+  #set ($appendQuotedCharMethod = "true")
+
+  private static void appendQuoted(StringBuilder sb, char[] chars) {
+    sb.append('[');
+    String sep = "";
+    for (char c : chars) {
+      sb.append(sep);
+      sep = ", ";
+      appendQuoted(sb, c);
+    }
+    sb.append(']');
+  }
+#end
+
+#if ($appendQuotedStringMethod)
+  #set ($appendEscapedMethod = "true")
+
+  private static void appendQuoted(StringBuilder sb, String s) {
+    sb.append('"');
+    for (int i = 0; i < s.length(); i++) {
+      appendEscaped(sb, s.charAt(i));
+    }
+    sb.append('"');
+  }
+#end
+
+#if ($appendQuotedCharMethod)
+  #set ($appendEscapedMethod = "true")
+
+  private static void appendQuoted(StringBuilder sb, char c) {
+    sb.append('\'');
+    appendEscaped(sb, c);
+    sb.append('\'');
+  }
+#end
+
+#if ($appendEscapedMethod)
+  private static void appendEscaped(StringBuilder sb, char c) {
+    switch (c) {
+    case '\\':
+    case '"':
+    case '\'':
+      sb.append('\\').append(c);
+      break;
+    case '\n':
+      sb.append("\\n");
+      break;
+    case '\r':
+      sb.append("\\r");
+      break;
+    case '\t':
+      sb.append("\\t");
+      break;
+    default:
+      if (c < 0x20) {
+        sb.append(String.format("\\%03o", (int) c));
+      } else if (c < 0x7f || Character.isLetter(c)) {
+        sb.append(c);
+      } else {
+        sb.append(String.format("\\u%04x", (int) c));
+      }
+      break;
+    }
+  }
+#end
+}

--- a/value/src/test/java/com/google/auto/value/processor/AutoAnnotationCompilationTest.java
+++ b/value/src/test/java/com/google/auto/value/processor/AutoAnnotationCompilationTest.java
@@ -1,0 +1,296 @@
+/*
+ * Copyright (C) 2014 The Guava Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.auto.value.processor;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assert_;
+import static com.google.testing.compile.JavaSourcesSubjectFactory.javaSources;
+
+import com.google.common.collect.ImmutableList;
+import com.google.testing.compile.JavaFileObjects;
+
+import junit.framework.TestCase;
+
+import java.io.Writer;
+import java.util.List;
+
+import javax.tools.Diagnostic;
+import javax.tools.DiagnosticCollector;
+import javax.tools.JavaCompiler;
+import javax.tools.JavaFileManager;
+import javax.tools.JavaFileObject;
+import javax.tools.ToolProvider;
+
+/**
+ * @author emcmanus@google.com (Éamonn McManus)
+ */
+public class AutoAnnotationCompilationTest extends TestCase {
+  public void testSimple() {
+    JavaFileObject myAnnotationJavaFile = JavaFileObjects.forSourceLines(
+        "com.example.annotations.MyAnnotation",
+        "package com.example.annotations;",
+        "",
+        "import com.example.enums.MyEnum;",
+        "",
+        "public @interface MyAnnotation {",
+        "  MyEnum value();",
+        "}"
+    );
+    JavaFileObject myEnumJavaFile = JavaFileObjects.forSourceLines(
+        "com.example.enums.MyEnum",
+        "package com.example.enums;",
+        "",
+        "public enum MyEnum {",
+        "  ONE",
+        "}"
+    );
+    JavaFileObject annotationFactoryJavaFile = JavaFileObjects.forSourceLines(
+        "com.example.factories.AnnotationFactory",
+        "package com.example.factories;",
+        "",
+        "import com.google.auto.value.AutoAnnotation;",
+        "import com.example.annotations.MyAnnotation;",
+        "import com.example.enums.MyEnum;",
+        "",
+        "public class AnnotationFactory {",
+        "  @AutoAnnotation",
+        "  public static MyAnnotation newMyAnnotation(MyEnum value) {",
+        "    return new AutoAnnotation_AnnotationFactory_newMyAnnotation(value);",
+        "  }",
+        "}");
+    JavaFileObject expectedOutput = JavaFileObjects.forSourceLines(
+        "com.example.factories.AutoAnnotation_AnnotationFactory_newMyAnnotation",
+        "package com.example.factories;",
+        "",
+        "import com.example.annotations.MyAnnotation;",
+        "import com.example.enums.MyEnum;",
+        "import javax.annotation.Generated",
+        "",
+        "@Generated(\"" + AutoAnnotationProcessor.class.getName() + "\")",
+        "final class AutoAnnotation_AnnotationFactory_newMyAnnotation implements MyAnnotation {",
+        "  private final MyEnum value;",
+        "",
+        "  AutoAnnotation_AnnotationFactory_newMyAnnotation(MyEnum value) {",
+        "    if (value == null) {",
+        "      throw new NullPointerException(\"Null value\");",
+        "    }",
+        "    this.value = value;",
+        "  }",
+        "",
+        "  @Override public Class<? extends MyAnnotation> annotationType() {",
+        "    return MyAnnotation.class;",
+        "  }",
+        "",
+        "  @Override public MyEnum value() {",
+        "    return value;",
+        "  }",
+        "",
+        "  @Override public String toString() {",
+        "    StringBuilder sb = new StringBuilder(\"@com.example.annotations.MyAnnotation(\");",
+        "    sb.append(value);",
+        "    return sb.append(')').toString();",
+        "  }",
+        "",
+        "  @Override public boolean equals(Object o) {",
+        "    if (o == this) {",
+        "      return true;",
+        "    }",
+        "    if (o instanceof MyAnnotation) {",
+        "      MyAnnotation that = (MyAnnotation) o;",
+        "      return (value.equals(that.value()));",
+        "    }",
+        "    return false;",
+        "  }",
+        "",
+        "  @Override public int hashCode() {",
+        "    return ((127 * " + "value".hashCode() + ") ^ (value.hashCode()));",
+        "  }",
+        "}"
+    );
+    assert_().about(javaSources())
+        .that(ImmutableList.of(annotationFactoryJavaFile, myAnnotationJavaFile, myEnumJavaFile))
+        .processedWith(new AutoAnnotationProcessor())
+        .compilesWithoutError()
+        .and().generatesSources(expectedOutput);
+  }
+
+  public void testCollectionsForArrays() {
+    JavaFileObject myAnnotationJavaFile = JavaFileObjects.forSourceLines(
+        "com.example.annotations.MyAnnotation",
+        "package com.example.annotations;",
+        "",
+        "import com.example.enums.MyEnum;",
+        "",
+        "public @interface MyAnnotation {",
+        "  int[] value();",
+        "  MyEnum[] enums() default {};",
+        "}"
+    );
+    JavaFileObject myEnumJavaFile = JavaFileObjects.forSourceLines(
+        "com.example.enums.MyEnum",
+        "package com.example.enums;",
+        "",
+        "public enum MyEnum {",
+        "  ONE",
+        "}"
+    );
+    JavaFileObject annotationFactoryJavaFile = JavaFileObjects.forSourceLines(
+        "com.example.factories.AnnotationFactory",
+        "package com.example.factories;",
+        "",
+        "import com.google.auto.value.AutoAnnotation;",
+        "import com.example.annotations.MyAnnotation;",
+        "import com.example.enums.MyEnum;",
+        "",
+        "import java.util.List;",
+        "import java.util.Set;",
+        "",
+        "public class AnnotationFactory {",
+        "  @AutoAnnotation",
+        "  public static MyAnnotation newMyAnnotation(",
+        "      List<Integer> value, Set<MyEnum> enums) {",
+        "    return new AutoAnnotation_AnnotationFactory_newMyAnnotation(value, enums);",
+        "  }",
+        "}");
+    JavaFileObject expectedOutput = JavaFileObjects.forSourceLines(
+        "com.example.factories.AutoAnnotation_AnnotationFactory_newMyAnnotation",
+        "package com.example.factories;",
+        "",
+        "import com.example.annotations.MyAnnotation;",
+        "import com.example.enums.MyEnum;",
+        "import java.util.Arrays;",
+        "import java.util.Collection;",
+        "import java.util.List;",
+        "import java.util.Set;",
+        "import javax.annotation.Generated",
+        "",
+        "@Generated(\"" + AutoAnnotationProcessor.class.getName() + "\")",
+        "final class AutoAnnotation_AnnotationFactory_newMyAnnotation implements MyAnnotation {",
+        "  private final int[] value;",
+        "  private final MyEnum[] enums;",
+        "",
+        "  AutoAnnotation_AnnotationFactory_newMyAnnotation(",
+        "      List<Integer> value,",
+        "      Set<MyEnum> enums) {",
+        "    if (value == null) {",
+        "      throw new NullPointerException(\"Null value\");",
+        "    }",
+        "    this.value = intArrayFromCollection(value);",
+        "    if (enums == null) {",
+        "      throw new NullPointerException(\"Null enums\");",
+        "    }",
+        "    this.enums = enums.toArray(new MyEnum[enums.size()];",
+        "  }",
+        "",
+        "  @Override public Class<? extends MyAnnotation> annotationType() {",
+        "    return MyAnnotation.class;",
+        "  }",
+        "",
+        "  @Override public int[] value() {",
+        "    return value.clone();",
+        "  }",
+        "",
+        "  @Override public MyEnum[] enums() {",
+        "    return enums.clone();",
+        "  }",
+        "",
+        "  @Override public String toString() {",
+        "    StringBuilder sb = new StringBuilder(\"@com.example.annotations.MyAnnotation(\");",
+        "    sb.append(\"value=\");",
+        "    sb.append(Arrays.toString(value));",
+        "    sb.append(\", \");",
+        "    sb.append(\"enums=\");",
+        "    sb.append(Arrays.toString(enums));",
+        "    return sb.append(')').toString();",
+        "  }",
+        "",
+        "  @Override public boolean equals(Object o) {",
+        "    if (o == this) {",
+        "      return true;",
+        "    }",
+        "    if (o instanceof MyAnnotation) {",
+        "      MyAnnotation that = (MyAnnotation) o;",
+        "      return (Arrays.equals(value,",
+        "          (that instanceof AutoAnnotation_AnnotationFactory_newMyAnnotation)",
+        "              ? ((AutoAnnotation_AnnotationFactory_newMyAnnotation) that).value",
+        "              : that.value()))",
+        "          && (Arrays.equals(enums,",
+        "          (that instanceof AutoAnnotation_AnnotationFactory_newMyAnnotation)",
+        "              ? ((AutoAnnotation_AnnotationFactory_newMyAnnotation) that).enums",
+        "              : that.enums()))",
+        "    }",
+        "    return false;",
+        "  }",
+        "",
+        "  @Override public int hashCode() {",
+        "    return ",
+        "        ((127 * " + "value".hashCode() + ") ^ (Arrays.hashCode(value))) +",
+        "        ((127 * " + "enums".hashCode() + ") ^ (Arrays.hashCode(enums)));",
+        "  }",
+        "",
+        "  private static int[] intArrayFromCollection(Collection<Integer> c) {",
+        "    int[] a = new int[c.size()];",
+        "    int i = 0;",
+        "    for (int x : c) {",
+        "      a[i++] = x;",
+        "    }",
+        "    return a;",
+        "  }",
+        "}"
+    );
+    assert_().about(javaSources())
+        .that(ImmutableList.of(annotationFactoryJavaFile, myEnumJavaFile, myAnnotationJavaFile))
+        .processedWith(new AutoAnnotationProcessor())
+        .compilesWithoutError()
+        .and().generatesSources(expectedOutput);
+  }
+
+  public void testMissingClass() {
+    // Test that referring to an undefined annotation does not trigger @AutoAnnotation processing.
+    // The class Erroneous references an undefined annotation @NotAutoAnnotation. If we didn't have
+    // any special treatment of undefined types then we could run into a compiler bug where
+    // AutoAnnotationProcessor would think that a method annotated with @NotAutoAnnotation was in
+    // fact annotated with @AutoAnnotation. As it is, we do get an error about @NotAutoAnnotation
+    // being undefined, and we do not get an error complaining that this supposed @AutoAnnotation
+    // method is not static. We do need to have @AutoAnnotation appear somewhere so that the
+    // processor will run.
+    JavaFileObject erroneousJavaFileObject = JavaFileObjects.forSourceLines(
+        "com.example.annotations.Erroneous",
+        "package com.example.annotations;",
+        "",
+        "import com.google.auto.value.AutoAnnotation;",
+        "",
+        "public class Erroneous {",
+        "  @interface Empty {}",
+        "  @AutoAnnotation static Empty newEmpty() {}",
+        "  @NotAutoAnnotation Empty notNewEmpty() {}",
+        "}"
+    );
+    JavaCompiler javaCompiler = ToolProvider.getSystemJavaCompiler();
+    DiagnosticCollector<JavaFileObject> diagnosticCollector =
+        new DiagnosticCollector<JavaFileObject>();
+    JavaCompiler.CompilationTask compilationTask = javaCompiler.getTask(
+        (Writer) null, (JavaFileManager) null, diagnosticCollector, (Iterable<String>) null,
+        (Iterable<String>) null, ImmutableList.of(erroneousJavaFileObject));
+    compilationTask.setProcessors(ImmutableList.of(new AutoAnnotationProcessor()));
+    boolean result = compilationTask.call();
+    assertThat(result).isFalse();
+    List<Diagnostic<? extends JavaFileObject>> diagnostics = diagnosticCollector.getDiagnostics();
+    assertThat(diagnostics).isNotEmpty();
+    assertThat(diagnostics.get(0).getMessage(null)).contains("NotAutoAnnotation");
+    assertThat(diagnostics.get(0).getMessage(null)).doesNotContain("static");
+  }
+}

--- a/value/src/test/java/com/google/auto/value/processor/AutoAnnotationErrorsTest.java
+++ b/value/src/test/java/com/google/auto/value/processor/AutoAnnotationErrorsTest.java
@@ -1,0 +1,273 @@
+package com.google.auto.value.processor;
+
+import static com.google.common.truth.Truth.assert_;
+import static com.google.testing.compile.JavaSourcesSubjectFactory.javaSources;
+
+import com.google.common.collect.ImmutableList;
+import com.google.testing.compile.JavaFileObjects;
+
+import junit.framework.TestCase;
+
+import javax.tools.JavaFileObject;
+
+/**
+ * Tests for compilation errors with the AutoAnnotation processor.
+ *
+ * @author emcmanus@google.com (Éamonn McManus)
+ */
+public class AutoAnnotationErrorsTest extends TestCase {
+  private final JavaFileObject TEST_ANNOTATION = JavaFileObjects.forSourceLines(
+      "com.example.TestAnnotation",
+      "package com.example;",
+      "",
+      "public @interface TestAnnotation {",
+      "  int value();",
+      "}");
+
+  public void testCorrect() {
+    assert_().about(javaSources())
+        .that(ImmutableList.of(
+            TEST_ANNOTATION,
+            JavaFileObjects.forSourceLines(
+            "com.foo.Test",
+
+            "package com.foo;",
+            "",
+            "import com.example.TestAnnotation;",
+            "import com.google.auto.value.AutoAnnotation;",
+            "",
+            "class Test {",
+            "  @AutoAnnotation static TestAnnotation newTestAnnotation(int value) {",
+            "    return new AutoAnnotation_Test_newTestAnnotation(value);",
+            "  }",
+            "}"
+        )))
+        .processedWith(new AutoAnnotationProcessor())
+        .compilesWithoutError();
+  }
+
+  public void testNotStatic() {
+    JavaFileObject testSource = JavaFileObjects.forSourceLines(
+        "com.foo.Test",
+        "package com.foo;",
+        "",
+        "import com.example.TestAnnotation;",
+        "import com.google.auto.value.AutoAnnotation;",
+        "",
+        "class Test {",
+        "  @AutoAnnotation TestAnnotation newTestAnnotation(int value) {",
+        "    return new AutoAnnotation_Test_newTestAnnotation(value);",
+        "  }",
+        "}");
+    assert_().about(javaSources())
+        .that(ImmutableList.of(TEST_ANNOTATION, testSource))
+        .processedWith(new AutoAnnotationProcessor())
+        .failsToCompile()
+        .withErrorContaining("must be static")
+        .in(testSource).onLine(7);
+  }
+
+  public void testDoesNotReturnAnnotation() {
+    JavaFileObject testSource = JavaFileObjects.forSourceLines(
+        "com.foo.Test",
+        "package com.foo;",
+        "",
+        "import com.google.auto.value.AutoAnnotation;",
+        "",
+        "class Test {",
+        "  @AutoAnnotation static String newString(int value) {",
+        "    return new AutoAnnotation_Test_newString(value);",
+        "  }",
+        "}");
+    assert_().about(javaSources())
+        .that(ImmutableList.of(TEST_ANNOTATION, testSource))
+        .processedWith(new AutoAnnotationProcessor())
+        .failsToCompile()
+        .withErrorContaining("must be an annotation type, not java.lang.String")
+        .in(testSource).onLine(6);
+  }
+
+  public void testOverload() {
+    JavaFileObject testSource = JavaFileObjects.forSourceLines(
+        "com.foo.Test",
+        "package com.foo;",
+        "",
+        "import com.example.TestAnnotation;",
+        "import com.google.auto.value.AutoAnnotation;",
+        "",
+        "class Test {",
+        "  @AutoAnnotation static TestAnnotation newTestAnnotation(int value) {",
+        "    return new AutoAnnotation_Test_newTestAnnotation(value);",
+        "  }",
+        "",
+        "  @AutoAnnotation static TestAnnotation newTestAnnotation(Integer value) {",
+        "    return new AutoAnnotation_Test_newTestAnnotation(value);",
+        "  }",
+        "}");
+    assert_().about(javaSources())
+        .that(ImmutableList.of(TEST_ANNOTATION, testSource))
+        .processedWith(new AutoAnnotationProcessor())
+        .failsToCompile()
+        .withErrorContaining("@AutoAnnotation methods cannot be overloaded")
+        .in(testSource).onLine(11);
+  }
+
+  public void testWrongName() {
+    JavaFileObject testSource = JavaFileObjects.forSourceLines(
+        "com.foo.Test",
+        "package com.foo;",
+        "",
+        "import com.example.TestAnnotation;",
+        "import com.google.auto.value.AutoAnnotation;",
+        "",
+        "class Test {",
+        "  @AutoAnnotation static TestAnnotation newTestAnnotation(int fred) {",
+        "    return new AutoAnnotation_Test_newTestAnnotation(fred);",
+        "  }",
+        "}");
+    assert_().about(javaSources())
+        .that(ImmutableList.of(TEST_ANNOTATION, testSource))
+        .processedWith(new AutoAnnotationProcessor())
+        .failsToCompile()
+        .withErrorContaining("method parameter 'fred' must have the same name")
+        .in(testSource).onLine(7);
+  }
+
+  public void testWrongType() {
+    JavaFileObject testSource = JavaFileObjects.forSourceLines(
+        "com.foo.Test",
+        "package com.foo;",
+        "",
+        "import com.example.TestAnnotation;",
+        "import com.google.auto.value.AutoAnnotation;",
+        "",
+        "class Test {",
+        "  @AutoAnnotation static TestAnnotation newTestAnnotation(String value) {",
+        "    return new AutoAnnotation_Test_newTestAnnotation(value);",
+        "  }",
+        "}");
+    assert_().about(javaSources())
+        .that(ImmutableList.of(TEST_ANNOTATION, testSource))
+        .processedWith(new AutoAnnotationProcessor())
+        .failsToCompile()
+        .withErrorContaining(
+            "method parameter 'value' has type java.lang.String "
+                + "but com.example.TestAnnotation.value has type int")
+        .in(testSource).onLine(7);
+  }
+
+  public void testWrongTypeCollection() {
+    JavaFileObject testAnnotation = JavaFileObjects.forSourceLines(
+        "com.example.TestAnnotation",
+        "package com.example;",
+        "",
+        "public @interface TestAnnotation {",
+        "  int[] value();",
+        "}");
+    String[] wrongTypes = {
+        "java.util.List<java.lang.Long>",
+        "java.util.List<java.lang.String>",
+        "java.util.Set<java.lang.Long>",
+        "java.util.Map<java.lang.Integer,java.lang.Integer>",
+        "java.util.concurrent.Callable<java.lang.Integer>",
+        "java.util.List<int[]>",
+    };
+    for (String wrongType : wrongTypes) {
+      JavaFileObject testSource = JavaFileObjects.forSourceLines(
+          "com.foo.Test",
+          "package com.foo;",
+          "",
+          "import com.example.TestAnnotation;",
+          "import com.google.auto.value.AutoAnnotation;",
+          "",
+          "class Test {",
+          "  @AutoAnnotation static TestAnnotation newTestAnnotation(" + wrongType + " value) {",
+          "    return new AutoAnnotation_Test_newTestAnnotation(value);",
+          "  }",
+          "}");
+      assert_().withFailureMessage("For wrong type " + wrongType).about(javaSources())
+          .that(ImmutableList.of(testAnnotation, testSource))
+          .processedWith(new AutoAnnotationProcessor())
+          .failsToCompile()
+          .withErrorContaining(
+              "method parameter 'value' has type " + wrongType
+                  + " but com.example.TestAnnotation.value has type int[]")
+          .in(testSource).onLine(7);
+    }
+  }
+
+  public void testExtraParameters() {
+    JavaFileObject testSource = JavaFileObjects.forSourceLines(
+        "com.foo.Test",
+        "package com.foo;",
+        "",
+        "import com.example.TestAnnotation;",
+        "import com.google.auto.value.AutoAnnotation;",
+        "",
+        "class Test {",
+        "  @AutoAnnotation static TestAnnotation newTestAnnotation(int value, int other) {",
+        "    return new AutoAnnotation_Test_newTestAnnotation(value);",
+        "  }",
+        "}");
+    assert_().about(javaSources())
+        .that(ImmutableList.of(TEST_ANNOTATION, testSource))
+        .processedWith(new AutoAnnotationProcessor())
+        .failsToCompile()
+        .withErrorContaining(
+            "method parameter 'other' must have the same name as a member of "
+                + "com.example.TestAnnotation")
+        .in(testSource).onLine(7);
+  }
+
+  public void testMissingParameters() {
+    JavaFileObject testSource = JavaFileObjects.forSourceLines(
+        "com.foo.Test",
+        "package com.foo;",
+        "",
+        "import com.example.TestAnnotation;",
+        "import com.google.auto.value.AutoAnnotation;",
+        "",
+        "class Test {",
+        "  @AutoAnnotation static TestAnnotation newTestAnnotation() {",
+        "    return new AutoAnnotation_Test_newTestAnnotation();",
+        "  }",
+        "}");
+    assert_().about(javaSources())
+        .that(ImmutableList.of(TEST_ANNOTATION, testSource))
+        .processedWith(new AutoAnnotationProcessor())
+        .failsToCompile()
+        .withErrorContaining("method needs a parameter with name 'value' and type int")
+        .in(testSource).onLine(7);
+  }
+
+  public void testAnnotationValuedDefaultsNotSupportedYet() {
+    JavaFileObject annotationSource = JavaFileObjects.forSourceLines(
+        "com.example.TestAnnotation",
+        "package com.example;",
+        "",
+        "public @interface TestAnnotation {",
+        "  String value();",
+        "  Override optionalAnnotation() default @Override;",
+        "}");
+    JavaFileObject testSource = JavaFileObjects.forSourceLines(
+        "com.foo.Test",
+        "package com.foo;",
+        "",
+        "import com.example.TestAnnotation;",
+        "import com.google.auto.value.AutoAnnotation;",
+        "",
+        "class Test {",
+        "  @AutoAnnotation static TestAnnotation newTestAnnotation(String value) {",
+        "    return new AutoAnnotation_Test_newTestAnnotation(value);",
+        "  }",
+        "}");
+    assert_().about(javaSources())
+        .that(ImmutableList.of(annotationSource, testSource))
+        .processedWith(new AutoAnnotationProcessor())
+        .failsToCompile()
+        .withErrorContaining(
+            "@AutoAnnotation cannot yet supply a default value for annotation-valued member "
+                + "'optionalAnnotation'")
+        .in(testSource).onLine(7);
+  }
+}


### PR DESCRIPTION
Open-source `@AutoAnnotation`, an alternative annotation processor for auto-generating @interface implementations which correctly adhere to the `.equals()` and `.hashcode()` contract for annotations per the JDK documentation.  Specifically, this should be used and not `@AutoAnnotation` which is, in a prior commit, prohibited from processing @interface types.

---

Created by MOE: http://code.google.com/p/moe-java
MOE_MIGRATED_REVID=75069737
