### PR TITLE
Moves method verification after extensions have had the chance to consume properties.

### DIFF
--- a/value/pom.xml
+++ b/value/pom.xml
@@ -79,7 +79,7 @@
     <dependency>
       <groupId>com.google.testing.compile</groupId>
       <artifactId>compile-testing</artifactId>
-      <version>0.6</version>
+      <version>0.9</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/value/src/main/java/com/google/auto/value/extension/AutoValueExtension.java
+++ b/value/src/main/java/com/google/auto/value/extension/AutoValueExtension.java
@@ -18,7 +18,8 @@ import javax.lang.model.element.TypeElement;
  *
  * <p>Extensions can extend the AutoValue implementation by generating subclasses of the AutoValue
  * generated class. It is not guaranteed that an Extension's generated class will be the final
- * class in the inheritance hierarchy, unless its {@link #mustBeFinal(Context)} method returns true.
+ * class in the inheritance hierarchy, unless its
+ * {@link com.google.auto.value.extension.AutoValueExtension#mustBeFinal(Context)} method returns true.
  * Only one Extension can return true for a given context. Only generated classes that will be the
  * final class in the inheritance hierarchy can be declared final. All others should be declared
  * abstract.
@@ -81,7 +82,8 @@ public abstract class AutoValueExtension {
    * in the inheritance hierarchy.  Only one extension may be the final class, so
    * this should be used sparingly.
    *
-   * @param context The Context of the code generation for this class.
+   * @param context The {@link com.google.auto.value.extension.AutoValueExtension.Context} of the
+   *                code generation for this class.
    * @return True if the resulting class must be the final class in the inheritance hierarchy.
    */
   public boolean mustBeFinal(Context context) {
@@ -89,10 +91,11 @@ public abstract class AutoValueExtension {
   }
 
   /**
-   * Returns a non-null set of property names from {@link Context#properties()} that this extension
-   * intends to implement. This will prevent AutoValue from generating an implementation, and remove
-   * the supplied properties from builders, constructors, {@code toString}, {@code equals},
-   * and {@code hashCode}. The default set returned by this method is empty.
+   * Returns a non-null set of property names from {@link AutoValueExtension.Context#properties()}
+   * that this extension intends to implement.  This will prevent AutoValue from generating an
+   * implementation, and remove the supplied properties from builders, constructors,
+   * {@code toString}, {@code equals}, and {@code hashCode}. The default set returned by this
+   * method is empty.
    *
    * <p>For example, Android's {@code Parcelable} interface includes a
    * <a href="http://developer.android.com/reference/android/os/Parcelable.html#describeContents()">method</a>
@@ -105,7 +108,8 @@ public abstract class AutoValueExtension {
    * implementation and return a set containing {@code "describeContents"}. Then
    * {@code describeContents} will be omitted from builders and the rest.
    *
-   * @param context The Context of the code generation for this class.
+   * @param context The {@link com.google.auto.value.extension.AutoValueExtension.Context} of the code
+   *     generation for this class.
    * @return A collection of property names that this extension intends to implement.
    */
   public Set<String> consumeProperties(Context context) {

--- a/value/src/main/java/com/google/auto/value/extension/AutoValueExtension.java
+++ b/value/src/main/java/com/google/auto/value/extension/AutoValueExtension.java
@@ -18,16 +18,14 @@ import javax.lang.model.element.TypeElement;
  *
  * <p>Extensions can extend the AutoValue implementation by generating subclasses of the AutoValue
  * generated class. It is not guaranteed that an Extension's generated class will be the final
- * class in the inheritance hierarchy, unless its
- * {@link com.google.auto.value.extension.AutoValueExtension#mustBeFinal(Context)} method returns true.
+ * class in the inheritance hierarchy, unless its {@link #mustBeFinal(Context)} method returns true.
  * Only one Extension can return true for a given context. Only generated classes that will be the
  * final class in the inheritance hierarchy can be declared final. All others should be declared
  * abstract.
  *
  * <p>Each Extension must also be sure to generate a constructor with arguments corresponding to
- * all properties in
- * {@link com.google.auto.value.extension.AutoValueExtension.Context#properties()}, in order. This
- * constructor must have at least package visibility.
+ * all properties in {@link Context#properties()}, in order. This constructor must have at least
+ * package visibility.
  */
 public abstract class AutoValueExtension {
 
@@ -82,8 +80,7 @@ public abstract class AutoValueExtension {
    * in the inheritance hierarchy.  Only one extension may be the final class, so
    * this should be used sparingly.
    *
-   * @param context The {@link com.google.auto.value.extension.AutoValueExtension.Context} of the
-   *                code generation for this class.
+   * @param context The {@link Context} of the code generation for this class.
    * @return True if the resulting class must be the final class in the inheritance hierarchy.
    */
   public boolean mustBeFinal(Context context) {

--- a/value/src/main/java/com/google/auto/value/processor/AutoValueProcessor.java
+++ b/value/src/main/java/com/google/auto/value/processor/AutoValueProcessor.java
@@ -361,7 +361,7 @@ public class AutoValueProcessor extends AbstractProcessor {
 
     ImmutableSet<ExecutableElement> methods =
         getLocalAndInheritedMethods(type, processingEnv.getElementUtils());
-    ImmutableSet<ExecutableElement> methodsToImplement = methodsToImplement(type, methods);
+    ImmutableSet<ExecutableElement> methodsToImplement = methodsToImplement(methods);
     ImmutableBiMap<String, ExecutableElement> properties =
         propertyNameToMethodMap(methodsToImplement);
 
@@ -395,6 +395,7 @@ public class AutoValueProcessor extends AbstractProcessor {
         methods = ImmutableSet.copyOf(newMethods);
       }
     }
+    verifyMethods(type, methods);
 
     String finalSubclass = generatedSubclassName(type, 0);
     String subclass = generatedSubclassName(type, appliedExtensions.size());
@@ -450,7 +451,7 @@ public class AutoValueProcessor extends AbstractProcessor {
       Set<ExecutableElement> methods) {
     Types typeUtils = processingEnv.getTypeUtils();
     determineObjectMethodsToGenerate(methods, vars);
-    ImmutableSet<ExecutableElement> methodsToImplement = methodsToImplement(type, methods);
+    ImmutableSet<ExecutableElement> methodsToImplement = methodsToImplement(methods);
     Set<TypeMirror> types = new TypeMirrorSet();
     types.addAll(returnTypesOf(methodsToImplement));
     TypeElement generatedTypeElement =
@@ -643,21 +644,31 @@ public class AutoValueProcessor extends AbstractProcessor {
     }
   }
 
-  private ImmutableSet<ExecutableElement> methodsToImplement(
-      TypeElement autoValueClass, Set<ExecutableElement> methods) {
+  private ImmutableSet<ExecutableElement> methodsToImplement(Set<ExecutableElement> methods) {
     ImmutableSet.Builder<ExecutableElement> toImplement = ImmutableSet.builder();
     Set<Name> toImplementNames = Sets.newHashSet();
+    for (ExecutableElement method : methods) {
+      if (method.getModifiers().contains(Modifier.ABSTRACT)
+          && objectMethodToOverride(method) == ObjectMethodToOverride.NONE) {
+        if (method.getParameters().isEmpty() && method.getReturnType().getKind() != TypeKind.VOID) {
+          if (toImplementNames.add(method.getSimpleName())) {
+            // If an abstract method with the same signature is inherited on more than one path,
+            // we only add it once.
+            toImplement.add(method);
+          }
+        }
+      }
+    }
+    return toImplement.build();
+  }
+
+  private void verifyMethods(TypeElement autoValueClass, ImmutableSet<ExecutableElement> methods) {
     boolean ok = true;
     for (ExecutableElement method : methods) {
       if (method.getModifiers().contains(Modifier.ABSTRACT)
           && objectMethodToOverride(method) == ObjectMethodToOverride.NONE) {
         if (method.getParameters().isEmpty() && method.getReturnType().getKind() != TypeKind.VOID) {
           ok &= checkReturnType(autoValueClass, method);
-          if (toImplementNames.add(method.getSimpleName())) {
-            // If an abstract method with the same signature is inherited on more than one path,
-            // we only add it once.
-            toImplement.add(method);
-          }
         } else {
           // This could reasonably be an error, were it not for an Eclipse bug in
           // ElementUtils.override that sometimes fails to recognize that one method overrides
@@ -671,7 +682,6 @@ public class AutoValueProcessor extends AbstractProcessor {
     if (!ok) {
       throw new AbortProcessingException();
     }
-    return toImplement.build();
   }
 
   private boolean checkReturnType(TypeElement autoValueClass, ExecutableElement getter) {

--- a/value/src/test/java/com/google/auto/value/processor/ExtensionTest.java
+++ b/value/src/test/java/com/google/auto/value/processor/ExtensionTest.java
@@ -121,10 +121,25 @@ public class ExtensionTest extends TestCase {
     );
     assertAbout(javaSource())
         .that(javaFileObject)
-        .processedWith(
-            new AutoValueProcessor(ImmutableList.<AutoValueExtension>of(new FooExtension())))
+        .processedWith(new AutoValueProcessor(ImmutableList.of(new FooExtension())))
         .compilesWithoutError()
         .and().generatesSources(expectedExtensionOutput);
+  }
+
+  public void testDoesntRaiseWarningOnConsumedProperties() {
+    JavaFileObject impl = JavaFileObjects.forSourceLines("foo.bar.Baz",
+        "package foo.bar;",
+        "import com.google.auto.value.AutoValue;",
+        "@AutoValue public abstract class Baz {",
+        "  abstract String foo();",
+        "  abstract String dizzle();",
+        "}");
+    assertAbout(javaSource())
+        .that(impl)
+        .processedWith(new AutoValueProcessor(ImmutableList.of(new FooExtension())))
+        .compilesWithoutError()
+        // expected warnings: @AutoValue and @Generated annotations not consumed
+        .withWarningCount(2);
   }
 
   public void testExtensionWithoutConsumedPropertiesFails() throws Exception {

--- a/value/src/test/java/com/google/auto/value/processor/ExtensionTest.java
+++ b/value/src/test/java/com/google/auto/value/processor/ExtensionTest.java
@@ -2,6 +2,7 @@ package com.google.auto.value.processor;
 
 import static com.google.common.truth.Truth.assertAbout;
 import static com.google.testing.compile.JavaSourceSubjectFactory.javaSource;
+import static com.google.testing.compile.JavaSourcesSubjectFactory.javaSources;
 
 import com.google.auto.value.extension.AutoValueExtension;
 import com.google.common.collect.ImmutableList;
@@ -124,6 +125,28 @@ public class ExtensionTest extends TestCase {
             new AutoValueProcessor(ImmutableList.<AutoValueExtension>of(new FooExtension())))
         .compilesWithoutError()
         .and().generatesSources(expectedExtensionOutput);
+  }
+
+  public void testExtensionWithoutConsumedPropertiesFails() throws Exception {
+    JavaFileObject javaFileObject = JavaFileObjects.forSourceLines(
+        "foo.bar.Baz",
+        "package foo.bar;",
+        "",
+        "import com.google.auto.value.AutoValue;",
+        "",
+        "@AutoValue",
+        "public abstract class Baz {",
+        "  abstract String foo();",
+        "  abstract String dizzle();",
+        "  abstract Double[] bad();",
+        "}");
+    assertAbout(javaSource())
+        .that(javaFileObject)
+        .processedWith(
+            new AutoValueProcessor(ImmutableList.<AutoValueExtension>of(new FooExtension())))
+        .failsToCompile()
+        .withErrorContaining("An @AutoValue class cannot define an array-valued property unless "
+            + "it is a primitive array");
   }
 
   public void testExtensionWithBuilderCompilation() throws Exception {


### PR DESCRIPTION
Since compile-testing [doesn't support](https://github.com/google/compile-testing/issues/41) checking warnings, I've simply tested for the inverse here, ensuring that invalid properties fail with the appropriate error.  This move should also remove the warning for "abstract methods other than property getters and builder converters" for consumed methods.