### PR TITLE
Update AutoFactory latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Save time.  Save code.  Save sanity.
 
   * [AutoFactory] - JSR-330-compatible factories
 
-    Latest version: `0.1-beta3`
+    Latest version: `1.0-beta3`
 
   * [AutoService] - Provider-configuration files for [`ServiceLoader`]
 


### PR DESCRIPTION
The latest version of AutoFactory is actually [published at Maven Repository as 1.0-beta3](https://mvnrepository.com/artifact/com.google.auto.factory/auto-factory/1.0-beta3).
