### PR TITLE
Do not create factory methods for private constructors

### DIFF
--- a/factory/src/test/java/com/google/auto/factory/processor/AutoFactoryProcessorTest.java
+++ b/factory/src/test/java/com/google/auto/factory/processor/AutoFactoryProcessorTest.java
@@ -337,4 +337,37 @@ public class AutoFactoryProcessorTest {
         JavaFileObjects.forResource(
             "expected/FactoryImplementingCreateMethod_ConcreteClassFactory.java"));
   }
+
+  @Test public void classWithPrivateConstructor() {
+    assertAbout(javaSource())
+        .that(JavaFileObjects.forResource("good/ClassWithPrivateConstructor.java"))
+        .processedWith(new AutoFactoryProcessor())
+        .compilesWithoutError()
+        .and().generatesSources(
+            JavaFileObjects.forResource("expected/ClassWithPrivateConstructorFactory.java"));
+  }
+
+  @Test public void classWithOnlyPrivateConstructors() {
+    JavaFileObject file =
+        JavaFileObjects.forResource("bad/ClassWithOnlyPrivateConstructors.java");
+    assertAbout(javaSource())
+        .that(file)
+        .processedWith(new AutoFactoryProcessor())
+        .failsToCompile()
+        .withErrorContaining("Auto-factory doesn't support being applied to classes " +
+            "with only private constructors.")
+                .in(file).onLine(20);
+  }
+
+  @Test public void privateConstructor() {
+    JavaFileObject file =
+        JavaFileObjects.forResource("bad/PrivateConstructor.java");
+    assertAbout(javaSource())
+        .that(file)
+        .processedWith(new AutoFactoryProcessor())
+        .failsToCompile()
+        .withErrorContaining("Auto-factory doesn't support being applied to private " +
+            "constructors.")
+                .in(file).onLine(21);
+  }
 }

--- a/factory/src/test/resources/bad/ClassWithOnlyPrivateConstructors.java
+++ b/factory/src/test/resources/bad/ClassWithOnlyPrivateConstructors.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package tests;
+
+import com.google.auto.factory.AutoFactory;
+
+@AutoFactory
+final class ClassWithOnlyPrivateConstructors {
+  private ClassWithOnlyPrivateConstructors() {}
+}

--- a/factory/src/test/resources/bad/PrivateConstructor.java
+++ b/factory/src/test/resources/bad/PrivateConstructor.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package tests;
+
+import com.google.auto.factory.AutoFactory;
+
+final class PrivateConstructor {
+  @AutoFactory private PrivateConstructor() {}
+}

--- a/factory/src/test/resources/expected/ClassWithPrivateConstructorFactory.java
+++ b/factory/src/test/resources/expected/ClassWithPrivateConstructorFactory.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package tests;
+
+import javax.annotation.Generated;
+import javax.inject.Inject;
+
+@Generated(
+    value = "com.google.auto.factory.processor.AutoFactoryProcessor",
+    comments = "https://github.com/google/auto/tree/master/factory"
+)
+final class ClassWithPrivateConstructorFactory {
+
+  @Inject ClassWithPrivateConstructorFactory() {}
+
+  ClassWithPrivateConstructor create(String s) {
+    return new ClassWithPrivateConstructor(s);
+  }
+
+  ClassWithPrivateConstructor create(Integer i) {
+    return new ClassWithPrivateConstructor(i);
+  }
+}

--- a/factory/src/test/resources/good/ClassWithPrivateConstructor.java
+++ b/factory/src/test/resources/good/ClassWithPrivateConstructor.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package tests;
+
+import com.google.auto.factory.AutoFactory;
+
+@AutoFactory
+final class ClassWithPrivateConstructor {
+  ClassWithPrivateConstructor(String s) {}
+  ClassWithPrivateConstructor(Integer i) {}
+  private ClassWithPrivateConstructor(String s, Integer i) {}
+}


### PR DESCRIPTION
This pull request adds 2 compile-time errors:
1. AutoFactory cannot be applied to a private constructor.
2. AutoFactory cannot be applied to a class with only private constructors.

When using AutoFactory on a project, I noticed that it was trying to generate create methods for private constructors.  This caused the build to fail as the factory could not access the private constructor.

This can be worked around by applying AutoFactory directly to all non-private constructors.  I figured it would be better if AutoFactory was able to handle this case as I didn't even know I could apply AutoFactory directly to a constructor until I dug into the code.  (A feature that should probably be mentioned in the README)

Let me know if there are wording changes to the error messages or any changes with the code you would like me to make.  I tried to match the other error messages and make the new ones as concise as possible.