### PR TITLE
Fix the SuperficialValidator to properly handle upstream impact on AnnotationValues

### DIFF
--- a/common/src/test/java/com/google/auto/common/MoreTypesIsTypeOfTest.java
+++ b/common/src/test/java/com/google/auto/common/MoreTypesIsTypeOfTest.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright (C) 2014 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.auto.common;
+
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assert_;
+
+import com.google.common.collect.Iterables;
+import com.google.testing.compile.CompilationRule;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import javax.lang.model.element.Element;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.Elements;
+
+/**
+ * Tests {@link MoreTypes#isTypeOf}.
+ */
+@RunWith(JUnit4.class)
+public class MoreTypesIsTypeOfTest {
+
+  @Rule public CompilationRule compilationRule = new CompilationRule();
+
+  private Elements elements;
+
+  @Before public void setUp() {
+    this.elements = compilationRule.getElements();
+  }
+
+  private interface TestType {}
+
+  @Test public void isTypeOf_DeclaredType() {
+    assertThat(MoreTypes.isTypeOf(TestType.class, typeElementFor(TestType.class).asType()))
+        .named("mirror represents the TestType")
+        .isTrue();
+    assertThat(MoreTypes.isTypeOf(String.class, typeElementFor(TestType.class).asType()))
+        .named("mirror does not represent a String")
+        .isFalse();
+  }
+
+  private interface ArrayType {
+    String[] array();
+  }
+
+  @Test public void isTypeOf_ArrayType() {
+    TypeMirror type = extractReturnTypeFromHolder(typeElementFor(ArrayType.class));
+    assertThat(MoreTypes.isTypeOf(new String[] {}.getClass(), type))
+        .named("array mirror represents an array Class object")
+        .isTrue();
+  }
+
+  private interface PrimitiveBoolean {
+    boolean method();
+  }
+
+  @Test public void isTypeOf_PrimitiveBoolean() {
+    TypeMirror type = extractReturnTypeFromHolder(typeElementFor(PrimitiveBoolean.class));
+    assertThat(MoreTypes.isTypeOf(Boolean.TYPE, type)).named("mirror of a boolean").isTrue();
+  }
+
+  private interface PrimitiveByte {
+    byte method();
+  }
+
+  @Test public void isTypeOf_PrimitiveByte() {
+    TypeMirror type = extractReturnTypeFromHolder(typeElementFor(PrimitiveByte.class));
+    assertThat(MoreTypes.isTypeOf(Byte.TYPE, type)).named("mirror of a byte").isTrue();
+  }
+
+  private interface PrimitiveChar {
+    char method();
+  }
+
+  @Test public void isTypeOf_PrimitiveChar() {
+    TypeMirror type = extractReturnTypeFromHolder(typeElementFor(PrimitiveChar.class));
+    assertThat(MoreTypes.isTypeOf(Character.TYPE, type)).named("mirror of a char").isTrue();
+  }
+
+  private interface PrimitiveDouble {
+    double method();
+  }
+
+  @Test public void isTypeOf_PrimitiveDouble() {
+    TypeMirror type = extractReturnTypeFromHolder(typeElementFor(PrimitiveDouble.class));
+    assertThat(MoreTypes.isTypeOf(Double.TYPE, type)).named("mirror of a double").isTrue();
+  }
+
+  private interface PrimitiveFloat {
+    float method();
+  }
+
+  @Test public void isTypeOf_PrimitiveFloat() {
+    TypeMirror type = extractReturnTypeFromHolder(typeElementFor(PrimitiveFloat.class));
+    assertThat(MoreTypes.isTypeOf(Float.TYPE, type)).named("mirror of a float").isTrue();
+  }
+
+  private interface PrimitiveInt {
+    int method();
+  }
+
+  @Test public void isTypeOf_PrimitiveInt() {
+    TypeMirror type = extractReturnTypeFromHolder(typeElementFor(PrimitiveInt.class));
+    assertThat(MoreTypes.isTypeOf(Integer.TYPE, type)).named("mirror of a int").isTrue();
+  }
+
+  private interface PrimitiveLong {
+    long method();
+  }
+
+  @Test public void isTypeOf_PrimitiveLong() {
+    TypeMirror type = extractReturnTypeFromHolder(typeElementFor(PrimitiveLong.class));
+    assertThat(MoreTypes.isTypeOf(Long.TYPE, type)).named("mirror of a long").isTrue();
+  }
+
+  private interface PrimitiveShort {
+    short method();
+  }
+
+  @Test public void isTypeOf_PrimitiveShort() {
+    TypeMirror type = extractReturnTypeFromHolder(typeElementFor(PrimitiveShort.class));
+    assertThat(MoreTypes.isTypeOf(Short.TYPE, type)).named("mirror of a short").isTrue();
+  }
+
+  private interface PrimitiveVoid {
+    void method();
+  }
+
+  @Test public void isTypeOf_void() {
+    TypeMirror primitive = extractReturnTypeFromHolder(typeElementFor(PrimitiveVoid.class));
+    assertThat(MoreTypes.isTypeOf(Void.TYPE, primitive)).named("mirror of a void").isTrue();
+  }
+
+  private interface DeclaredVoid {
+    Void method();
+  }
+
+  @Test public void isTypeOf_Void() {
+    TypeMirror declared = extractReturnTypeFromHolder(typeElementFor(DeclaredVoid.class));
+    assertThat(MoreTypes.isTypeOf(Void.class, declared)).named("mirror of a void").isTrue();
+  }
+
+  @Test public void isTypeOf_fail() {
+    TypeMirror method =
+        getOnlyElement(typeElementFor(DeclaredVoid.class).getEnclosedElements()).asType();
+    try {
+      MoreTypes.isTypeOf(String.class, method);
+      assert_().fail();
+    } catch (IllegalArgumentException expected) {}
+  }
+
+  // Utility methods for this test.
+
+  private TypeMirror extractReturnTypeFromHolder(TypeElement typeElement) {
+    Element element = Iterables.getOnlyElement(typeElement.getEnclosedElements());
+    TypeMirror arrayType = MoreElements.asExecutable(element).getReturnType();
+    return arrayType;
+  }
+
+  private TypeElement typeElementFor(Class<?> clazz) {
+    return elements.getTypeElement(clazz.getCanonicalName());
+  }
+}

