### PR TITLE
Fixes javadoc reference errors after refactor.

### DIFF
--- a/value/src/main/java/com/google/auto/value/extension/AutoValueExtension.java
+++ b/value/src/main/java/com/google/auto/value/extension/AutoValueExtension.java
@@ -20,14 +20,16 @@ import javax.lang.model.element.TypeElement;
  *
  * <p>Extensions can extend the AutoValue implementation by generating subclasses of the AutoValue
  * generated class. It is not guaranteed that an Extension's generated class will be the final
- * class in the inheritance hierarchy, unless its {@link #mustBeFinal()} method returns true. Only
- * one Extension can return true for a given context. Only generated classes that will be the
+ * class in the inheritance hierarchy, unless its
+ * {@link com.google.auto.value.extension.AutoValueExtension#mustBeFinal(Context)} method returns true.
+ * Only one Extension can return true for a given context. Only generated classes that will be the
  * final class in the inheritance hierarchy can be declared final. All others should be declared
  * abstract.
  *
  * <p>Each Extension must also be sure to generate a constructor with arguments corresponding to
- * all properties in {@link com.google.auto.value.AutoValueExtension.Context#properties()}, in
- * order. This constructor must have at least package visibility.
+ * all properties in
+ * {@link com.google.auto.value.extension.AutoValueExtension.Context#properties()}, in order. This
+ * constructor must have at least package visibility.
  */
 public abstract class AutoValueExtension {
 
@@ -82,8 +84,8 @@ public abstract class AutoValueExtension {
    * in the inheritance hierarchy.  Only one extension may be the final class, so
    * this should be used sparingly.
    *
-   * @param context The {@link com.google.auto.value.AutoValueExtension.Context} of the code
-   *                generation for this class.
+   * @param context The {@link com.google.auto.value.extension.AutoValueExtension.Context} of the
+   *                code generation for this class.
    * @return True if the resulting class must be the final class in the inheritance hierarchy.
    */
   public boolean mustBeFinal(Context context) {
@@ -91,10 +93,11 @@ public abstract class AutoValueExtension {
   }
 
   /**
-   * Returns a non-null set of property names from {@link #properties()} that this extension intends
-   * to implement.  This will prevent AutoValue from generating an implementation, and remove the
-   * supplied properties from builders, constructors, {@code toString}, {@code equals},
-   * and {@code hashCode}. The default set returned by this method is empty.
+   * Returns a non-null set of property names from {@link AutoValueExtension.Context#properties()}
+   * that this extension intends to implement.  This will prevent AutoValue from generating an
+   * implementation, and remove the supplied properties from builders, constructors,
+   * {@code toString}, {@code equals}, and {@code hashCode}. The default set returned by this
+   * method is empty.
    *
    * <p>For example, Android's {@code Parcelable} interface includes a
    * <a href="http://developer.android.com/reference/android/os/Parcelable.html#describeContents()">method</a>
@@ -107,7 +110,7 @@ public abstract class AutoValueExtension {
    * implementation and return a set containing {@code "describeContents"}. Then
    * {@code describeContents} will be omitted from builders and the rest.
    *
-   * @param context The {@link com.google.auto.value.AutoValueExtension.Context} of the code
+   * @param context The {@link com.google.auto.value.extension.AutoValueExtension.Context} of the code
    *     generation for this class.
    * @return A collection of property names that this extension intends to implement.
    */


### PR DESCRIPTION
The refactor of the `extension` package left some references in the javadocs broken.