### PR TITLE
Update 2016 05 31

### DIFF
--- a/common/src/main/java/com/google/auto/common/MoreElements.java
+++ b/common/src/main/java/com/google/auto/common/MoreElements.java
@@ -245,6 +245,12 @@ public final class MoreElements {
    * result. So if {@code type} defines {@code public String toString()}, the returned set will
    * contain that method, but not the {@code toString()} method defined by {@code Object}.
    *
+   * <p>The returned set may contain more than one method with the same signature, if
+   * {@code type} inherits those methods from different ancestors. For example, if it
+   * inherits from unrelated interfaces {@code One} and {@code Two} which each define
+   * {@code void foo();}, and if it does not itself override the {@code foo()} method,
+   * then both {@code One.foo()} and {@code Two.foo()} will be in the returned set.
+   *
    * @param type the type whose own and inherited methods are to be returned
    * @param elementUtils an {@link Elements} object, typically returned by
    *     {@link javax.annotation.processing.AbstractProcessor#processingEnv processingEnv}<!--

--- a/factory/README.md
+++ b/factory/README.md
@@ -54,6 +54,10 @@ final class SomeClassFactory {
 }
 ```
 
+> NOTE: AutoFactory only supports JSR-330 @Qualifier annotations. Older, 
+> framework-specific annotations from Guice, Spring, etc are not
+> supported (though these all support JSR-330)
+
 Download
 --------
 

--- a/value/src/it/functional-java8/src/main/java/PackagelessNestedValueType.java
+++ b/value/src/it/functional-java8/src/main/java/PackagelessNestedValueType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 The Guava Authors
+ * Copyright (C) 2012 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/it/functional-java8/src/main/java/PackagelessValueType.java
+++ b/value/src/it/functional-java8/src/main/java/PackagelessValueType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 The Guava Authors
+ * Copyright (C) 2012 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/it/functional-java8/src/main/java/com/google/auto/value/NestedValueType.java
+++ b/value/src/it/functional-java8/src/main/java/com/google/auto/value/NestedValueType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2013 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.google.auto.value;
 
 import java.util.Map;

--- a/value/src/it/functional-java8/src/main/java/com/google/auto/value/SimpleValueType.java
+++ b/value/src/it/functional-java8/src/main/java/com/google/auto/value/SimpleValueType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 The Guava Authors
+ * Copyright (C) 2012 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/it/functional-java8/src/main/java/com/google/auto/value/annotation/Nullable.java
+++ b/value/src/it/functional-java8/src/main/java/com/google/auto/value/annotation/Nullable.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.google.auto.value.annotation;
 
 /**

--- a/value/src/it/functional-java8/src/test/java/PackagelessValueTypeTest.java
+++ b/value/src/it/functional-java8/src/test/java/PackagelessValueTypeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 The Guava Authors
+ * Copyright (C) 2012 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/it/functional-java8/src/test/java/com/google/auto/value/AutoValueTest.java
+++ b/value/src/it/functional-java8/src/test/java/com/google/auto/value/AutoValueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 The Guava Authors
+ * Copyright (C) 2012 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/it/functional-java8/src/test/java/com/google/auto/value/SimpleValueTypeTest.java
+++ b/value/src/it/functional-java8/src/test/java/com/google/auto/value/SimpleValueTypeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 The Guava Authors
+ * Copyright (C) 2012 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/it/functional-java8/src/test/java/com/google/auto/value/enums/MyEnum.java
+++ b/value/src/it/functional-java8/src/test/java/com/google/auto/value/enums/MyEnum.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 The Guava Authors
+ * Copyright (C) 2014 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/it/functional/src/main/java/PackagelessNestedValueType.java
+++ b/value/src/it/functional/src/main/java/PackagelessNestedValueType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 The Guava Authors
+ * Copyright (C) 2012 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/it/functional/src/main/java/PackagelessValueType.java
+++ b/value/src/it/functional/src/main/java/PackagelessValueType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 The Guava Authors
+ * Copyright (C) 2012 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/it/functional/src/main/java/com/google/auto/value/NestedValueType.java
+++ b/value/src/it/functional/src/main/java/com/google/auto/value/NestedValueType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2013 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.google.auto.value;
 
 import java.util.Map;

--- a/value/src/it/functional/src/main/java/com/google/auto/value/SimpleValueType.java
+++ b/value/src/it/functional/src/main/java/com/google/auto/value/SimpleValueType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 The Guava Authors
+ * Copyright (C) 2012 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/it/functional/src/test/java/PackagelessValueTypeTest.java
+++ b/value/src/it/functional/src/test/java/PackagelessValueTypeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 The Guava Authors
+ * Copyright (C) 2012 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/it/functional/src/test/java/com/google/auto/value/AutoValueTest.java
+++ b/value/src/it/functional/src/test/java/com/google/auto/value/AutoValueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 The Guava Authors
+ * Copyright (C) 2012 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/it/functional/src/test/java/com/google/auto/value/SimpleValueTypeTest.java
+++ b/value/src/it/functional/src/test/java/com/google/auto/value/SimpleValueTypeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 The Guava Authors
+ * Copyright (C) 2012 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/it/functional/src/test/java/com/google/auto/value/enums/MyEnum.java
+++ b/value/src/it/functional/src/test/java/com/google/auto/value/enums/MyEnum.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 The Guava Authors
+ * Copyright (C) 2014 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/it/gwtserializer/src/test/java/com/google/auto/value/GwtSerializerSuite.java
+++ b/value/src/it/gwtserializer/src/test/java/com/google/auto/value/GwtSerializerSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 The Guava Authors
+ * Copyright (C) 2015 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/it/gwtserializer/src/test/java/com/google/auto/value/client/GwtSerializerTest.java
+++ b/value/src/it/gwtserializer/src/test/java/com/google/auto/value/client/GwtSerializerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 The Guava Authors
+ * Copyright (C) 2015 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/main/java/com/google/auto/value/AutoValue.java
+++ b/value/src/main/java/com/google/auto/value/AutoValue.java
@@ -18,6 +18,27 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * Specifies that <a href="https://github.com/google/auto/tree/master/value">AutoValue</a> should
+ * generate an implementation class for the annotated abstract class, implementing the standard
+ * {@link Object} methods like {@link Object#equals equals} to have conventional value semantics. A
+ * simple example: <pre>
+ *
+ *   &#64;AutoValue
+ *   abstract class Person {
+ *     static Person create(String name, int id) {
+ *       return new AutoValue_Person(name, id);
+ *     }
+ *
+ *     abstract String name();
+ *     abstract int id();
+ *   }</pre>
+ *
+ * @see <a href="https://github.com/google/auto/tree/master/value">AutoValue User's Guide</a>
+ *
+ * @author Éamonn McManus
+ * @author Kevin Bourrillion
+ */
 @Retention(RetentionPolicy.SOURCE)
 @Target(ElementType.TYPE)
 public @interface AutoValue {

--- a/value/src/main/java/com/google/auto/value/extension/AutoValueExtension.java
+++ b/value/src/main/java/com/google/auto/value/extension/AutoValueExtension.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2015 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.google.auto.value.extension;
 
 import java.util.Collections;

--- a/value/src/main/java/com/google/auto/value/processor/AutoValueProcessor.java
+++ b/value/src/main/java/com/google/auto/value/processor/AutoValueProcessor.java
@@ -21,6 +21,7 @@ import com.google.auto.common.MoreElements;
 import com.google.auto.service.AutoService;
 import com.google.auto.value.AutoValue;
 import com.google.auto.value.extension.AutoValueExtension;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
 import com.google.common.base.Functions;
 import com.google.common.base.Joiner;
@@ -87,7 +88,8 @@ public class AutoValueProcessor extends AbstractProcessor {
     this(ServiceLoader.load(AutoValueExtension.class, AutoValueProcessor.class.getClassLoader()));
   }
 
-  /* testing */ AutoValueProcessor(Iterable<? extends AutoValueExtension> extensions) {
+  @VisibleForTesting
+  public AutoValueProcessor(Iterable<? extends AutoValueExtension> extensions) {
     this.extensions = extensions;
   }
 

--- a/value/src/main/java/com/google/auto/value/processor/ExtensionContext.java
+++ b/value/src/main/java/com/google/auto/value/processor/ExtensionContext.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2015 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.google.auto.value.processor;
 
 import com.google.auto.value.extension.AutoValueExtension;

--- a/value/src/main/java/com/google/auto/value/processor/Java8Support.java
+++ b/value/src/main/java/com/google/auto/value/processor/Java8Support.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.google.auto.value.processor;
 
 import java.lang.reflect.Method;

--- a/value/src/main/java/com/google/auto/value/processor/Optionalish.java
+++ b/value/src/main/java/com/google/auto/value/processor/Optionalish.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.google.auto.value.processor;
 
 import com.google.auto.common.MoreElements;

--- a/value/src/main/java/com/google/auto/value/processor/Reformatter.java
+++ b/value/src/main/java/com/google/auto/value/processor/Reformatter.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.google.auto.value.processor;
 
 /**

--- a/value/src/main/java/com/google/auto/value/processor/autoannotation.vm
+++ b/value/src/main/java/com/google/auto/value/processor/autoannotation.vm
@@ -343,7 +343,7 @@ final class $className implements $annotationName {
     default:
       if (c < 0x20) {
         sb.append('\\');
-        appendWithZeroPadding(sb, Integer.toOctalString(c), 3);;
+        appendWithZeroPadding(sb, Integer.toOctalString(c), 3);
       } else if (c < 0x7f || Character.isLetter(c)) {
         sb.append(c);
       } else {
@@ -355,6 +355,7 @@ final class $className implements $annotationName {
   }
 
   ## We use this rather than String.format because that doesn't exist on GWT.
+
   private static void appendWithZeroPadding(StringBuilder sb, String s, int width) {
     for (int i = width - s.length(); i > 0; i--) {
       sb.append('0');

--- a/value/src/test/java/com/google/auto/value/processor/AbstractMethodExtractorTest.java
+++ b/value/src/test/java/com/google/auto/value/processor/AbstractMethodExtractorTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2013 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.google.auto.value.processor;
 
 import com.google.common.collect.ImmutableMultimap;

--- a/value/src/test/java/com/google/auto/value/processor/AbstractMethodListerTest.java
+++ b/value/src/test/java/com/google/auto/value/processor/AbstractMethodListerTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2013 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.google.auto.value.processor;
 
 import junit.framework.TestCase;

--- a/value/src/test/java/com/google/auto/value/processor/AutoAnnotationCompilationTest.java
+++ b/value/src/test/java/com/google/auto/value/processor/AutoAnnotationCompilationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 The Guava Authors
+ * Copyright (C) 2014 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/test/java/com/google/auto/value/processor/AutoAnnotationErrorsTest.java
+++ b/value/src/test/java/com/google/auto/value/processor/AutoAnnotationErrorsTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.google.auto.value.processor;
 
 import static com.google.common.truth.Truth.assertWithMessage;

--- a/value/src/test/java/com/google/auto/value/processor/CompilationErrorsTest.java
+++ b/value/src/test/java/com/google/auto/value/processor/CompilationErrorsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 The Guava Authors
+ * Copyright (C) 2012 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/test/java/com/google/auto/value/processor/CompilationTest.java
+++ b/value/src/test/java/com/google/auto/value/processor/CompilationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 The Guava Authors
+ * Copyright (C) 2014 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/test/java/com/google/auto/value/processor/EclipseHackTokenizerTest.java
+++ b/value/src/test/java/com/google/auto/value/processor/EclipseHackTokenizerTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2013 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.google.auto.value.processor;
 
 import junit.framework.TestCase;

--- a/value/src/test/java/com/google/auto/value/processor/ExtensionTest.java
+++ b/value/src/test/java/com/google/auto/value/processor/ExtensionTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2015 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.google.auto.value.processor;
 
 import static com.google.testing.compile.JavaSourcesSubject.assertThat;

--- a/value/src/test/java/com/google/auto/value/processor/GeneratedDoesNotExistTest.java
+++ b/value/src/test/java/com/google/auto/value/processor/GeneratedDoesNotExistTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2015 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.google.auto.value.processor;
 
 import static com.google.common.truth.Truth.assertAbout;

--- a/value/src/test/java/com/google/auto/value/processor/GuavaCollectionBuildersTest.java
+++ b/value/src/test/java/com/google/auto/value/processor/GuavaCollectionBuildersTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2015 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.google.auto.value.processor;
 
 import static com.google.common.truth.Truth.assertThat;

--- a/value/src/test/java/com/google/auto/value/processor/JavaScannerTest.java
+++ b/value/src/test/java/com/google/auto/value/processor/JavaScannerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 The Guava Authors
+ * Copyright (C) 2015 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/test/java/com/google/auto/value/processor/PropertyAnnotationsTest.java
+++ b/value/src/test/java/com/google/auto/value/processor/PropertyAnnotationsTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.google.auto.value.processor;
 
 import static com.google.common.truth.Truth.assertAbout;

--- a/value/src/test/java/com/google/auto/value/processor/ReformatterTest.java
+++ b/value/src/test/java/com/google/auto/value/processor/ReformatterTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.google.auto.value.processor;
 
 import junit.framework.TestCase;

--- a/value/src/test/java/com/google/auto/value/processor/TemplateVarsTest.java
+++ b/value/src/test/java/com/google/auto/value/processor/TemplateVarsTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.google.auto.value.processor;
 
 import com.google.auto.value.processor.escapevelocity.Template;

--- a/value/src/test/java/com/google/auto/value/processor/TypeSimplifierTest.java
+++ b/value/src/test/java/com/google/auto/value/processor/TypeSimplifierTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 The Guava Authors
+ * Copyright (C) 2012 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
# AutoValue, AutoAnnotation

* Make AutoValueProcessor's constructor that takes extensions public so that it can be used by compile-testing tests of AutoValueExtensions.
* Rework the javadoc of AutoValue.java so that it doesn't get stripped during export.
* Remove a redundant semicolon in the @AutoAnnotation template, and introduce a blank line because indentation disappears on the line after a Velocity comment. Fixes #337.
* Make copyright notices consistent.

# AutoFactory

* Add a note that states that you have to use @Qualifier instead of @BindingAnnotation in order for the generated code to work correctly.

# AutoCommon

* Add text to the specification of MoreElements.getLocalAndInheritedMethods to point out that the returned set may contain more than one method with the same signature.