### PR TITLE
Fix build issue on Windows with Maven 3.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
       <plugins>
         <plugin>
           <artifactId>maven-invoker-plugin</artifactId>
-          <version>1.8</version>
+          <version>1.10</version>
         </plugin>
       </plugins>
     </pluginManagement>


### PR DESCRIPTION
The start script for Maven 3.3 on Windows changed to mvn.cmd from mvn.bat. This makes the Maven Invoker Plugin fail. See also https://issues.apache.org/jira/browse/MINVOKER-185
