### PR TITLE
Fix issues with multiple factories that implement the same interface

### DIFF
--- a/factory/src/it/github-82/pom.xml
+++ b/factory/src/it/github-82/pom.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (C) 2013 Google, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!-- TODO(gak): see if we can manage these dependencies any better -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.google.auto.value.it.functional</groupId>
+  <artifactId>github-82</artifactId>
+  <version>HEAD-SNAPSHOT</version>
+  <name>Auto-Value Functional Integration Test for https://github.com/google/auto/issues/82</name>
+  <dependencies>
+    <dependency>
+      <groupId>com.google.auto.factory</groupId>
+      <artifactId>auto-factory</artifactId>
+      <version>@auto.version@</version>
+      <!--<scope>provided</scope>-->
+    </dependency>
+    <!--<dependency>-->
+      <!--<groupId>com.google.code.findbugs</groupId>-->
+      <!--<artifactId>jsr305</artifactId>-->
+      <!--<version>1.3.9</version>-->
+      <!--<scope>provided</scope>-->
+    <!--</dependency>-->
+    <!--<dependency>-->
+      <!--<groupId>com.google.inject</groupId>-->
+      <!--<artifactId>guice</artifactId>-->
+      <!--<version>4.0-beta</version>-->
+    <!--</dependency>-->
+    <!--<dependency>-->
+      <!--<groupId>com.google.dagger</groupId>-->
+      <!--<artifactId>dagger</artifactId>-->
+      <!--<version>2.0-SNAPSHOT</version>-->
+    <!--</dependency>-->
+    <!--<dependency>-->
+      <!--<groupId>com.google.dagger</groupId>-->
+      <!--<artifactId>dagger-compiler</artifactId>-->
+      <!--<version>2.0-SNAPSHOT</version>-->
+      <!--<optional>true</optional>-->
+    <!--</dependency>-->
+    <!--<dependency>-->
+      <!--<groupId>junit</groupId>-->
+      <!--<artifactId>junit</artifactId>-->
+      <!--<version>4.12</version>-->
+      <!--<scope>test</scope>-->
+    <!--</dependency>-->
+    <!--<dependency>-->
+      <!--<groupId>com.google.truth</groupId>-->
+      <!--<artifactId>truth</artifactId>-->
+      <!--<version>0.25</version>-->
+      <!--<scope>test</scope>-->
+    <!--</dependency>-->
+    <!--<dependency>-->
+      <!--<groupId>com.google.guava</groupId>-->
+      <!--<artifactId>guava-testlib</artifactId>-->
+      <!--<version>18.0</version>-->
+      <!--<scope>test</scope>-->
+    <!--</dependency>-->
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.1</version>
+        <configuration>
+          <source>1.6</source>
+          <target>1.6</target>
+          <compilerArgument>-Xlint:all</compilerArgument>
+          <showWarnings>true</showWarnings>
+          <showDeprecation>true</showDeprecation>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/factory/src/it/github-82/src/main/java/foo/Foo.java
+++ b/factory/src/it/github-82/src/main/java/foo/Foo.java
@@ -1,0 +1,3 @@
+package foo;
+
+public interface Foo {}

--- a/factory/src/it/github-82/src/main/java/foo/FooFactory.java
+++ b/factory/src/it/github-82/src/main/java/foo/FooFactory.java
@@ -1,0 +1,5 @@
+package foo;
+
+public interface FooFactory {
+    Foo heyDoMe();
+}

--- a/factory/src/it/github-82/src/main/java/foo/bar/Bar.java
+++ b/factory/src/it/github-82/src/main/java/foo/bar/Bar.java
@@ -1,0 +1,10 @@
+package foo.bar;
+
+import com.google.auto.factory.AutoFactory;
+
+import foo.Foo;
+import foo.FooFactory;
+
+@AutoFactory(implementing = FooFactory.class)
+public class Bar implements Foo {
+}

--- a/factory/src/it/github-82/src/main/java/foo/qux/Qux.java
+++ b/factory/src/it/github-82/src/main/java/foo/qux/Qux.java
@@ -1,0 +1,10 @@
+package foo.qux;
+
+import com.google.auto.factory.AutoFactory;
+
+import foo.Foo;
+import foo.FooFactory;
+
+@AutoFactory(implementing = FooFactory.class)
+public class Qux implements Foo {
+}


### PR DESCRIPTION
Assuming a bug in either auto-common or dagger-compiler. Since the latter depends on 1.0-SNAPSHOT of the former, it seems that having 0.3 in auto-factory messed things up. Set it back to snapshot here until a new release of auto-common is available and/or it is shaded into dagger-compiler.

Somehow I'd have expected this kind of problem to break the build, but this isn't the first time I notice an annotation processor that just silently does nothing.
