### PR TITLE
Auto-push snapshot releases and javadocs. 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,26 @@
 language: java
-install: mvn -U -f build-pom.xml install clean --fail-never --quiet -DskipTests=true -Dinvoker.skip=true
-script: mvn -U -f build-pom.xml verify
 
-notifications:
-  email: cgruber@google.com
+install:
+  - mvn -U -f build.pom.xml dependency:go-offline test clean --quiet --fail-never -DskipTests=true
+
+script:
+  - mvn -U -f build-pom.xml verify --fail-at-end -Dsource.skip=true -Dmaven.javadoc.skip=true
+
+jdk:
+  - oraclejdk7
+  - openjdk7
 
 branches:
   except:
     - gh-pages
+
+env:
+  global:
+  - secure: "bWNSSMURwYC0oZWIMZRd7dy5+JdoyZ060d427TAqFRJmOkYtlR+dBbBggjeJmM0PEkQDzeBrWwln/Vq3lnRPv8czA7hSg/R33r3GzTyi1GZhjCYN2mPW8qp4qgqlloh78aaOODUNSJsOtQqPDJPmhLLfD6UCY0eq9zHhweIjYdw="
+  - secure: "s5V9d8MKl7ZHqCxuYLljLSD4sp9KLtYkk9hVxEPqCLAi4zA70WkX9h+GZI1gAOpcavomfrWcgSDT2ZReiuNpwx7OtczdS4zB+s6mo4F598iRs4bhSLiPT+Hzvx6BSwf1ZKZTYEhrUPGmKOp2T29AxMV7D0Q+P7n574ubvpUuZmA="
+  - secure: "T24JAd60zthkeLBmenvZn6+qI43uvfuLwVb70Ljhbc19XDYEZV4Zm/kaafsisP5+F6kV4GjFaT+NCq2sJlwvPSMMRvU1JJgmNVh8TmtswkC/PHKonkMkOsj2KmFP0RRSPdvQv2NrSguZUq8mg+2pvnPO0qoPg4VeIODPGtAxNb8="
+
+after_success:
+  - util/generate-latest-docs.sh
+  - util/publish-snapshot-on-commit.sh
+

--- a/util/generate-latest-docs.sh
+++ b/util/generate-latest-docs.sh
@@ -1,0 +1,25 @@
+# see http://benlimmer.com/2013/12/26/automatically-publish-javadoc-to-gh-pages-with-travis-ci/ for details
+
+if [ "$TRAVIS_REPO_SLUG" == "google/truth" ] && \
+   [ "$TRAVIS_JDK_VERSION" == "oraclejdk7" ] && \
+   [ "$TRAVIS_PULL_REQUEST" == "false" ] && \
+   [ "$TRAVIS_BRANCH" == "master" ]; then
+  echo -e "Publishing javadoc...\n"
+  
+  mvn -f build-pom.xml javadoc:aggregate
+  TARGET="$(pwd)/target"
+
+  cd $HOME
+  git clone --quiet --branch=gh-pages https://${GH_TOKEN}@github.com/google/truth gh-pages > /dev/null
+  
+  cd gh-pages
+  git config --global user.email "travis@travis-ci.org"
+  git config --global user.name "travis-ci"
+  git rm -rf api/latest 
+  mv ${TARGET}/site/apidocs api/latest
+  git add -A -f api/latest
+  git commit -m "Lastest javadoc on successful travis build $TRAVIS_BUILD_NUMBER auto-pushed to gh-pages"
+  git push -fq origin gh-pages > /dev/null
+
+  echo -e "Published Javadoc to gh-pages.\n"
+fi

--- a/util/publish-snapshot-on-commit.sh
+++ b/util/publish-snapshot-on-commit.sh
@@ -1,0 +1,12 @@
+# see https://coderwall.com/p/9b_lfq
+
+if [ "$TRAVIS_REPO_SLUG" == "google/truth" ] && \
+   [ "$TRAVIS_JDK_VERSION" == "oraclejdk7" ] && \
+   [ "$TRAVIS_PULL_REQUEST" == "false" ] && \
+   [ "$TRAVIS_BRANCH" == "master" ]; then
+  echo -e "Publishing maven snapshot...\n"
+
+  mvn -f build-pom.xml clean source:jar deploy --settings="util/settings.xml" -DskipTests=true -Dmaven.javadoc.skip=true
+
+  echo -e "Published maven snapshot"
+fi

--- a/util/settings.xml
+++ b/util/settings.xml
@@ -1,0 +1,9 @@
+<settings>
+  <servers>
+    <server>
+      <id>sonatype-nexus-snapshots</id>
+      <username>${env.CI_DEPLOY_USERNAME}</username>
+      <password>${env.CI_DEPLOY_PASSWORD}</password>
+    </server>
+  </servers>
+</settings>


### PR DESCRIPTION
Add travis configuration, secure variables, and scripts suitable to add automatic snapshot and javadoc publishing on a successful build.