### PR TITLE
Change auto-factory's dependency on auto-common from 0.3 to 1.0-SNAPSHOT.

### DIFF
--- a/factory/pom.xml
+++ b/factory/pom.xml
@@ -44,7 +44,7 @@
     <dependency>
       <groupId>com.google.auto</groupId>
       <artifactId>auto-common</artifactId>
-      <version>0.3</version>
+      <version>1.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>com.google.auto.service</groupId>


### PR DESCRIPTION
Fixes #185. It's not clear to me why the failure in that issue wasn't clearer, but this does fix it.