--- a/common/src/test/java/com/google/auto/common/SuperficialValidationTest.java
+++ b/common/src/test/java/com/google/auto/common/SuperficialValidationTest.java
@@ -203,6 +203,32 @@ public class SuperficialValidationTest {
         .failsToCompile();
   }
 
+  @Test
+  public void invalidAnnotationValue() {
+    JavaFileObject javaFileObject = JavaFileObjects.forSourceLines("test.Outer",
+        "package test;",
+        "",
+        "final class Outer {",
+        "  @interface TestAnnotation {",
+        "    Class[] classes();",
+        "  }",
+        "",
+        "  @TestAnnotation(classes = Foo)",
+        "  static class TestClass {}",
+        "}");
+    assert_().about(javaSource())
+        .that(javaFileObject)
+        .processedWith(new AssertingProcessor() {
+          @Override void runAssertions() {
+            TypeElement testClassElement =
+                processingEnv.getElementUtils().getTypeElement("test.Outer.TestClass");
+            assert_().that(SuperficialValidation.validateElement(testClassElement))
+                .named("testClassElement is valid").isFalse();
+          }
+        }).failsToCompile();
+  }
+
+
   private static abstract class AssertingProcessor extends AbstractProcessor {
     @Override
     public Set<String> getSupportedAnnotationTypes() {


### PR DESCRIPTION
Fix the SuperficialValidator to properly handle upstream compilation problems resulting in unreasonable AnnotationValues (specifically  "<any>" and "<error>" strings appearing instead of real values where there are missing imports or other upstream compilation issues).  Migrate isTypeOf from Dagger to perform the key test (i.e. is there a sane match between the expected annotation value type and the type returned by the processor environment)

---

Created by MOE: http://code.google.com/p/moe-java
MOE_MIGRATED_REVID=75599279
