### PR TITLE
Add a local tmp-file based repository for build-only pom.

### DIFF
--- a/build-pom.xml
+++ b/build-pom.xml
@@ -12,4 +12,16 @@
     <module>service</module>
     <module>value</module>
   </modules>
+  <distributionManagement>
+    <repository>
+      <id>sonatype-nexus-staging</id>
+      <name>Nexus Release Repository</name>
+      <url>file:///tmp/auto_project_maven_fake_repo/</url>
+    </repository>
+    <snapshotRepository>
+      <id>sonatype-nexus-snapshots</id>
+      <name>Sonatype Nexus Snapshots</name>
+      <url>file:///tmp/auto_project_maven_fake_repo/</url>
+    </snapshotRepository>
+  </distributionManagement>
 </project>


### PR DESCRIPTION
Add a local tmp-file based repository for distribution of the build-only pom, so that a 'mvn deploy' command applied to it will simply put its artifact harmlessly into a local temp directory.

This is not inherited by any other project, since they do not list the build-pom as a parent, so it is purely to tuck away the build convenience pom when doing whole-project builds. 