### PR TITLE
Remove the use of the obsolescent com.google.common.base.Charsets from some tests.

### DIFF
--- a/value/src/test/java/com/google/auto/value/processor/CompilationErrorsTest.java
+++ b/value/src/test/java/com/google/auto/value/processor/CompilationErrorsTest.java
@@ -15,7 +15,6 @@
  */
 package com.google.auto.value.processor;
 
-import com.google.common.base.Charsets;
 import com.google.common.base.Predicates;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ImmutableList;
@@ -30,6 +29,7 @@ import junit.framework.TestCase;
 import java.io.File;
 import java.io.IOException;
 import java.io.StringWriter;
+import java.nio.charset.Charset;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -206,7 +206,7 @@ public class CompilationErrorsTest extends TestCase {
       dir.mkdirs();
       assertTrue(dir.isDirectory());  // True if we just made it, or it was already there.
       String sourceName = className.simpleName + ".java";
-      Files.write(source, new File(dir, sourceName), Charsets.UTF_8);
+      Files.write(source, new File(dir, sourceName), Charset.forName("UTF-8"));
       classNames.add(className.fullName());
       JavaFileObject sourceFile = fileManager.getJavaFileForInput(
           StandardLocation.SOURCE_PATH, className.fullName(), Kind.SOURCE);

--- a/value/src/test/java/com/google/auto/value/processor/NoVelocityLoggingTest.java
+++ b/value/src/test/java/com/google/auto/value/processor/NoVelocityLoggingTest.java
@@ -11,7 +11,7 @@ import org.apache.velocity.runtime.log.JdkLogChute;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
+import java.nio.charset.Charset;
 import java.util.logging.FileHandler;
 import java.util.logging.Level;
 import java.util.logging.LogManager;
@@ -74,6 +74,6 @@ public class NoVelocityLoggingTest extends TestCase {
 
     // The log file should be empty.
     fileHandler.close();
-    assertEquals("", Files.toString(log, StandardCharsets.UTF_8));
+    assertEquals("", Files.toString(log, Charset.forName("UTF-8")));
   }
 }

--- a/value/src/test/java/com/google/auto/value/processor/TypeSimplifierTest.java
+++ b/value/src/test/java/com/google/auto/value/processor/TypeSimplifierTest.java
@@ -15,7 +15,6 @@
  */
 package com.google.auto.value.processor;
 
-import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -29,6 +28,7 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -123,7 +123,7 @@ public class TypeSimplifierTest extends TestCase {
     File tmpDir = Files.createTempDir();
     for (String className : classToSource.keySet()) {
       File java = new File(tmpDir, className + ".java");
-      Files.write(classToSource.get(className), java, Charsets.UTF_8);
+      Files.write(classToSource.get(className), java, Charset.forName("UTF-8"));
     }
     try {
       doTestTypeSimplifier(testProcessor, tmpDir, classToSource);


### PR DESCRIPTION
Remove the use of the obsolescent com.google.common.base.Charsets from a couple of AutoValue tests. It's trivial to replace its use with Charset.forName.

Also change NoVelocityLoggingTest so that it also uses Charset.forName instead of using java.nio.charset.StandardCharsets, since the latter is unavailable on Java 6. (Apparently we haven't been running tests on Java 6, so who knows what else might be broken.)
-------------
Created by MOE: http://code.google.com/p/moe-java
MOE_MIGRATED_REVID=86527338