### PR TITLE
Issue #116: Annotate constructor parameters with `@Nullable` where relevant

### DIFF
--- a/value/src/main/java/com/google/auto/value/processor/AutoValueProcessor.java
+++ b/value/src/main/java/com/google/auto/value/processor/AutoValueProcessor.java
@@ -174,6 +174,7 @@ public class AutoValueProcessor extends AbstractProcessor {
     private final ExecutableElement method;
     private final String type;
     private final ImmutableList<String> annotations;
+    private final String nullableAnnotation;
 
     Property(
         String name,
@@ -186,6 +187,18 @@ public class AutoValueProcessor extends AbstractProcessor {
       this.method = method;
       this.type = type;
       this.annotations = buildAnnotations(typeSimplifier);
+      this.nullableAnnotation = buildNullableAnnotation(typeSimplifier);
+    }
+
+    private String buildNullableAnnotation(TypeSimplifier typeSimplifier) {
+      for (AnnotationMirror annotationMirror : method.getAnnotationMirrors()) {
+        String name = annotationMirror.getAnnotationType().asElement().getSimpleName().toString();
+        if (name.equals("Nullable")) {
+          AnnotationOutput annotationOutput = new AnnotationOutput(typeSimplifier);
+          return annotationOutput.sourceFormForAnnotation(annotationMirror);
+        }
+      }
+      return null;
     }
 
     private ImmutableList<String> buildAnnotations(TypeSimplifier typeSimplifier) {
@@ -257,13 +270,11 @@ public class AutoValueProcessor extends AbstractProcessor {
     }
 
     public boolean isNullable() {
-      for (AnnotationMirror annotationMirror : method.getAnnotationMirrors()) {
-        String name = annotationMirror.getAnnotationType().asElement().getSimpleName().toString();
-        if (name.equals("Nullable")) {
-          return true;
-        }
-      }
-      return false;
+      return nullableAnnotation != null;
+    }
+    
+    public String getNullableAnnotation() {
+      return nullableAnnotation;
     }
 
     public String getAccess() {

--- a/value/src/main/java/com/google/auto/value/processor/autovalue.vm
+++ b/value/src/main/java/com/google/auto/value/processor/autovalue.vm
@@ -35,7 +35,7 @@ final class $subclass$formalTypes extends $origClass$actualTypes {
   $subclass(
 #foreach ($p in $props)
 
-      $p.type $p #if ($foreach.hasNext) , #end
+     #if ($p.nullable) ${p.nullableAnnotation} #end $p.type $p #if ($foreach.hasNext) , #end
 #end ) {
 #foreach ($p in $props)
   #if (!$p.kind.primitive && !$p.nullable)

--- a/value/src/test/java/com/google/auto/value/processor/CompilationTest.java
+++ b/value/src/test/java/com/google/auto/value/processor/CompilationTest.java
@@ -545,7 +545,7 @@ public class CompilationTest extends TestCase {
         "  private final List<T> aList;",
         "",
         "  private AutoValue_Baz("
-            + "int anInt, byte[] aByteArray, int[] aNullableIntArray, List<T> aList) {",
+            + "int anInt, byte[] aByteArray, @javax.annotation.Nullable int[] aNullableIntArray, List<T> aList) {",
         "    this.anInt = anInt;",
         "    if (aByteArray == null) {",
         "      throw new NullPointerException(\"Null aByteArray\");",

--- a/value/src/test/java/com/google/auto/value/processor/PropertyAnnotationsTest.java
+++ b/value/src/test/java/com/google/auto/value/processor/PropertyAnnotationsTest.java
@@ -99,7 +99,8 @@ public class PropertyAnnotationsTest extends TestCase {
     return JavaFileObjects.forSourceLines("foo.bar.Baz", lines);
   }
 
-  private JavaFileObject expectedCode(List<String> annotations) {
+  private JavaFileObject expectedCode(List<String> annotations, String expectedConstructorParamAnnotation) {
+    String constructorParamPrefix = expectedConstructorParamAnnotation != null ? expectedConstructorParamAnnotation + " " : "";
     ImmutableList<String> list = ImmutableList.<String>builder()
         .add(
             "package foo.bar;",
@@ -110,7 +111,7 @@ public class PropertyAnnotationsTest extends TestCase {
             "final class AutoValue_Baz extends Baz {",
             "  private final int buh;",
             "",
-            "  AutoValue_Baz(int buh) {",
+            "  AutoValue_Baz("+constructorParamPrefix+"int buh) {",
             "    this.buh = buh;",
             "  }",
             ""
@@ -152,26 +153,37 @@ public class PropertyAnnotationsTest extends TestCase {
     return JavaFileObjects.forSourceLines("foo.bar.AutoValue_Baz", lines);
   }
 
+  
   private void assertGeneratedMatches(
       List<String> imports,
       List<String> annotations,
-      List<String> expectedAnnotations) {
+      List<String> expectedAnnotations, String expectedConstructorParamAnnotation) {
 
     JavaFileObject javaFileObject = sourceCode(imports, annotations);
-    JavaFileObject expectedOutput = expectedCode(expectedAnnotations);
+    JavaFileObject expectedOutput = expectedCode(expectedAnnotations, expectedConstructorParamAnnotation);
 
     assert_().about(javaSource())
         .that(javaFileObject)
         .processedWith(new AutoValueProcessor())
         .compilesWithoutError()
         .and().generatesSources(expectedOutput);
+
+  }
+  
+  private void assertGeneratedMatches(
+      List<String> imports,
+      List<String> annotations,
+      List<String> expectedAnnotations) {
+    assertGeneratedMatches(imports, annotations, expectedAnnotations, null);
   }
 
   public void testSimpleAnnotation() {
     assertGeneratedMatches(
         ImmutableList.of("import javax.annotation.Nullable;"),
         ImmutableList.of("@Nullable"),
-        ImmutableList.of("@javax.annotation.Nullable"));
+        ImmutableList.of("@javax.annotation.Nullable"),
+        "@javax.annotation.Nullable"
+        );
   }
 
   public void testSingleStringValueAnnotation() {

--- a/value/src/test/java/com/google/auto/value/processor/PropertyAnnotationsTest.java
+++ b/value/src/test/java/com/google/auto/value/processor/PropertyAnnotationsTest.java
@@ -99,8 +99,15 @@ public class PropertyAnnotationsTest extends TestCase {
     return JavaFileObjects.forSourceLines("foo.bar.Baz", lines);
   }
 
-  private JavaFileObject expectedCode(List<String> annotations, String expectedConstructorParamAnnotation) {
-    String constructorParamPrefix = expectedConstructorParamAnnotation != null ? expectedConstructorParamAnnotation + " " : "";
+  private JavaFileObject expectedCode(
+      List<String> annotations,
+      String constructorParamAnnotation) {
+    String constructorParamPrefix;
+    if (constructorParamAnnotation == null) {
+      constructorParamPrefix = "";
+    } else {
+      constructorParamPrefix = constructorParamAnnotation + " ";
+    }
     ImmutableList<String> list = ImmutableList.<String>builder()
         .add(
             "package foo.bar;",
@@ -111,7 +118,7 @@ public class PropertyAnnotationsTest extends TestCase {
             "final class AutoValue_Baz extends Baz {",
             "  private final int buh;",
             "",
-            "  AutoValue_Baz("+constructorParamPrefix+"int buh) {",
+            "  AutoValue_Baz(" + constructorParamPrefix + "int buh) {",
             "    this.buh = buh;",
             "  }",
             ""
@@ -157,7 +164,8 @@ public class PropertyAnnotationsTest extends TestCase {
   private void assertGeneratedMatches(
       List<String> imports,
       List<String> annotations,
-      List<String> expectedAnnotations, String expectedConstructorParamAnnotation) {
+      List<String> expectedAnnotations,
+      String expectedConstructorParamAnnotation) {
 
     JavaFileObject javaFileObject = sourceCode(imports, annotations);
     JavaFileObject expectedOutput = expectedCode(expectedAnnotations, expectedConstructorParamAnnotation);
@@ -182,8 +190,7 @@ public class PropertyAnnotationsTest extends TestCase {
         ImmutableList.of("import javax.annotation.Nullable;"),
         ImmutableList.of("@Nullable"),
         ImmutableList.of("@javax.annotation.Nullable"),
-        "@javax.annotation.Nullable"
-        );
+        "@javax.annotation.Nullable");
   }
 
   public void testSingleStringValueAnnotation() {


### PR DESCRIPTION
Pull request for Issue #116: Annotate constructor parameters with `@Nullable` where relevant

If a "Nullable" annotation is found on a property it is now also used for the constructor parameters.