### PR TITLE
Sync out google internal changes.

### DIFF
--- a/common/src/main/java/com/google/auto/common/AnnotationMirrors.java
+++ b/common/src/main/java/com/google/auto/common/AnnotationMirrors.java
@@ -74,7 +74,7 @@ public final class AnnotationMirrors {
    * {@link ExecutableElement}, supplying default values from the annotation if the
    * annotation property has not been set.  This is equivalent to
    * {@link Elements#getElementValuesWithDefaults(AnnotationMirror)} but can be called
-   * statically without an {@Elements} instance.
+   * statically without an {@link Elements} instance.
    */
   public static Map<ExecutableElement, AnnotationValue> getAnnotationValuesWithDefaults(
       AnnotationMirror annotation) {

--- a/common/src/main/java/com/google/auto/common/BasicAnnotationProcessor.java
+++ b/common/src/main/java/com/google/auto/common/BasicAnnotationProcessor.java
@@ -64,7 +64,7 @@ import javax.lang.model.util.SimpleElementVisitor6;
  * access the {@link ProcessingEnvironment} using {@link #processingEnv}.
  *
  * Any logic that needs to happen once per round can be specified by overriding
- * {@link #postProcess()}.
+ * {@link #postRound(RoundEnvironment)}.
  *
  * <h3>Ill-formed elements are deferred</h3>
  * Any annotated element whose nearest enclosing type is not well-formed is deferred, and not passed

--- a/common/src/main/java/com/google/auto/common/MoreElements.java
+++ b/common/src/main/java/com/google/auto/common/MoreElements.java
@@ -270,7 +270,7 @@ public final class MoreElements {
    * @param type the type whose own and inherited methods are to be returned
    * @param elementUtils an {@link Elements} object, typically returned by
    *     {@link javax.annotation.processing.AbstractProcessor#processingEnv processingEnv}<!--
-   *     -->.{@link javax.annotation.processing.ProcessingEnvironment.getElementUtils()
+   *     -->.{@link javax.annotation.processing.ProcessingEnvironment#getElementUtils
    *     getElementUtils()}
    *
    * @deprecated The method {@link #getLocalAndInheritedMethods(TypeElement, Types, Elements)}
@@ -298,11 +298,11 @@ public final class MoreElements {
    * @param type the type whose own and inherited methods are to be returned
    * @param typeUtils a {@link Types} object, typically returned by
    *     {@link javax.annotation.processing.AbstractProcessor#processingEnv processingEnv}<!--
-   *     -->.{@link javax.annotation.processing.ProcessingEnvironment.getTypeUtils()
+   *     -->.{@link javax.annotation.processing.ProcessingEnvironment#getTypeUtils
    *     getTypeUtils()}
    * @param elementUtils an {@link Elements} object, typically returned by
    *     {@link javax.annotation.processing.AbstractProcessor#processingEnv processingEnv}<!--
-   *     -->.{@link javax.annotation.processing.ProcessingEnvironment.getElementUtils()
+   *     -->.{@link javax.annotation.processing.ProcessingEnvironment#getElementUtils
    *     getElementUtils()}
    */
   public static ImmutableSet<ExecutableElement> getLocalAndInheritedMethods(

--- a/factory/pom.xml
+++ b/factory/pom.xml
@@ -60,7 +60,7 @@
     <dependency>
       <groupId>com.google.googlejavaformat</groupId>
       <artifactId>google-java-format</artifactId>
-      <version>1.0</version>
+      <version>1.1</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>

--- a/factory/src/main/java/com/google/auto/factory/processor/AutoFactoryProcessor.java
+++ b/factory/src/main/java/com/google/auto/factory/processor/AutoFactoryProcessor.java
@@ -27,6 +27,8 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Multimaps;
+import com.google.googlejavaformat.java.filer.FormattingFiler;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
@@ -72,7 +74,7 @@ public final class AutoFactoryProcessor extends AbstractProcessor {
     elements = processingEnv.getElementUtils();
     types = processingEnv.getTypeUtils();
     messager = processingEnv.getMessager();
-    factoryWriter = new FactoryWriter(processingEnv.getFiler());
+    factoryWriter = new FactoryWriter(new FormattingFiler(processingEnv.getFiler()));
     providedChecker = new ProvidedChecker(messager);
     declarationFactory = new AutoFactoryDeclaration.Factory(elements, messager);
     factoryDescriptorGenerator =

--- a/value/pom.xml
+++ b/value/pom.xml
@@ -61,7 +61,7 @@
     <dependency>
       <groupId>org.ow2.asm</groupId>
       <artifactId>asm</artifactId>
-      <version>4.1</version>
+      <version>5.0.4</version>
     </dependency>
     <dependency>
       <groupId>com.squareup</groupId>

--- a/value/src/main/java/com/google/auto/value/processor/AbstractMethodLister.java
+++ b/value/src/main/java/com/google/auto/value/processor/AbstractMethodLister.java
@@ -55,7 +55,7 @@ class AbstractMethodLister {
     private final ImmutableList.Builder<String> abstractNoArgMethods = ImmutableList.builder();
 
     RecordingClassVisitor() {
-      super(Opcodes.ASM4);
+      super(Opcodes.ASM5);
     }
 
     @Override

--- a/value/src/test/java/com/google/auto/value/processor/PropertyAnnotationsTest.java
+++ b/value/src/test/java/com/google/auto/value/processor/PropertyAnnotationsTest.java
@@ -32,17 +32,14 @@ import junit.framework.TestCase;
  * @author jmcampanini
  */
 public class PropertyAnnotationsTest extends TestCase {
-
-  private static final String PROPERTY_ANNOTATION_TEST =
-      new Object(){}.getClass().getEnclosingClass().getName();
-  private static final String IMPORT_TEST_ANNOTATION =
-      "import " + PROPERTY_ANNOTATION_TEST + ".TestAnnotation;";
+  private static final String PROPERTY_ANNOTATIONS_TEST =
+      PropertyAnnotationsTest.class.getName();
+  private static final String IMPORT_PROPERTY_ANNOTATIONS_TEST =
+      "import " + PROPERTY_ANNOTATIONS_TEST + ";";
   private static final String TEST_ANNOTATION =
-      "@TestAnnotation";
-  private static final String IMPORT_TEST_ARRAY_ANNOTATION =
-      "import " + PROPERTY_ANNOTATION_TEST + ".TestArrayAnnotation;";
+      "@PropertyAnnotationsTest.TestAnnotation";
   private static final String TEST_ARRAY_ANNOTATION =
-      "@TestArrayAnnotation";
+      "@PropertyAnnotationsTest.TestArrayAnnotation";
 
   public static enum TestEnum {
     A, B;
@@ -220,29 +217,25 @@ public class PropertyAnnotationsTest extends TestCase {
   }
 
   public void testNumberValueAnnotation() {
-    assertGeneratedMatches(
-        ImmutableList.of(IMPORT_TEST_ANNOTATION),
+    assertGeneratedMatches(ImmutableList.of(IMPORT_PROPERTY_ANNOTATIONS_TEST),
         ImmutableList.of(TEST_ANNOTATION + "(testShort = 1, testInt = 2, testLong = 3L)"),
         ImmutableList.of(TEST_ANNOTATION + "(testShort = 1, testInt = 2, testLong = 3L)"));
   }
 
   public void testByteValueAnnotation() {
-    assertGeneratedMatches(
-        ImmutableList.of(IMPORT_TEST_ANNOTATION),
+    assertGeneratedMatches(ImmutableList.of(IMPORT_PROPERTY_ANNOTATIONS_TEST),
         ImmutableList.of(TEST_ANNOTATION + "(testByte = 0)"),
         ImmutableList.of(TEST_ANNOTATION + "(testByte = 0)"));
   }
 
   public void testDecimalValueAnnotation() {
-    assertGeneratedMatches(
-        ImmutableList.of(IMPORT_TEST_ANNOTATION),
+    assertGeneratedMatches(ImmutableList.of(IMPORT_PROPERTY_ANNOTATIONS_TEST),
         ImmutableList.of(TEST_ANNOTATION + "(testDouble = 1.2d, testFloat = 3.4f)"),
         ImmutableList.of(TEST_ANNOTATION + "(testDouble = 1.2d, testFloat = 3.4f)"));
   }
 
   public void testOtherValuesAnnotation() {
-    assertGeneratedMatches(
-        ImmutableList.of(IMPORT_TEST_ANNOTATION),
+    assertGeneratedMatches(ImmutableList.of(IMPORT_PROPERTY_ANNOTATIONS_TEST),
         ImmutableList.of(TEST_ANNOTATION
             + "(testBoolean = true, testString = \"hallo\", testChar = 'a')"),
         ImmutableList.of(TEST_ANNOTATION
@@ -250,8 +243,7 @@ public class PropertyAnnotationsTest extends TestCase {
   }
 
   public void testClassAnnotation() {
-    assertGeneratedMatches(
-        ImmutableList.of(IMPORT_TEST_ANNOTATION),
+    assertGeneratedMatches(ImmutableList.of(IMPORT_PROPERTY_ANNOTATIONS_TEST),
         ImmutableList.of(TEST_ANNOTATION
             + "(testClass = String.class)"),
         ImmutableList.of(TEST_ANNOTATION
@@ -259,35 +251,32 @@ public class PropertyAnnotationsTest extends TestCase {
   }
 
   public void testEnumAnnotation() {
-    assertGeneratedMatches(
-        ImmutableList.of(IMPORT_TEST_ANNOTATION),
+    assertGeneratedMatches(ImmutableList.of(IMPORT_PROPERTY_ANNOTATIONS_TEST),
         ImmutableList.of(TEST_ANNOTATION
-            + "(testEnum = " + PROPERTY_ANNOTATION_TEST + ".TestEnum.A)"),
+            + "(testEnum = " + PROPERTY_ANNOTATIONS_TEST + ".TestEnum.A)"),
         ImmutableList.of(TEST_ANNOTATION
-            + "(testEnum = " + PROPERTY_ANNOTATION_TEST + ".TestEnum.A)"));
+            + "(testEnum = PropertyAnnotationsTest.TestEnum.A)"));
   }
 
   public void testEmptyAnnotationAnnotation() {
-    assertGeneratedMatches(
-        ImmutableList.of(IMPORT_TEST_ANNOTATION),
+    assertGeneratedMatches(ImmutableList.of(IMPORT_PROPERTY_ANNOTATIONS_TEST),
         ImmutableList.of(TEST_ANNOTATION
-            + "(testAnnotation = @" + PROPERTY_ANNOTATION_TEST + ".OtherAnnotation)"),
+            + "(testAnnotation = @PropertyAnnotationsTest.OtherAnnotation)"),
         ImmutableList.of(TEST_ANNOTATION
-            + "(testAnnotation = @" + PROPERTY_ANNOTATION_TEST + ".OtherAnnotation)"));
+            + "(testAnnotation = @PropertyAnnotationsTest.OtherAnnotation)"));
   }
 
   public void testValuedAnnotationAnnotation() {
-    assertGeneratedMatches(
-        ImmutableList.of(IMPORT_TEST_ANNOTATION),
+    assertGeneratedMatches(ImmutableList.of(IMPORT_PROPERTY_ANNOTATIONS_TEST),
         ImmutableList.of(TEST_ANNOTATION
-            + "(testAnnotation = @" + PROPERTY_ANNOTATION_TEST + ".OtherAnnotation(foo=999))"),
+            + "(testAnnotation = @PropertyAnnotationsTest.OtherAnnotation(foo=999))"),
         ImmutableList.of(TEST_ANNOTATION
-            + "(testAnnotation = @" + PROPERTY_ANNOTATION_TEST + ".OtherAnnotation(foo=999))"));
+            + "(testAnnotation = @PropertyAnnotationsTest.OtherAnnotation(foo=999))"));
   }
 
   public void testNumberArrayAnnotation() {
     assertGeneratedMatches(
-        ImmutableList.of(IMPORT_TEST_ARRAY_ANNOTATION),
+        ImmutableList.of(IMPORT_PROPERTY_ANNOTATIONS_TEST),
         ImmutableList.of(TEST_ARRAY_ANNOTATION
             + "(testShorts = {2, 3}, testInts = {4, 5}, testLongs = {6L, 7L})"),
         ImmutableList.of(TEST_ARRAY_ANNOTATION
@@ -296,14 +285,14 @@ public class PropertyAnnotationsTest extends TestCase {
 
   public void testByteArrayAnnotation() {
     assertGeneratedMatches(
-        ImmutableList.of(IMPORT_TEST_ARRAY_ANNOTATION),
+        ImmutableList.of(IMPORT_PROPERTY_ANNOTATIONS_TEST),
         ImmutableList.of(TEST_ARRAY_ANNOTATION + "(testBytes = {0, 1})"),
         ImmutableList.of(TEST_ARRAY_ANNOTATION + "(testBytes = {0, 1})"));
   }
 
   public void testDecimalArrayAnnotation() {
     assertGeneratedMatches(
-        ImmutableList.of(IMPORT_TEST_ARRAY_ANNOTATION),
+        ImmutableList.of(IMPORT_PROPERTY_ANNOTATIONS_TEST),
         ImmutableList.of(TEST_ARRAY_ANNOTATION
             + "(testDoubles = {1.2d, 3.4d}, testFloats = {5.6f, 7.8f})"),
         ImmutableList.of(TEST_ARRAY_ANNOTATION
@@ -312,7 +301,7 @@ public class PropertyAnnotationsTest extends TestCase {
 
   public void testOtherArrayAnnotation() {
     assertGeneratedMatches(
-        ImmutableList.of(IMPORT_TEST_ARRAY_ANNOTATION),
+        ImmutableList.of(IMPORT_PROPERTY_ANNOTATIONS_TEST),
         ImmutableList.of(TEST_ARRAY_ANNOTATION
             + "(testBooleans = {false, false},"
             + " testStrings = {\"aaa\", \"bbb\"}, testChars={'x', 'y'})"),
@@ -323,7 +312,7 @@ public class PropertyAnnotationsTest extends TestCase {
 
   public void testClassArrayAnnotation() {
     assertGeneratedMatches(
-        ImmutableList.of(IMPORT_TEST_ARRAY_ANNOTATION),
+        ImmutableList.of(IMPORT_PROPERTY_ANNOTATIONS_TEST),
         ImmutableList.of(TEST_ARRAY_ANNOTATION + "(testClasses = {String.class, Long.class})"),
         ImmutableList.of(TEST_ARRAY_ANNOTATION
             + "(testClasses = {java.lang.String.class, java.lang.Long.class})"));
@@ -331,7 +320,7 @@ public class PropertyAnnotationsTest extends TestCase {
 
   public void testImportedClassArrayAnnotation() {
     assertGeneratedMatches(
-        ImmutableList.of(IMPORT_TEST_ARRAY_ANNOTATION),
+        ImmutableList.of(IMPORT_PROPERTY_ANNOTATIONS_TEST),
         ImmutableList.of(TEST_ARRAY_ANNOTATION
             + "(testClasses = {javax.annotation.Nullable.class, Long.class})"),
         ImmutableList.of(TEST_ARRAY_ANNOTATION
@@ -339,32 +328,27 @@ public class PropertyAnnotationsTest extends TestCase {
   }
 
   public void testEnumArrayAnnotation() {
-    assertGeneratedMatches(
-        ImmutableList.of(IMPORT_TEST_ARRAY_ANNOTATION),
+    assertGeneratedMatches(ImmutableList.of(IMPORT_PROPERTY_ANNOTATIONS_TEST),
         ImmutableList.of(TEST_ARRAY_ANNOTATION
-            + "(testEnums = {" + PROPERTY_ANNOTATION_TEST + ".TestEnum.A})"),
+            + "(testEnums = {PropertyAnnotationsTest.TestEnum.A})"),
         ImmutableList.of(TEST_ARRAY_ANNOTATION
-            + "(testEnums = {" + PROPERTY_ANNOTATION_TEST + ".TestEnum.A})"));
+            + "(testEnums = {PropertyAnnotationsTest.TestEnum.A})"));
   }
 
   public void testArrayOfEmptyAnnotationAnnotation() {
-    assertGeneratedMatches(
-        ImmutableList.of(IMPORT_TEST_ARRAY_ANNOTATION),
+    assertGeneratedMatches(ImmutableList.of(IMPORT_PROPERTY_ANNOTATIONS_TEST),
         ImmutableList.of(TEST_ARRAY_ANNOTATION
-            + "(testAnnotations = {@" + PROPERTY_ANNOTATION_TEST + ".OtherAnnotation})"),
+            + "(testAnnotations = {@PropertyAnnotationsTest.OtherAnnotation})"),
         ImmutableList.of(TEST_ARRAY_ANNOTATION
-            + "(testAnnotations = {@" + PROPERTY_ANNOTATION_TEST + ".OtherAnnotation})"));
+            + "(testAnnotations = {@PropertyAnnotationsTest.OtherAnnotation})"));
   }
 
   public void testArrayOfValuedAnnotationAnnotation() {
-    assertGeneratedMatches(
-        ImmutableList.of(IMPORT_TEST_ARRAY_ANNOTATION),
+    assertGeneratedMatches(ImmutableList.of(IMPORT_PROPERTY_ANNOTATIONS_TEST),
         ImmutableList.of(TEST_ARRAY_ANNOTATION
-            + "(testAnnotations = {@" + PROPERTY_ANNOTATION_TEST
-            + ".OtherAnnotation(foo = 999)})"),
+            + "(testAnnotations = {@PropertyAnnotationsTest.OtherAnnotation(foo = 999)})"),
         ImmutableList.of(TEST_ARRAY_ANNOTATION
-            + "(testAnnotations = {@" + PROPERTY_ANNOTATION_TEST
-            + ".OtherAnnotation(foo = 999)})"));
+            + "(testAnnotations = {@PropertyAnnotationsTest.OtherAnnotation(foo = 999)})"));
   }
 
   /**
@@ -374,22 +358,20 @@ public class PropertyAnnotationsTest extends TestCase {
    */
   public void testCopyingMethodAnnotations() {
     ImmutableList<String> sourceImports =
-        ImmutableList.of(
-            "import javax.annotation.Resource;",
-            IMPORT_TEST_ANNOTATION,
-            "import " + PROPERTY_ANNOTATION_TEST + ".InheritedAnnotation;");
+        ImmutableList.of("import javax.annotation.Resource;",
+            IMPORT_PROPERTY_ANNOTATIONS_TEST);
     ImmutableList<String> sourceAnnotations =
         ImmutableList.of(
-            "@AutoValue.CopyAnnotations(exclude={TestAnnotation.class})",
+            "@AutoValue.CopyAnnotations(exclude={PropertyAnnotationsTest.TestAnnotation.class})",
             "@Resource",
-            "@TestAnnotation",
-            "@InheritedAnnotation");
+            "@PropertyAnnotationsTest.TestAnnotation",
+            "@PropertyAnnotationsTest.InheritedAnnotation");
 
     ImmutableList<String> expectedImports = ImmutableList.of("import javax.annotation.Resource;");
     ImmutableList<String> expectedAnnotations =
         ImmutableList.of(
             "@Resource",
-            "@com.google.auto.value.processor.PropertyAnnotationsTest.InheritedAnnotation");
+            "@" + PROPERTY_ANNOTATIONS_TEST + ".InheritedAnnotation");
 
     JavaFileObject javaFileObject = sourceCode(sourceImports, sourceAnnotations);
     JavaFileObject expectedOutput = expectedCode(expectedImports, expectedAnnotations);

--- a/value/src/test/java/com/google/auto/value/processor/testclasses/RuntimePermission.java
+++ b/value/src/test/java/com/google/auto/value/processor/testclasses/RuntimePermission.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.auto.value.processor.testclasses;
+
+/**
+ * This class just exists to test import behaviour when referencing a class which has the same
+ * name as a class in java.lang.
+ *
+ * @author emcmanus@google.com (Éamonn McManus)
+ */
+public class RuntimePermission {
+}


### PR DESCRIPTION
Changes include:

  * Javadoc fixes
  * Update to ASM-5 for Java8 compatibility (should still work in Java7)
  * Support @LazyInit from error-prone in cases where @Memoized is too eager
  * Make AutoValue only import top-level types (and use relative references to nested types)
  * Switch to using the FormattingFiler from google-java-format.