### PR TITLE
Change the AutoValue pom.xml so that it uses the Maven shade plugin to i...

### DIFF
--- a/value/pom.xml
+++ b/value/pom.xml
@@ -123,6 +123,46 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+	<groupId>org.apache.maven.plugins</groupId>
+	<artifactId>maven-shade-plugin</artifactId>
+	<version>2.3</version>
+	<executions>
+	  <execution>
+	    <phase>package</phase>
+	    <goals>
+	      <goal>shade</goal>
+	    </goals>
+	    <configuration>
+	      <minimizeJar>true</minimizeJar>
+              <filters>
+                <filter>
+                   <artifact>org.apache.velocity:*</artifact>
+                   <includes>
+                       <include>**</include>
+                   </includes>
+                </filter>
+              </filters>
+	      <relocations>
+		<!-- We don't relocate Apache classes because they often load classes from strings,
+                     and the relocator doesn't know to rewrite those strings. This applies to both
+                     Velocity and Commons. We also don't minimize Velocity for similar reasons. -->
+		<relocation>
+		  <pattern>org.objectweb</pattern>
+		  <shadedPattern>autovalue.shaded.org.objectweb</shadedPattern>
+		</relocation>
+		<relocation>
+		  <pattern>com.google</pattern>
+		  <shadedPattern>autovalue.shaded.com.google.common</shadedPattern>
+		  <excludes>
+		    <exclude>com.google.auto.value.**</exclude>
+		  </excludes>
+		</relocation>
+	      </relocations>
+	    </configuration>
+	  </execution>
+	</executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/value/src/main/java/com/google/auto/value/processor/TemplateVars.java
+++ b/value/src/main/java/com/google/auto/value/processor/TemplateVars.java
@@ -31,6 +31,7 @@ import java.io.StringWriter;
 import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
+import org.apache.velocity.runtime.resource.ResourceCacheImpl;
 
 /**
  * A template and a set of variables to be substituted into that template. A concrete subclass of
@@ -53,7 +54,13 @@ abstract class TemplateVars {
   static {
     // Ensure that $undefinedvar will produce an exception rather than outputting $undefinedvar.
     velocityRuntimeInstance.setProperty(RuntimeConstants.RUNTIME_REFERENCES_STRICT, "true");
-    velocityRuntimeInstance.setProperty(RuntimeConstants.RUNTIME_LOG_LOGSYSTEM_CLASS, new NullLogChute());
+    velocityRuntimeInstance.setProperty(RuntimeConstants.RUNTIME_LOG_LOGSYSTEM_CLASS,
+        new NullLogChute());
+    velocityRuntimeInstance.setProperty(RuntimeConstants.RESOURCE_MANAGER_CACHE_CLASS,
+        ResourceCacheImpl.class.getName());
+    // Setting ResourceCacheImpl is should not be necessary since that is the default value, but
+    // ensures that Maven shading sees that Apache Commons classes referenced from ResourceCacheImpl
+    // are indeed referenced and cannot be removed during minimization.
 
     // Velocity likes its "managers", LogManager and ResourceManager, which it loads through the
     // context class loader. If that loader can see another copy of Velocity then that will lead


### PR DESCRIPTION
Change the AutoValue pom.xml so that it uses the Maven shade plugin to include all dependencies in the generated jar, and to rename most of them. This is intended to address https://github.com/google/auto/issues/156.
