### PR TITLE
Fix top level class factory generation

### DIFF
--- a/factory/src/main/java/com/google/auto/factory/processor/FactoryWriter.java
+++ b/factory/src/main/java/com/google/auto/factory/processor/FactoryWriter.java
@@ -169,6 +169,9 @@ final class FactoryWriter {
 
   private static CharSequence getPackage(CharSequence fullyQualifiedName) {
     int lastDot = lastIndexOf(fullyQualifiedName, '.');
+    if (lastDot == -1) {
+      return "";
+    }
     return fullyQualifiedName.subSequence(0, lastDot);
   }
 

--- a/factory/src/test/java/com/google/auto/factory/processor/AutoFactoryProcessorTest.java
+++ b/factory/src/test/java/com/google/auto/factory/processor/AutoFactoryProcessorTest.java
@@ -243,4 +243,13 @@ public class AutoFactoryProcessorTest {
         .and().generatesSources(JavaFileObjects.forResource(
             "expected/FactoryImplementingGenericInterfaceExtension.java"));
   }
+
+  @Test public void topLevelClass() {
+    assert_().about(javaSource())
+        .that(JavaFileObjects.forResource("good/TopLevelClass.java"))
+        .processedWith(new AutoFactoryProcessor())
+        .compilesWithoutError()
+        .and().generatesSources(JavaFileObjects.forResource("expected/TopLevelClassFactory.java"));
+  }
+
 }

--- a/factory/src/test/resources/expected/TopLevelClassFactory.java
+++ b/factory/src/test/resources/expected/TopLevelClassFactory.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2013 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import javax.annotation.Generated;
+import javax.inject.Inject;
+
+@Generated("com.google.auto.factory.processor.AutoFactoryProcessor")
+final class TopLevelClassFactory {
+  @Inject TopLevelClassFactory() {}
+  
+  TopLevelClass create() {
+    return new TopLevelClass();
+  }
+}

--- a/factory/src/test/resources/good/TopLevelClass.java
+++ b/factory/src/test/resources/good/TopLevelClass.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2013 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import com.google.auto.factory.AutoFactory;
+
+@AutoFactory
+final class TopLevelClass {}


### PR DESCRIPTION
FactoryWriter.getPackage() assumed that the fully qualified class name would contain a package and hence failed with a StringIndexOutOfBoundsException for top-level classes without a package.
