### PR TITLE
Makes autovalue bean constructor always visible

### DIFF
--- a/value/src/main/java/com/google/auto/value/processor/autovalue.vm
+++ b/value/src/main/java/com/google/auto/value/processor/autovalue.vm
@@ -31,9 +31,6 @@ ${gwtCompatibleAnnotation}
 
 ## Constructor
 
-#if ($isFinal && $builderTypeName != "")
-  private ##
-#end
   $subclass(
 #foreach ($p in $props)
 

--- a/value/src/test/java/com/google/auto/value/processor/CompilationTest.java
+++ b/value/src/test/java/com/google/auto/value/processor/CompilationTest.java
@@ -594,7 +594,7 @@ public class CompilationTest {
         "  private final List<T> aList;",
         "  private final ImmutableList<T> anImmutableList;",
         "",
-        "  private AutoValue_Baz(",
+        "  AutoValue_Baz(",
         "      int anInt,",
         "      byte[] aByteArray,",
         "      @Nullable int[] aNullableIntArray,",


### PR DESCRIPTION
Changes the visibility of the constructor for the generated bean to be
unconditionally package private.

Now it is possible to have static construction methods and a builder
at the same time e.g. when creating a bean incrementally in logic
while deserializing it wholesale from e.g. JSON or Protobuf.