### PR TITLE
Add @Memoized to the open-source AutoValue project.

### DIFF
--- a/value/pom.xml
+++ b/value/pom.xml
@@ -63,6 +63,11 @@
       <artifactId>asm</artifactId>
       <version>4.1</version>
     </dependency>
+    <dependency>
+      <groupId>com.squareup</groupId>
+      <artifactId>javapoet</artifactId>
+      <version>1.7.0</version>
+    </dependency>
     <!-- test dependencies -->
     <dependency>
       <groupId>org.apache.velocity</groupId>
@@ -77,12 +82,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.google.testing.compile</groupId>
-      <artifactId>compile-testing</artifactId>
-      <version>0.9</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.11</version>
@@ -91,8 +90,21 @@
     <dependency>
       <groupId>com.google.truth</groupId>
       <artifactId>truth</artifactId>
-      <version>0.25</version>
+      <version>0.28</version>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.testing.compile</groupId>
+      <artifactId>compile-testing</artifactId>
+      <version>0.9</version>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <!-- Don't drag Truth in transitively -->
+          <groupId>com.google.truth</groupId>
+          <artifactId>truth</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 
@@ -154,6 +166,10 @@
                   <excludes>
                     <exclude>com.google.auto.value.**</exclude>
                   </excludes>
+                </relocation>
+                <relocation>
+                  <pattern>com.squareup.javapoet</pattern>
+                  <shadedPattern>autovalue.shaded.com.squareup.javapoet$</shadedPattern>
                 </relocation>
               </relocations>
             </configuration>

