### PR TITLE
AutoValue doesn't correctly handle conflicting type names in subtle circumstances

### DIFF
--- a/value/src/test/java/com/google/auto/value/processor/CompilationTest.java
+++ b/value/src/test/java/com/google/auto/value/processor/CompilationTest.java
@@ -1759,4 +1759,36 @@ public class CompilationTest {
         .processedWith(new AutoValueProcessor(), new FooProcessor())
         .compilesWithoutError();
   }
+
+  @Test
+  public void conflictingTypeNames() {
+    JavaFileObject nestedClassFileObject = JavaFileObjects.forSourceLines(
+      "foo.eggs.IdTypes",
+      "package foo.eggs;",
+      "",
+      "public class IdTypes {",
+      "  public class Baz {}",
+      "}");
+
+    JavaFileObject autoValueFileObject = JavaFileObjects.forSourceLines(
+      "foo.bar.Baz",
+      "package foo.bar;",
+      "",
+      "import foo.eggs.IdTypes;",
+      "",
+      "import com.google.auto.value.AutoValue;",
+      "",
+      "public class Baz {",
+      "",
+      "  @AutoValue",
+      "  public static abstract class Spam {",
+      "    public abstract IdTypes.Baz getId();",
+      "  }",
+      "}");
+
+    assertAbout(javaSources())
+      .that(ImmutableList.of(nestedClassFileObject, autoValueFileObject))
+      .processedWith(new AutoValueProcessor())
+      .compilesWithoutError();
+  }
 }


### PR DESCRIPTION
Hey all,

At my company we have a lot of domain objects running around with different IDs. We keep track of which ID is of which type by having an `IdTypes` class and inner classes on them that match the name of the domain object. So we'd have something like:

``` java
public class IdTypes {
  public class Foo {}
}

public class Foo {
  public IdTypes.Foo id;
}
```

This looks well and great. But in addition to this, the `Foo` class sometimes has a static class for, say, a database lookup key, which might have an `IdTypes.Foo` attribute:

``` java
public class Foo {
  public static class Key {
    public IdTypes.Foo id;
  }
}
```

We wanted to bring the joys of AutoValue to bear on the `Key` class. However, in this situation, AutoValue generates source that does not compile! In particular, the generated code will create an import statement that causes the ID type name to conflict with the outer class name. Oh no!

``` java
import xyz.abc.IdTypes.Foo;

@Generated
public class AutoValue_Foo_Key extends Foo.Key
```

I've attached a failing test that demonstrates this issue. I took a quick glance at the implementation but couldn't find an easy way to fix this, so I figured I'd send the issue in as-is.

This is a pretty subtle bug and I'd totally understand if it was a low-priority fix. In the mean time we're just naming the ID type `FooId`, which is really not so bad.

Thank you!
