### PR TITLE
Add support for varargs in AutoFactories

### DIFF
--- a/factory/src/main/java/com/google/auto/factory/processor/FactoryDescriptorGenerator.java
+++ b/factory/src/main/java/com/google/auto/factory/processor/FactoryDescriptorGenerator.java
@@ -139,6 +139,7 @@ final class FactoryDescriptorGenerator {
         .name("create")
         .returnType(classElement.asType())
         .publicMethod(classElement.getModifiers().contains(PUBLIC))
+        .isVarargs(constructor.isVarArgs())
         .providedParameters(providedParameters)
         .passedParameters(passedParameters)
         .creationParameters(Parameter.forParameterList(constructor.getParameters(), types))

--- a/factory/src/main/java/com/google/auto/factory/processor/FactoryMethodDescriptor.java
+++ b/factory/src/main/java/com/google/auto/factory/processor/FactoryMethodDescriptor.java
@@ -36,6 +36,7 @@ abstract class FactoryMethodDescriptor {
   abstract TypeMirror returnType();
   abstract boolean publicMethod();
   abstract boolean overridingMethod();
+  abstract boolean isVarargs();
   abstract ImmutableSet<Parameter> passedParameters();
   abstract ImmutableSet<Parameter> providedParameters();
   abstract ImmutableSet<Parameter> creationParameters();
@@ -49,7 +50,8 @@ abstract class FactoryMethodDescriptor {
     return new AutoValue_FactoryMethodDescriptor.Builder()
         .declaration(checkNotNull(declaration))
         .publicMethod(false)
-        .overridingMethod(false);
+        .overridingMethod(false)
+        .isVarargs(false);
   }
 
   @AutoValue.Builder
@@ -59,6 +61,7 @@ abstract class FactoryMethodDescriptor {
     abstract Builder returnType(TypeMirror returnType);
     abstract Builder publicMethod(boolean publicMethod);
     abstract Builder overridingMethod(boolean overridingMethod);
+    abstract Builder isVarargs(boolean varargs);
     abstract Builder passedParameters(Iterable<Parameter> passedParameters);
     abstract Builder providedParameters(Iterable<Parameter> providedParameters);
     abstract Builder creationParameters(Iterable<Parameter> creationParameters);

--- a/factory/src/main/java/com/google/auto/factory/processor/FactoryWriter.java
+++ b/factory/src/main/java/com/google/auto/factory/processor/FactoryWriter.java
@@ -132,6 +132,7 @@ final class FactoryWriter {
           "return new $T($L)",
           methodDescriptor.returnType(),
           argumentJoiner.join(creationParameterNames));
+      method.varargs(methodDescriptor.isVarargs());
       factory.addMethod(method.build());
     }
 

--- a/factory/src/test/java/com/google/auto/factory/processor/AutoFactoryProcessorTest.java
+++ b/factory/src/test/java/com/google/auto/factory/processor/AutoFactoryProcessorTest.java
@@ -95,6 +95,15 @@ public class AutoFactoryProcessorTest {
         .and().generatesSources(
             JavaFileObjects.forResource("expected/SimpleClassPassedDepsFactory.java"));
   }
+  
+  @Test public void simpleClassVarargsDeps() {
+    assertAbout(javaSource())
+        .that(JavaFileObjects.forResource("good/SimpleClassVarargsDeps.java"))
+        .processedWith(new AutoFactoryProcessor())
+        .compilesWithoutError()
+        .and().generatesSources(
+    		JavaFileObjects.forResource("expected/SimpleClassVarargsDepsFactory.java"));
+  }
 
   @Test public void simpleClassProvidedDeps() {
     assertAbout(javaSources())

--- a/factory/src/test/resources/expected/SimpleClassVarargsDepsFactory.java
+++ b/factory/src/test/resources/expected/SimpleClassVarargsDepsFactory.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2013 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package tests;
+
+import javax.annotation.Generated;
+import javax.inject.Inject;
+
+@Generated(
+    value = "com.google.auto.factory.processor.AutoFactoryProcessor",
+    comments = "https://github.com/google/auto/tree/master/factory"
+)
+final class SimpleClassVarargsDepsFactory {
+  @Inject
+  SimpleClassVarargsDepsFactory() {
+  }
+
+  SimpleClassVarargsDeps create(String... deps) {
+    return new SimpleClassVarargsDeps(deps);
+  }
+}

--- a/factory/src/test/resources/good/SimpleClassVarargsDeps.java
+++ b/factory/src/test/resources/good/SimpleClassVarargsDeps.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2013 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package tests;
+
+import com.google.auto.factory.AutoFactory;
+
+/**
+ * @author Matthias Muth
+ */
+@AutoFactory
+class SimpleClassVarargsDeps{
+    public SimpleClassVarargsDeps(String... deps) {
+    }
+}


### PR DESCRIPTION
The create()-method of the generated factory transformed varargs of the constructor to arrays, which made the use less convenient. This Pull Request is a possible fix for [#326](https://github.com/google/auto/issues/326).