--- a/value/src/main/java/com/google/auto/value/extension/memoized/MemoizeExtension.java
+++ b/value/src/main/java/com/google/auto/value/extension/memoized/MemoizeExtension.java
@@ -1,0 +1,317 @@
+/*
+ * Copyright (C) 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.auto.value.extension.memoized;
+
+import static com.google.auto.common.MoreElements.isAnnotationPresent;
+import static com.google.common.base.Predicates.equalTo;
+import static com.google.common.base.Predicates.not;
+import static com.google.common.collect.Iterables.filter;
+import static com.squareup.javapoet.MethodSpec.constructorBuilder;
+import static com.squareup.javapoet.MethodSpec.methodBuilder;
+import static com.squareup.javapoet.TypeSpec.classBuilder;
+import static javax.lang.model.element.Modifier.ABSTRACT;
+import static javax.lang.model.element.Modifier.FINAL;
+import static javax.lang.model.element.Modifier.PRIVATE;
+import static javax.lang.model.element.Modifier.STATIC;
+import static javax.lang.model.element.Modifier.VOLATILE;
+import static javax.lang.model.type.TypeKind.VOID;
+import static javax.lang.model.util.ElementFilter.methodsIn;
+import static javax.tools.Diagnostic.Kind.ERROR;
+
+import com.google.auto.common.MoreElements;
+import com.google.auto.service.AutoService;
+import com.google.auto.value.extension.AutoValueExtension;
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.squareup.javapoet.AnnotationSpec;
+import com.squareup.javapoet.ClassName;
+import com.squareup.javapoet.CodeBlock;
+import com.squareup.javapoet.FieldSpec;
+import com.squareup.javapoet.JavaFile;
+import com.squareup.javapoet.MethodSpec;
+import com.squareup.javapoet.TypeName;
+import com.squareup.javapoet.TypeSpec;
+import java.util.Map;
+import javax.annotation.Generated;
+import javax.annotation.processing.Messager;
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.Modifier;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.util.Elements;
+import javax.tools.Diagnostic.Kind;
+
+/** An extension that implements the {@link Memoized} contract. */
+@AutoService(AutoValueExtension.class)
+public final class MemoizeExtension extends AutoValueExtension {
+  private static final ImmutableSet<String> DO_NOT_PULL_DOWN_ANNOTATIONS =
+      ImmutableSet.of(Override.class.getCanonicalName(), Memoized.class.getCanonicalName());
+
+  private static final AnnotationSpec GENERATED =
+      AnnotationSpec.builder(Generated.class)
+          .addMember("value", "$S", MemoizeExtension.class.getCanonicalName())
+          .build();
+
+  @Override
+  public boolean applicable(Context context) {
+    return !memoizedMethods(context).isEmpty();
+  }
+
+  @Override
+  public String generateClass(
+      Context context, String className, String classToExtend, boolean isFinal) {
+    return new Generator(context, className, classToExtend, isFinal).generate();
+  }
+
+  private static ImmutableSet<ExecutableElement> memoizedMethods(Context context) {
+    ImmutableSet.Builder<ExecutableElement> memoizedMethods = ImmutableSet.builder();
+    for (ExecutableElement method : methodsIn(context.autoValueClass().getEnclosedElements())) {
+      if (isAnnotationPresent(method, Memoized.class)) {
+        memoizedMethods.add(method);
+      }
+    }
+    return memoizedMethods.build();
+  }
+
+  static final class Generator {
+    private final Context context;
+    private final String className;
+    private final String classToExtend;
+    private final boolean isFinal;
+    private final Elements elements;
+    private final Messager messager;
+    private boolean hasErrors;
+
+    Generator(Context context, String className, String classToExtend, boolean isFinal) {
+      this.context = context;
+      this.className = className;
+      this.classToExtend = classToExtend;
+      this.isFinal = isFinal;
+      this.elements = context.processingEnvironment().getElementUtils();
+      this.messager = context.processingEnvironment().getMessager();
+    }
+
+    String generate() {
+      TypeSpec.Builder generated =
+          classBuilder(className)
+              .superclass(ClassName.get(context.packageName(), classToExtend))
+              .addModifiers(isFinal ? FINAL : ABSTRACT)
+              .addAnnotation(GENERATED)
+              .addMethod(constructor());
+      for (ExecutableElement method : memoizedMethods(context)) {
+        MethodOverrider methodOverrider = new MethodOverrider(method);
+        generated.addFields(methodOverrider.fields());
+        generated.addMethod(methodOverrider.method());
+      }
+      if (hasErrors) {
+        // TODO(b/28869279) Return null if invalid.
+        return "";
+      }
+      return JavaFile.builder(context.packageName(), generated.build()).build().toString();
+    }
+
+    private MethodSpec constructor() {
+      MethodSpec.Builder constructor = constructorBuilder();
+      for (Map.Entry<String, ExecutableElement> property : context.properties().entrySet()) {
+        constructor.addParameter(
+            TypeName.get(property.getValue().getReturnType()), property.getKey());
+      }
+      constructor.addStatement("super($L)", Joiner.on(", ").join(context.properties().keySet()));
+      return constructor.build();
+    }
+
+    /**
+     * Determines the required fields and overriding method for a {@link Memoized @Memoized}
+     * method.
+     */
+    private final class MethodOverrider {
+      private final ExecutableElement method;
+      private final MethodSpec.Builder override;
+      private final FieldSpec cacheField;
+      private final ImmutableList.Builder<FieldSpec> fields = ImmutableList.builder();
+
+      MethodOverrider(ExecutableElement method) {
+        this.method = method;
+        validate();
+        cacheField =
+            FieldSpec.builder(
+                    TypeName.get(method.getReturnType()),
+                    method.getSimpleName().toString(),
+                    PRIVATE,
+                    VOLATILE)
+                .build();
+        fields.add(cacheField);
+        override =
+            methodBuilder(method.getSimpleName().toString())
+                .addAnnotation(Override.class)
+                .returns(cacheField.type)
+                .addModifiers(filter(method.getModifiers(), not(equalTo(ABSTRACT))));
+        for (AnnotationMirror annotation : method.getAnnotationMirrors()) {
+          AnnotationSpec annotationSpec = AnnotationSpec.get(annotation);
+          if (pullDownMethodAnnotation(annotation)) {
+            override.addAnnotation(annotationSpec);
+          }
+        }
+
+        InitializationStrategy checkStrategy = strategy();
+        fields.addAll(checkStrategy.additionalFields());
+        override
+            .beginControlFlow("if ($L)", checkStrategy.checkMemoized())
+            .beginControlFlow("synchronized (this)")
+            .beginControlFlow("if ($L)", checkStrategy.checkMemoized())
+            .addStatement("$N = super.$L()", cacheField, method.getSimpleName())
+            .addCode(checkStrategy.setMemoized())
+            .endControlFlow()
+            .endControlFlow()
+            .endControlFlow()
+            .addStatement("return $N", cacheField);
+      }
+
+      /** The fields that should be added to the subclass. */
+      Iterable<FieldSpec> fields() {
+        return fields.build();
+      }
+
+      /** The overriding method that should be added to the subclass. */
+      MethodSpec method() {
+        return override.build();
+      }
+
+      private void validate() {
+        if (method.getReturnType().getKind().equals(VOID)) {
+          printMessage(ERROR, "@Memoized methods cannot be void");
+        }
+        if (!method.getParameters().isEmpty()) {
+          printMessage(ERROR, "@Memoized methods cannot have parameters");
+        }
+        checkIllegalModifier(PRIVATE);
+        checkIllegalModifier(FINAL);
+        checkIllegalModifier(STATIC);
+        
+        if (!overridesObjectMethod("hashCode") && !overridesObjectMethod("toString")) {
+          checkIllegalModifier(ABSTRACT);
+        }
+      }
+
+      private void checkIllegalModifier(Modifier modifier) {
+        if (method.getModifiers().contains(modifier)) {
+          printMessage(ERROR, "@Memoized methods cannot be " + modifier.toString());
+        }
+      }
+
+      private void printMessage(Kind kind, String format, Object... args) {
+        if (kind.equals(ERROR)) {
+          hasErrors = true;
+        }
+        messager.printMessage(kind, String.format(format, args), method);
+      }
+      
+      private boolean overridesObjectMethod(String methodName) {
+        return elements.overrides(method, objectMethod(methodName), context.autoValueClass());
+      }
+
+      private ExecutableElement objectMethod(final String methodName) {
+        TypeElement object = elements.getTypeElement(Object.class.getName());
+        for (ExecutableElement method : methodsIn(object.getEnclosedElements())) {
+          if (method.getSimpleName().contentEquals(methodName)) {
+            return method;
+          }
+        }
+        throw new IllegalArgumentException(
+            String.format("No method in Object named \"%s\"", methodName));
+      }
+
+      private boolean pullDownMethodAnnotation(AnnotationMirror annotation) {
+        return !DO_NOT_PULL_DOWN_ANNOTATIONS.contains(
+            MoreElements.asType(annotation.getAnnotationType().asElement())
+                .getQualifiedName()
+                .toString());
+      }
+
+      InitializationStrategy strategy() {
+        if (method.getReturnType().getKind().isPrimitive()) {
+          return new CheckBooleanField();
+        }
+        for (AnnotationMirror annotationMirror : method.getAnnotationMirrors()) {
+          if (annotationMirror
+              .getAnnotationType()
+              .asElement()
+              .getSimpleName()
+              .contentEquals("Nullable")) {
+            return new CheckBooleanField();
+          }
+        }
+        return new NullMeansUninitialized();
+      }
+
+      private abstract class InitializationStrategy {
+
+        abstract Iterable<FieldSpec> additionalFields();
+
+        abstract CodeBlock checkMemoized();
+
+        abstract CodeBlock setMemoized();
+      }
+
+      private final class NullMeansUninitialized extends InitializationStrategy {
+        @Override
+        Iterable<FieldSpec> additionalFields() {
+          return ImmutableList.of();
+        }
+
+        @Override
+        CodeBlock checkMemoized() {
+          return CodeBlock.of("$N == null", cacheField);
+        }
+
+        @Override
+        CodeBlock setMemoized() {
+          return CodeBlock.builder()
+              .beginControlFlow("if ($N == null)", cacheField)
+              .addStatement(
+                  "throw new NullPointerException($S)",
+                  method.getSimpleName() + "() cannot return null")
+              .endControlFlow()
+              .build();
+        }
+      }
+
+      private final class CheckBooleanField extends InitializationStrategy {
+
+        private final FieldSpec field =
+            FieldSpec.builder(
+                    TypeName.BOOLEAN, method.getSimpleName() + "$Memoized", PRIVATE, VOLATILE)
+                .build();
+
+        @Override
+        Iterable<FieldSpec> additionalFields() {
+          return ImmutableList.of(field);
+        }
+
+        @Override
+        CodeBlock checkMemoized() {
+          return CodeBlock.of("!$N", field);
+        }
+
+        @Override
+        CodeBlock setMemoized() {
+          return CodeBlock.builder().addStatement("$N = true", field).build();
+        }
+      }
+    }
+  }
+}

