### PR TITLE
Use findbugs.annotations instead of findbugs.jsr305

### DIFF
--- a/factory/src/it/functional/pom.xml
+++ b/factory/src/it/functional/pom.xml
@@ -30,8 +30,8 @@
     </dependency>
     <dependency>
       <groupId>com.google.code.findbugs</groupId>
-      <artifactId>jsr305</artifactId>
-      <version>1.3.9</version>
+      <artifactId>annotations</artifactId>
+      <version>2.0.3</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -65,8 +65,8 @@
     <dependencies>
       <dependency>
         <groupId>com.google.code.findbugs</groupId>
-        <artifactId>jsr305</artifactId>
-        <version>1.3.9</version>
+        <artifactId>annotations</artifactId>
+        <version>2.0.3</version>
         <scope>provided</scope>
       </dependency>
       <dependency>

--- a/value/README.md
+++ b/value/README.md
@@ -158,7 +158,7 @@ add the following to your Maven configuration:
     <dependency>
       <groupId>com.google.auto.value</groupId>
       <artifactId>auto-value</artifactId>
-      <version>1.0-rc1</version>
+      <version>1.0</version>
       <scope>provided</scope>
     </dependency>
 ```

--- a/value/src/it/functional/pom.xml
+++ b/value/src/it/functional/pom.xml
@@ -30,8 +30,8 @@
     </dependency>
     <dependency>
       <groupId>com.google.code.findbugs</groupId>
-      <artifactId>jsr305</artifactId>
-      <version>1.3.9</version>
+      <artifactId>annotations</artifactId>
+      <version>2.0.3</version>
       <scope>provided</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
com.google.code.findbugs:jsr305 clashes with com.google.code.findbugs:annotations.  Having both jars as a dependency then clashes with the Maven dependency checker (because it is not very good at handling annotations).

Use the annotations jar instead which has all jsr305 annotations and the additional findbugs stuff.
