### PR TITLE
Rely on Guava 19.0 and use CharMatcher.whitespace()

### DIFF
--- a/value/pom.xml
+++ b/value/pom.xml
@@ -33,7 +33,7 @@
   </description>
 
   <properties>
-    <guava.version>18.0</guava.version>
+    <guava.version>19.0</guava.version>
   </properties>
   <scm>
     <url>http://github.com/google/auto</url>

--- a/value/src/main/java/com/google/auto/value/processor/escapevelocity/Reparser.java
+++ b/value/src/main/java/com/google/auto/value/processor/escapevelocity/Reparser.java
@@ -135,7 +135,7 @@ class Reparser {
   private static boolean isWhitespaceLiteral(Node node) {
     if (node instanceof ConstantExpressionNode) {
       Object constant = node.evaluate(null);
-      return constant instanceof String && CharMatcher.WHITESPACE.matchesAllOf((String) constant);
+      return constant instanceof String && CharMatcher.whitespace().matchesAllOf((String) constant);
     }
     return false;
   }


### PR DESCRIPTION
CharMatcher.WHITESPACE will be removed in a future version of Guava (improves performance on android - not relevant to auto-value, but still nicer).

-------------
Created by MOE: https://github.com/google/moe
MOE_MIGRATED_REVID=116549017