### PR TITLE
Broaden exception catching in EclipseHack

### DIFF
--- a/value/src/main/java/com/google/auto/value/processor/EclipseHack.java
+++ b/value/src/main/java/com/google/auto/value/processor/EclipseHack.java
@@ -168,7 +168,7 @@ class EclipseHack {
     final ImmutableList<String> order;
     try {
       order = propertyOrderer.determinePropertyOrder();
-    } catch (IOException e) {
+    } catch (Exception e) {
       processingEnv.getMessager().printMessage(Diagnostic.Kind.NOTE, e.toString());
       return;
     }


### PR DESCRIPTION
In EclipseHack, catch any exception from propertyOrderer.determinePropertyOrder(), and not just IOException. This should be sufficient to work around an ASM crash reported in #200.

-------------
Created by MOE: https://github.com/google/moe
MOE_MIGRATED_REVID=117612741