--- a/value/src/main/java/com/google/auto/value/extension/memoized/Memoized.java
+++ b/value/src/main/java/com/google/auto/value/extension/memoized/Memoized.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.auto.value.extension.memoized;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.SOURCE;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Annotates methods in {@link com.google.auto.value.AutoValue @AutoValue} classes for which the
+ * generated subclass will <a href="https://en.wikipedia.org/wiki/Memoization">memoize</a> the
+ * returned value.
+ *
+ * <p>Methods annotated with {@code @Memoized} cannot:
+ * <ul>
+ * <li>be {@code abstract} (except for {@link #hashCode()} and {@link #toString()}), {@code
+ *     private}, {@code final}, or {@code static}
+ * <li>return {@code void}
+ * <li>have any parameters
+ * </ul>
+ * 
+ * <p>If you want to memoize {@link #hashCode()} or {@link #toString()}, you can redeclare them,
+ * keeping them {@code abstract}, and annotate them with {@code @Memoize}.
+ *
+ * <p>If a {@code @Memoized} method is annotated with an annotation whose simple name is
+ * {@code Nullable}, then {@code null} values will also be memoized. Otherwise, if the method
+ * returns {@code null}, the overriding method will throw a {@link NullPointerException}.
+ *
+ * <p>The overriding method uses
+ * <a href="http://errorprone.info/bugpattern/DoubleCheckedLocking">double-checked locking</a> to
+ * ensure that the annotated method is called at most once.
+ *
+ * <h3>Example</h3>
+ *
+ * <pre>
+ *   {@code @AutoValue}
+ *   abstract class Value {
+ *     abstract String stringProperty();
+ *
+ *     {@code @Memoized}
+ *     String derivedProperty() {
+ *       return someCalculationOn(stringProperty());
+ *     }
+ *   }
+ *
+ *   {@code @Generated}
+ *   class AutoValue_Value {
+ *     // …
+ *
+ *     private volatile String derivedProperty;
+ *
+ *     {@code Override}
+ *     String derivedProperty() {
+ *       if (derivedProperty == null) {
+ *         synchronized (this) {
+ *           if (derivedProperty == null) {
+ *             derivedProperty = super.derivedProperty();
+ *           }
+ *         }
+ *       }
+ *       return derivedProperty;
+ *     }
+ *   }</pre>
+ */
+@Documented
+@Retention(SOURCE)
+@Target(METHOD)
+public @interface Memoized {}

--- a/value/src/test/java/com/google/auto/value/extension/memoized/MemoizedMethodSubject.java
+++ b/value/src/test/java/com/google/auto/value/extension/memoized/MemoizedMethodSubject.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.auto.value.extension.memoized;
+
+import static com.google.common.truth.Truth.assertAbout;
+import static com.google.testing.compile.JavaSourceSubjectFactory.javaSource;
+
+import com.google.auto.value.processor.AutoValueProcessor;
+import com.google.common.collect.ImmutableList;
+import com.google.common.truth.FailureStrategy;
+import com.google.common.truth.Subject;
+import com.google.testing.compile.JavaFileObjects;
+import javax.tools.JavaFileObject;
+
+final class MemoizedMethodSubject extends Subject<MemoizedMethodSubject, String> {
+
+  MemoizedMethodSubject(FailureStrategy failureStrategy, String subject) {
+    super(failureStrategy, subject);
+  }
+
+  void hasError(String error) {
+    JavaFileObject file =
+        JavaFileObjects.forSourceLines(
+            "Value",
+            "import com.google.auto.value.AutoValue;",
+            "import com.google.auto.value.extension.memoized.Memoized;",
+            "",
+            "@AutoValue abstract class Value {",
+            "  abstract String string();",
+            getSubject(),
+            "}");
+    assertAbout(javaSource())
+        .that(file)
+        .processedWith(new AutoValueProcessor(ImmutableList.of(new MemoizeExtension())))
+        .failsToCompile()
+        .withErrorContaining(error)
+        .in(file)
+        .onLine(6);
+  }
+}

--- a/value/src/test/java/com/google/auto/value/extension/memoized/MemoizedMethodSubjectFactory.java
+++ b/value/src/test/java/com/google/auto/value/extension/memoized/MemoizedMethodSubjectFactory.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.auto.value.extension.memoized;
+
+import static com.google.common.truth.Truth.assertAbout;
+
+import com.google.common.truth.FailureStrategy;
+import com.google.common.truth.SubjectFactory;
+
+final class MemoizedMethodSubjectFactory
+    extends SubjectFactory<MemoizedMethodSubject, String> {
+
+  static MemoizedMethodSubjectFactory memoizeMethod() {
+    return new MemoizedMethodSubjectFactory();
+  }
+
+  static MemoizedMethodSubject assertThatMemoizeMethod(String method) {
+    return assertAbout(memoizeMethod()).that(method);
+  }
+
+  @Override
+  public MemoizedMethodSubject getSubject(FailureStrategy fs, String that) {
+    return new MemoizedMethodSubject(fs, that);
+  }
+}

--- a/value/src/test/java/com/google/auto/value/extension/memoized/MemoizedTest.java
+++ b/value/src/test/java/com/google/auto/value/extension/memoized/MemoizedTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (C) 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.auto.value.extension.memoized;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.fail;
+
+import com.google.auto.value.AutoValue;
+import javax.annotation.Nullable;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class MemoizedTest {
+
+  private Value value;
+
+  @AutoValue
+  abstract static class Value {
+    private int primitiveCount;
+    private int notNullableCount;
+    private int nullableCount;
+    private int returnsNullCount;
+    private int notNullableButReturnsNullCount;
+
+    abstract String string();
+    abstract HashCodeAndToStringCounter counter();
+
+    @Memoized
+    int primitive() {
+      return ++primitiveCount;
+    }
+    
+    @Memoized
+    String notNullable() {
+      notNullableCount++;
+      return "derived " + string() + " " + notNullableCount;
+    }
+
+    @Memoized
+    @Nullable
+    String nullable() {
+      nullableCount++;
+      return "nullable derived " + string() + " " + nullableCount;
+    }
+
+    @Memoized
+    @Nullable
+    String returnsNull() {
+      returnsNullCount++;
+      return null;
+    }
+
+    @Memoized
+    String notNullableButReturnsNull() {
+      notNullableButReturnsNullCount++;
+      return null;
+    }
+    
+    @Override
+    @Memoized
+    public abstract int hashCode();
+
+    @Override
+    @Memoized
+    public abstract String toString();
+  }
+  
+  static class HashCodeAndToStringCounter {
+    int hashCodeCount;
+    int toStringCount;
+    
+    @Override
+    public int hashCode() {
+      return ++hashCodeCount;
+    }
+    
+    @Override
+    public String toString() {
+      return "a string" + ++toStringCount;
+    }
+  }
+
+  @Before
+  public void setUp() {
+    value = new AutoValue_MemoizedTest_Value("string", new HashCodeAndToStringCounter());
+  }
+
+  @Test
+  public void primitive() {
+    assertThat(value.primitive()).isEqualTo(1);
+    assertThat(value.primitive()).isEqualTo(1);
+    assertThat(value.primitiveCount).isEqualTo(1);
+  }
+
+  @Test
+  public void notNullable() {
+    assertThat(value.notNullable()).isEqualTo("derived string 1");
+    assertThat(value.notNullable()).isSameAs(value.notNullable());
+    assertThat(value.notNullableCount).isEqualTo(1);
+  }
+
+  @Test
+  public void nullable() {
+    assertThat(value.nullable()).isEqualTo("nullable derived string 1");
+    assertThat(value.nullable()).isSameAs(value.nullable());
+    assertThat(value.nullableCount).isEqualTo(1);
+  }
+
+  @Test
+  public void returnsNull() {
+    assertThat(value.returnsNull()).isNull();
+    assertThat(value.returnsNull()).isNull();
+    assertThat(value.returnsNullCount).isEqualTo(1);
+  }
+
+  @Test
+  public void notNullableButReturnsNull() {
+    try {
+      value.notNullableButReturnsNull();
+      fail();
+    } catch (NullPointerException expected) {
+      assertThat(expected).hasMessage("notNullableButReturnsNull() cannot return null");
+    }
+    assertThat(value.notNullableButReturnsNullCount).isEqualTo(1);
+  }
+  
+  @Test public void testHashCode() {
+    assertThat(value.hashCode()).isEqualTo(value.hashCode());
+    assertThat(value.counter().hashCodeCount).isEqualTo(1);
+  }
+  
+  @Test public void testToString() {
+    assertThat(value.toString()).isEqualTo(value.toString());
+    assertThat(value.counter().toStringCount).isEqualTo(1);
+  }
+}

--- a/value/src/test/java/com/google/auto/value/extension/memoized/MemoizedValidationTest.java
+++ b/value/src/test/java/com/google/auto/value/extension/memoized/MemoizedValidationTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.auto.value.extension.memoized;
+
+import static com.google.auto.value.extension.memoized.MemoizedMethodSubjectFactory.assertThatMemoizeMethod;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class MemoizedValidationTest {
+
+  @Test
+  public void privateMethod() {
+    assertThatMemoizeMethod("@Memoized private String method() { return \"\"; }")
+        .hasError("@Memoized methods cannot be private");
+  }
+
+  @Test
+  public void staticMethod() {
+    assertThatMemoizeMethod("@Memoized static String method() { return \"\"; }")
+        .hasError("@Memoized methods cannot be static");
+  }
+
+  @Test
+  public void finalMethod() {
+    assertThatMemoizeMethod("@Memoized final String method() { return \"\"; }")
+        .hasError("@Memoized methods cannot be final");
+  }
+
+  @Test
+  public void abstractMethod() {
+    assertThatMemoizeMethod("@Memoized abstract String method();")
+        .hasError("@Memoized methods cannot be abstract");
+  }
+
+  @Test
+  public void voidMethod() {
+    assertThatMemoizeMethod("@Memoized void method() {}")
+        .hasError("@Memoized methods cannot be void");
+  }
+
+  @Test
+  public void parameters() {
+    assertThatMemoizeMethod("@Memoized String method(Object param) { return \"\"; }")
+        .hasError("@Memoized methods cannot have parameters");
+  }
+}

--- a/value/userguide/index.md
+++ b/value/userguide/index.md
@@ -195,6 +195,7 @@ How do I...
     API?](howto.md#public_constructor)
 *   ... [use AutoValue on an **interface**, not abstract class?]
     (howto.md#interface)
+*   ... [**memoize** derived properties?](howto.md#memoize)
 
 <!-- TODO(kevinb): should the above be only a selected subset? -->
 


### PR DESCRIPTION
`@Memoized` can be used to annotate methods in `@AutoValue` classes for which the generated subclass will [memoize](https://en.wikipedia.org/wiki/Memoization) the returned value.

Methods annotated with `@Memoized` cannot:
  * be `abstract` (except for `hashCode()` and `toString()`),`private`, `final`, or `static`
  * return `void`
  * have any parameters

If you want to memoize `hashCode()` or `toString()`, you can redeclare them, keeping them `abstract`, and annotate them with `@Memoize`.

If a `@Memoized` method is annotated with an annotation whose simple name is `Nullable`, then `null` values will also be memoized. Otherwise, if the method returns `null`, the overriding method will throw a `NullPointerException`.

The overriding method uses [double-checked locking] to ensure that the annotated method is called at most once.

[double-checked locking]: http://errorprone.info/bugpattern/DoubleCheckedLocking

### Example

```java
@AutoValue
abstract class Value {
  abstract String stringProperty();

  @Memoized
  String derivedProperty() {
    return someCalculationOn(stringProperty());
  }
}

@Generated
class AutoValue_Value {
  // …

  private volatile String derivedProperty;

  @Override
  String derivedProperty() {
    if (derivedProperty == null) {
      synchronized (this) {
        if (derivedProperty == null) {
          derivedProperty = super.derivedProperty();
        }
      }
    }
    return derivedProperty;
  }
}
```

Extracted MemoizedMethodSubject and MemoizedMethodSubjectFactory in order for the Maven tests to work. ¯\_(ツ)_/¯

-------------
Created by MOE: https://github.com/google/moe
MOE_MIGRATED_REVID=132325012