### PR TITLE
Pull request for Issue #81Provide OSGi meta data

### DIFF
--- a/factory/pom.xml
+++ b/factory/pom.xml
@@ -90,6 +90,36 @@
   <build>
     <plugins>
       <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>2.5</version>
+        <configuration>
+          <archive>
+            <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+          </archive>   
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <extensions>true</extensions>
+        <executions>
+          <execution>
+            <id>bundle-manifest</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>manifest</goal>
+            </goals>
+            <configuration>
+              <instructions>
+                <Export-Package>com.google.auto.factory</Export-Package>
+                <Private-Package>*</Private-Package>
+                <Bundle-SymbolicName>${pom.artifactId}</Bundle-SymbolicName>
+              </instructions> 
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-invoker-plugin</artifactId>
         <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,11 @@
           <artifactId>maven-invoker-plugin</artifactId>
           <version>1.8</version>
         </plugin>
+        <plugin>
+      	  <groupId>org.apache.felix</groupId>
+      	  <artifactId>maven-bundle-plugin</artifactId>
+      	  <version>2.3.7</version>
+      	</plugin>
       </plugins>
     </pluginManagement>
   </build>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -81,6 +81,36 @@
           <compilerArgument>-proc:none</compilerArgument>
         </configuration>
       </plugin>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>2.5</version>
+        <configuration>
+          <archive>
+            <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+          </archive>   
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <extensions>true</extensions>
+        <executions>
+          <execution>
+            <id>bundle-manifest</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>manifest</goal>
+            </goals>
+            <configuration>
+              <instructions>
+                <Export-Package>com.google.auto.service</Export-Package>
+                <Private-Package>*</Private-Package>
+                <Bundle-SymbolicName>${pom.artifactId}</Bundle-SymbolicName>
+              </instructions> 
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/value/pom.xml
+++ b/value/pom.xml
@@ -102,7 +102,35 @@
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>
         <version>2.5</version>
+        <configuration>
+          <archive>
+            <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+          </archive>   
+        </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+	    <artifactId>maven-bundle-plugin</artifactId>
+        <extensions>true</extensions>
+        <executions>
+          <execution>
+            <id>bundle-manifest</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>manifest</goal>
+            </goals>
+            <configuration>
+              <instructions>
+                <!-- Force empty import package because all dependencies are shaded -->
+                <Import-Package></Import-Package>
+                <Export-Package>com.google.auto.value</Export-Package>
+                <Private-Package>*</Private-Package>
+                <Bundle-SymbolicName>${pom.artifactId}</Bundle-SymbolicName>
+              </instructions> 
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>      
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-invoker-plugin</artifactId>


### PR DESCRIPTION
Pull request for Issue #81.

Provide OSGI manifest attributes for auto-value, auto-factory and auto-service using maven-bundle-plugin.

Note that auto-factory does not compile currently. It complains about missing dagger  2.0-SNAPSHOT dependency I tried using the 2.0 but it then fails with compile errors. So I was not able to test the proposed changes are not tested for auto-factory. 
