### PR TITLE
Support constructors that throw checked exceptions (Fixes #90).

### DIFF
--- a/factory/src/main/java/com/google/auto/factory/processor/AutoFactoryProcessor.java
+++ b/factory/src/main/java/com/google/auto/factory/processor/AutoFactoryProcessor.java
@@ -192,6 +192,7 @@ public final class AutoFactoryProcessor extends AbstractProcessor {
                 .returnType(getAnnotatedType(autoFactoryElement))
                 .publicMethod()
                 .passedParameters(passedParameters)
+                .thrownTypes(methodType.getThrownTypes())
                 .isVarArgs(implementationMethod.isVarArgs())
                 .build());
       }

--- a/factory/src/main/java/com/google/auto/factory/processor/FactoryDescriptorGenerator.java
+++ b/factory/src/main/java/com/google/auto/factory/processor/FactoryDescriptorGenerator.java
@@ -42,6 +42,9 @@ import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
 import javax.lang.model.util.ElementKindVisitor6;
 import javax.lang.model.util.Types;
+import javax.lang.model.type.TypeMirror;
+import com.squareup.javapoet.TypeName;
+import java.util.ArrayList;
 
 /**
  * A service that traverses an element and returns the set of factory methods defined therein.
@@ -141,6 +144,7 @@ final class FactoryDescriptorGenerator {
         .publicMethod(classElement.getModifiers().contains(PUBLIC))
         .providedParameters(providedParameters)
         .passedParameters(passedParameters)
+        .thrownTypes(constructor.getThrownTypes())
         .creationParameters(Parameter.forParameterList(constructor.getParameters(), types))
         .isVarArgs(constructor.isVarArgs())
         .build();

--- a/factory/src/main/java/com/google/auto/factory/processor/FactoryMethodDescriptor.java
+++ b/factory/src/main/java/com/google/auto/factory/processor/FactoryMethodDescriptor.java
@@ -38,6 +38,7 @@ abstract class FactoryMethodDescriptor {
   abstract ImmutableSet<Parameter> passedParameters();
   abstract ImmutableSet<Parameter> providedParameters();
   abstract ImmutableSet<Parameter> creationParameters();
+  abstract ImmutableSet<? extends TypeMirror> thrownTypes();
   abstract Builder toBuilder();
   abstract boolean isVarArgs();
 
@@ -63,6 +64,7 @@ abstract class FactoryMethodDescriptor {
     abstract Builder passedParameters(Iterable<Parameter> passedParameters);
     abstract Builder providedParameters(Iterable<Parameter> providedParameters);
     abstract Builder creationParameters(Iterable<Parameter> creationParameters);
+    abstract Builder thrownTypes(Iterable<? extends TypeMirror> thrownTypes);
     abstract Builder isVarArgs(boolean isVarargs);
     abstract FactoryMethodDescriptor buildImpl();
 

--- a/factory/src/main/java/com/google/auto/factory/processor/FactoryWriter.java
+++ b/factory/src/main/java/com/google/auto/factory/processor/FactoryWriter.java
@@ -56,6 +56,7 @@ import javax.lang.model.type.PrimitiveType;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.SimpleTypeVisitor7;
 import javax.tools.JavaFileObject;
+import java.util.ArrayList;
 
 final class FactoryWriter {
 
@@ -137,6 +138,11 @@ final class FactoryWriter {
       }
       CodeBlock.Builder args = CodeBlock.builder();
       method.addParameters(parameters(methodDescriptor.passedParameters()));
+      ArrayList<TypeName> thrownTypeNames = new ArrayList<TypeName>();
+      for (TypeMirror tm : methodDescriptor.thrownTypes()) {
+        thrownTypeNames.add(TypeName.get(tm));
+      }
+      method.addExceptions(thrownTypeNames);
       Iterator<Parameter> parameters = methodDescriptor.creationParameters().iterator();
       for (int argumentIndex = 1; parameters.hasNext(); argumentIndex++) {
         Parameter parameter = parameters.next();
@@ -182,6 +188,11 @@ final class FactoryWriter {
       if (methodDescriptor.publicMethod()) {
         implementationMethod.addModifiers(PUBLIC);
       }
+      ArrayList<TypeName> thrownTypeNames = new ArrayList<TypeName>();
+      for (TypeMirror tm : methodDescriptor.thrownTypes()) {
+        thrownTypeNames.add(TypeName.get(tm));
+      }
+      implementationMethod.addExceptions(thrownTypeNames);
       implementationMethod.addParameters(parameters(methodDescriptor.passedParameters()));
       implementationMethod.addStatement(
           "return create($L)",

--- a/factory/src/main/java/com/google/auto/factory/processor/ImplementationMethodDescriptor.java
+++ b/factory/src/main/java/com/google/auto/factory/processor/ImplementationMethodDescriptor.java
@@ -25,6 +25,7 @@ abstract class ImplementationMethodDescriptor {
   abstract TypeMirror returnType();
   abstract boolean publicMethod();
   abstract ImmutableSet<Parameter> passedParameters();
+  abstract ImmutableSet<? extends TypeMirror> thrownTypes();
   abstract boolean isVarArgs();
 
   static Builder builder() {
@@ -39,6 +40,7 @@ abstract class ImplementationMethodDescriptor {
     abstract Builder returnType(TypeMirror returnTypeElement);
     abstract Builder publicMethod(boolean publicMethod);
     abstract Builder passedParameters(Iterable<Parameter> passedParameters);
+    abstract Builder thrownTypes(Iterable<? extends TypeMirror> thrownTypes);
     abstract Builder isVarArgs(boolean isVarargs);
     abstract ImplementationMethodDescriptor build();
 

--- a/factory/src/test/java/com/google/auto/factory/processor/AutoFactoryProcessorTest.java
+++ b/factory/src/test/java/com/google/auto/factory/processor/AutoFactoryProcessorTest.java
@@ -395,4 +395,12 @@ public class AutoFactoryProcessorTest {
         .and()
         .generatesSources(JavaFileObjects.forResource("expected/SimpleClassVarargsFactory.java"));
   }
+
+  @Test public void constructorWithException() {
+    assertThat(JavaFileObjects.forResource("good/ConstructorWithException.java"))
+        .processedWith(new AutoFactoryProcessor())
+        .compilesWithoutError()
+        .and()
+        .generatesSources(JavaFileObjects.forResource("expected/ConstructorWithExceptionFactory.java"));
+  }
 }

--- a/factory/src/test/resources/expected/ConstructorWithExceptionFactory.java
+++ b/factory/src/test/resources/expected/ConstructorWithExceptionFactory.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2013 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package tests;
+
+import javax.annotation.Generated;
+import javax.inject.Inject;
+
+@Generated(
+  value = "com.google.auto.factory.processor.AutoFactoryProcessor",
+  comments = "https://github.com/google/auto/tree/master/factory"
+  )
+final class ConstructorWithExceptionFactory {
+  @Inject ConstructorWithExceptionFactory() {}
+
+  ConstructorWithException create() throws Exception {
+    return new ConstructorWithException();
+  }
+}

--- a/factory/src/test/resources/good/ConstructorWithException.java
+++ b/factory/src/test/resources/good/ConstructorWithException.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2013 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package tests;
+
+import com.google.auto.factory.AutoFactory;
+import com.google.auto.factory.Provided;
+
+@AutoFactory
+final class ConstructorWithException {
+    ConstructorWithException() throws Exception {}
+}


### PR DESCRIPTION
This merge request adds checked exceptions that a constructor may throw to the throw list of the generated create() method.
The added code could probably be simpilfied more.
