### PR TITLE
Fix minor typo in generated code in README.md

### DIFF
--- a/factory/README.md
+++ b/factory/README.md
@@ -39,7 +39,7 @@ import javax.annotation.Generated;
 import javax.inject.Inject;
 import javax.inject.Provider;
 
-@Generated(value = "com.google.auto.factory.AutoFactoryProcessor")
+@Generated(value = "com.google.auto.factory.processor.AutoFactoryProcessor")
 final class SomeClassFactory {
   private final Provider<String> providedDepAProvider;
   


### PR DESCRIPTION
Add missing '.' in @Generated(value = "...") string constant.
