### PR TITLE
Only use one StringBuilder per Builder.build call

### DIFF
--- a/value/src/main/java/com/google/auto/value/processor/autovalue.vm
+++ b/value/src/main/java/com/google/auto/value/processor/autovalue.vm
@@ -329,17 +329,17 @@ ${gwtCompatibleAnnotation}
 
   #if (!$builderRequiredProperties.empty)
 
-      String missing = "";
+      StringBuilder missing = new StringBuilder();
 
     #foreach ($p in $builderRequiredProperties)
 
       if ($p == null) {
-        missing += " $p.name";
+        missing.append(" $p.name");
       }
 
     #end
 
-      if (!missing.isEmpty()) {
+      if (missing.length() > 0) {
         throw new IllegalStateException("Missing required properties:" + missing);
       }
   #end

--- a/value/src/test/java/com/google/auto/value/processor/CompilationTest.java
+++ b/value/src/test/java/com/google/auto/value/processor/CompilationTest.java
@@ -850,17 +850,17 @@ public class CompilationTest {
         "      if (anImmutableListBuilder$ != null) {",
         "        anImmutableList = anImmutableListBuilder$.build();",
         "      }",
-        "      String missing = \"\";",
+        "      StringBuilder missing = new StringBuilder();",
         "      if (anInt == null) {",
-        "        missing += \" anInt\";",
+        "        missing.append(\" anInt\");",
         "      }",
         "      if (aByteArray == null) {",
-        "        missing += \" aByteArray\";",
+        "        missing.append(\" aByteArray\");",
         "      }",
         "      if (aList == null) {",
-        "        missing += \" aList\";",
+        "        missing.append(\" aList\");",
         "      }",
-        "      if (!missing.isEmpty()) {",
+        "      if (missing.length() > 0) {",
         "        throw new IllegalStateException(\"Missing required properties:\" + missing);",
         "      }",
         "      return new AutoValue_Baz<T>(",
@@ -1870,3 +1870,4 @@ public class CompilationTest {
         .compilesWithoutError();
   }
 }
+


### PR DESCRIPTION
Rewrites the builder to use a single `StringBuilder` when building the `missing` variable. I'm not sure if this would have any noticeable performance impact (positive or negative), but I'd thought I'd PR it anyways since it has so little changes.