### PR TITLE
Bump dependency versions to latest releases

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -37,36 +37,42 @@
     <developerConnection>scm:git:ssh://git@github.com/google/auto.git</developerConnection>
     <tag>HEAD</tag>
   </scm>
+  <properties>
+    <guava.version>19.0</guava.version>
+    <compile.testing.version>0.9</compile.testing.version>
+    <junit.version>4.12</junit.version>
+    <truth.version>0.30</truth.version>
+  </properties>
 
   <dependencies>
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>19.0</version>
+      <version>${guava.version}</version>
     </dependency>
     <!-- test dependencies -->
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava-testlib</artifactId>
-      <version>19.0</version>
+      <version>${guava.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.google.testing.compile</groupId>
       <artifactId>compile-testing</artifactId>
-      <version>0.7</version>
+      <version>${compile.testing.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.11</version>
+      <version>${junit.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.google.truth</groupId>
       <artifactId>truth</artifactId>
-      <version>0.25</version>
+      <version>${truth.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
Note: should only affect tests, as these are all test-scoped dependencies, so not a release blocker

-------------
Created by MOE: https://github.com/google/moe
MOE_MIGRATED_REVID=132577188