### PR TITLE
Latest changes from Google.

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -75,6 +75,12 @@
       <version>${truth.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.eclipse.jdt.core.compiler</groupId>
+      <artifactId>ecj</artifactId>
+      <version>4.5.1</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/common/src/main/java/com/google/auto/common/MoreElements.java
+++ b/common/src/main/java/com/google/auto/common/MoreElements.java
@@ -310,7 +310,7 @@ public final class MoreElements {
     // TODO(emcmanus): detect if the Types and Elements are the javac ones, and use
     //   NativeOverrides if so. We may need to adjust the logic further to avoid the bug
     //   tested for by MoreElementsTest.getLocalAndInheritedMethods_DaggerBug.
-    Overrides overrides = new Overrides.ExplicitOverrides(typeUtils, elementUtils);
+    Overrides overrides = new Overrides.ExplicitOverrides(typeUtils);
     return getLocalAndInheritedMethods(type, overrides);
   }
 

--- a/common/src/main/java/com/google/auto/common/Overrides.java
+++ b/common/src/main/java/com/google/auto/common/Overrides.java
@@ -15,12 +15,28 @@
  */
 package com.google.auto.common;
 
+import com.google.common.base.Preconditions;
+import com.google.common.base.Verify;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import java.util.List;
+import java.util.Map;
+import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.TypeParameterElement;
+import javax.lang.model.element.VariableElement;
+import javax.lang.model.type.ArrayType;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.ExecutableType;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.type.TypeVariable;
+import javax.lang.model.util.ElementFilter;
 import javax.lang.model.util.Elements;
+import javax.lang.model.util.SimpleTypeVisitor6;
 import javax.lang.model.util.Types;
 
 /**
@@ -51,21 +67,30 @@ abstract class Overrides {
 
   static class ExplicitOverrides extends Overrides {
     private final Types typeUtils;
-    private final Elements elementUtils;
 
-    ExplicitOverrides(Types typeUtils, Elements elementUtils) {
+    ExplicitOverrides(Types typeUtils) {
       this.typeUtils = typeUtils;
-      this.elementUtils = elementUtils;
     }
 
     @Override
-    public boolean overrides(ExecutableElement overrider, ExecutableElement overridden,
-        TypeElement in) {
-      if (overrider.equals(overridden)) {
-        return false;
-      }
+    public boolean overrides(
+        ExecutableElement overrider, ExecutableElement overridden, TypeElement in) {
       if (!overrider.getSimpleName().equals(overridden.getSimpleName())) {
         // They must have the same name.
+        return false;
+      }
+      // We should just be able to write overrider.equals(overridden) here, but that runs afoul
+      // of a problem with Eclipse. If for example you look at the method Stream<E> stream() in
+      // Collection<E>, as obtained by collectionTypeElement.getEnclosedElements(), it will not
+      // compare equal to the method Stream<E> stream() as obtained by
+      // elementUtils.getAllMembers(listTypeElement), even though List<E> inherits the method
+      // from Collection<E>. The reason is that, in ecj, getAllMembers does type substitution,
+      // so the return type of stream() is Stream<E'>, where E' is the E from List<E> rather than
+      // the one from Collection<E>. Instead we compare the enclosing element, which will be
+      // Collection<E> no matter how we got the method. If two methods are in the same type
+      // then it's impossible for one to override the other, regardless of whether they are the
+      // same method.
+      if (overrider.getEnclosingElement().equals(overridden.getEnclosingElement())) {
         return false;
       }
       if (overridden.getModifiers().contains(Modifier.STATIC)) {
@@ -81,20 +106,7 @@ abstract class Overrides {
         // an "incorrect" result here for code that javac would not have allowed.
         return false;
       }
-      DeclaredType inType = MoreTypes.asDeclared(in.asType());
-      ExecutableType overriderExecutable;
-      ExecutableType overriddenExecutable;
-      try {
-        overriderExecutable = MoreTypes.asExecutable(typeUtils.asMemberOf(inType, overrider));
-        overriddenExecutable = MoreTypes.asExecutable(typeUtils.asMemberOf(inType, overridden));
-      } catch (IllegalArgumentException e) {
-        // This might mean that at least one of the methods is not in fact declared in or inherited
-        // by `in` (in which case we should indeed return false); or it might mean that we are
-        // tickling an Eclipse bug such as https://bugs.eclipse.org/bugs/show_bug.cgi?id=499026
-        // (in which case we can't do any better than returning false).
-        return false;
-      }
-      if (!typeUtils.isSubsignature(overriderExecutable, overriddenExecutable)) {
+      if (!isSubsignature(overrider, overridden, in)) {
         return false;
       }
       if (!MoreElements.methodVisibleFromPackage(overridden, MoreElements.getPackage(overrider))) {
@@ -110,7 +122,7 @@ abstract class Overrides {
       overriddenType = MoreElements.asType(overridden.getEnclosingElement());
       // We erase the types before checking subtypes, because the TypeMirror we get for List<E> is
       // not a subtype of the one we get for Collection<E> since the two E instances are not the
-      // same.  For the purposes of overriding, type parameters in the containing type should not
+      // same. For the purposes of overriding, type parameters in the containing type should not
       // matter because if the code compiles at all then they must be consistent.
       if (!typeUtils.isSubtype(
           typeUtils.erasure(in.asType()), typeUtils.erasure(overriddenType.asType()))) {
@@ -120,8 +132,16 @@ abstract class Overrides {
         // Method mC in or inherited by class C (JLS 8.4.8.1)...
         if (overriddenType.getKind().isClass()) {
           // ...overrides from C another method mA declared in class A. The only condition we
-          // haven't checked is that C does not inherit mA.
-          return !elementUtils.getAllMembers(in).contains(overridden);
+          // haven't checked is that C does not inherit mA. Ideally we could just write this:
+          //    return !elementUtils.getAllMembers(in).contains(overridden);
+          // But that doesn't work in Eclipse. For example, getAllMembers(AbstractList)
+          // contains List.isEmpty() where you might reasonably expect it to contain
+          // AbstractCollection.isEmpty(). So we need to visit superclasses until we reach
+          // one that declares the same method, and check that we haven't reached mA. We compare
+          // the enclosing elements rather than the methods themselves for the reason described
+          // at the start of the method.
+          ExecutableElement inherited = methodFromSuperclasses(in, overridden);
+          return !overridden.getEnclosingElement().equals(inherited.getEnclosingElement());
         } else if (overriddenType.getKind().isInterface()) {
           // ...overrides from C another method mI declared in interface I. We've already checked
           // the conditions (assuming that the only alternative to mI being abstract or default is
@@ -129,9 +149,15 @@ abstract class Overrides {
           // is necessary in order to be compatible with javac's `overrides` method. An inherited
           // abstract method does not override another method. (But, if it is not inherited,
           // it does, including if `in` inherits a concrete method of the same name from its
-          // superclass.)
+          // superclass.) Here again we can use getAllMembers with javac but not with ecj. javac
+          // says that getAllMembers(AbstractList) contains both AbstractCollection.size() and
+          // List.size(), but ecj doesn't have the latter. The spec is not particularly clear so
+          // either seems justifiable. So we need to look up the interface path that goes from `in`
+          // to `overriddenType` (or the several paths if there are several) and apply similar logic
+          // to methodFromSuperclasses above.
           if (overrider.getModifiers().contains(Modifier.ABSTRACT)) {
-            return !elementUtils.getAllMembers(in).contains(overridden);
+            ExecutableElement inherited = methodFromSuperinterfaces(in, overridden);
+            return !overridden.getEnclosingElement().equals(inherited.getEnclosingElement());
           } else {
             return true;
           }
@@ -144,6 +170,245 @@ abstract class Overrides {
         // Method mI in or inherited by interface I (JLS 9.4.1.1). We've already checked everything.
         // If this is not an interface then we don't know what it is so we say no.
       }
+    }
+
+    private boolean isSubsignature(
+        ExecutableElement overrider, ExecutableElement overridden, TypeElement in) {
+      DeclaredType inType = MoreTypes.asDeclared(in.asType());
+      try {
+        ExecutableType overriderExecutable =
+            MoreTypes.asExecutable(typeUtils.asMemberOf(inType, overrider));
+        ExecutableType overriddenExecutable =
+            MoreTypes.asExecutable(typeUtils.asMemberOf(inType, overridden));
+        return typeUtils.isSubsignature(overriderExecutable, overriddenExecutable);
+      } catch (IllegalArgumentException e) {
+        // This might mean that at least one of the methods is not in fact declared in or inherited
+        // by `in` (in which case we should indeed return false); or it might mean that we are
+        // tickling an Eclipse bug such as https://bugs.eclipse.org/bugs/show_bug.cgi?id=499026
+        // (in which case we fall back on explicit code to find the parameters).
+        int nParams = overrider.getParameters().size();
+        if (overridden.getParameters().size() != nParams) {
+          return false;
+        }
+        List<TypeMirror> overriderParams = erasedParameterTypes(overrider, in);
+        List<TypeMirror> overriddenParams = erasedParameterTypes(overridden, in);
+        if (overriderParams == null || overriddenParams == null) {
+          // This probably means that one or other of the methods is not in `in`.
+          return false;
+        }
+        for (int i = 0; i < nParams; i++) {
+          if (!typeUtils.isSameType(overriderParams.get(i), overriddenParams.get(i))) {
+            // If the erasures of the parameters don't correspond, return false. We erase so we
+            // don't get any confusion about different type variables not comparing equal.
+            return false;
+          }
+        }
+        return true;
+      }
+    }
+
+    /**
+     * Returns the list of erased parameter types of the given method as they appear in the given
+     * type. For example, if the method is {@code add(E)} from {@code List<E>} and we ask how it
+     * appears in {@code class NumberList implements List<Number>}, the answer will be
+     * {@code Number}. That will also be the answer for {@code class NumberList<E extends Number>
+     * implements List<E>}. The parameter types are erased since the purpose of this method is to
+     * determine whether two methods are candidates for one to override the other.
+     */
+    ImmutableList<TypeMirror> erasedParameterTypes(ExecutableElement method, TypeElement in) {
+      if (method.getParameters().isEmpty()) {
+        return ImmutableList.of();
+      }
+      return new TypeSubstVisitor().erasedParameterTypes(method, in);
+    }
+
+    /**
+     * Visitor that replaces type variables with their values in the types it sees. If we know
+     * that {@code E} is {@code String}, then we can return {@code String} for {@code E},
+     * {@code List<String>} for {@code List<E>}, {@code String[]} for {@code E[]}, etc. We don't
+     * have to cover all types here because (1) the type is going to end up being erased, and
+     * (2) wildcards can't appear in direct supertypes. So for example it is illegal to write
+     * {@code class MyList implements List<? extends Number>}. It's legal to write
+     * {@code class MyList implements List<Set<? extends Number>>} but that doesn't matter
+     * because the {@code E} of the {@code List} is going to be erased to raw {@code Set}.
+     */
+    private class TypeSubstVisitor extends SimpleTypeVisitor6<TypeMirror, Void> {
+      /**
+       * The bindings of type variables. We can put them all in one map because E in {@code List<E>}
+       * is not the same as E in {@code Collection<E>}. As we ascend the type hierarchy we'll add
+       * mappings for all the variables we see. We could equivalently create a new map for each type
+       * we visit, but this is slightly simpler and probably about as performant.
+       */
+      private final Map<TypeParameterElement, TypeMirror> typeBindings = Maps.newLinkedHashMap();
+
+      ImmutableList<TypeMirror> erasedParameterTypes(ExecutableElement method, TypeElement in) {
+        if (method.getEnclosingElement().equals(in)) {
+          ImmutableList.Builder<TypeMirror> params = ImmutableList.builder();
+          for (VariableElement param : method.getParameters()) {
+            params.add(typeUtils.erasure(visit(param.asType())));
+          }
+          return params.build();
+        }
+        // Make a list of supertypes we are going to visit recursively: the superclass, if there
+        // is one, plus the superinterfaces.
+        List<TypeMirror> supers = Lists.newArrayList();
+        if (in.getSuperclass().getKind() == TypeKind.DECLARED) {
+          supers.add(in.getSuperclass());
+        }
+        supers.addAll(in.getInterfaces());
+        for (TypeMirror supertype : supers) {
+          DeclaredType declared = MoreTypes.asDeclared(supertype);
+          TypeElement element = MoreElements.asType(declared.asElement());
+          List<? extends TypeMirror> actuals = declared.getTypeArguments();
+          List<? extends TypeParameterElement> formals = element.getTypeParameters();
+          Verify.verify(actuals.size() == formals.size());
+          for (int i = 0; i < actuals.size(); i++) {
+            typeBindings.put(formals.get(i), actuals.get(i));
+          }
+          ImmutableList<TypeMirror> params = erasedParameterTypes(method, element);
+          if (params != null) {
+            return params;
+          }
+        }
+        return null;
+      }
+
+      @Override
+      protected TypeMirror defaultAction(TypeMirror e, Void p) {
+        return e;
+      }
+
+      @Override
+      public TypeMirror visitTypeVariable(TypeVariable t, Void p) {
+        Element element = typeUtils.asElement(t);
+        if (element instanceof TypeParameterElement) {
+          TypeParameterElement e = (TypeParameterElement) element;
+          if (typeBindings.containsKey(e)) {
+            return visit(typeBindings.get(e));
+          }
+        }
+        // We erase the upper bound to avoid infinite recursion. We can get away with erasure for
+        // the reasons described above.
+        return visit(typeUtils.erasure(t.getUpperBound()));
+      }
+
+      @Override
+      public TypeMirror visitDeclared(DeclaredType t, Void p) {
+        if (t.getTypeArguments().isEmpty()) {
+          return t;
+        }
+        List<TypeMirror> newArgs = Lists.newArrayList();
+        for (TypeMirror arg : t.getTypeArguments()) {
+          newArgs.add(visit(arg));
+        }
+        return typeUtils.getDeclaredType(asTypeElement(t), newArgs.toArray(new TypeMirror[0]));
+      }
+
+      @Override
+      public TypeMirror visitArray(ArrayType t, Void p) {
+        return typeUtils.getArrayType(visit(t.getComponentType()));
+      }
+    }
+
+    /**
+     * Returns the given method as it appears in the given type. This is the method itself,
+     * or the nearest override in a superclass of the given type, or null if the method is not
+     * found in the given type or any of its superclasses.
+     */
+    ExecutableElement methodFromSuperclasses(TypeElement in, ExecutableElement method) {
+      for (TypeElement t = in; t != null; t = superclass(t)) {
+        ExecutableElement tMethod = methodInType(t, method);
+        if (tMethod != null) {
+          return tMethod;
+        }
+      }
+      return null;
+    }
+
+    /**
+     * Returns the given interface method as it appears in the given type. This is the method
+     * itself, or the nearest override in a superinterface of the given type, or null if the method
+     * is not found in the given type or any of its transitive superinterfaces.
+     */
+    ExecutableElement methodFromSuperinterfaces(TypeElement in, ExecutableElement method) {
+      TypeElement methodContainer = MoreElements.asType(method.getEnclosingElement());
+      Preconditions.checkArgument(methodContainer.getKind().isInterface());
+      TypeMirror methodContainerType = typeUtils.erasure(methodContainer.asType());
+      ImmutableList<TypeElement> types = ImmutableList.of(in);
+      // On the first pass through this loop, `types` is the type we're starting from,
+      // which might be a class or an interface. On later passes it is a list of direct
+      // superinterfaces we saw in the previous pass, but only the ones that were assignable
+      // to the interface that `method` appears in.
+      while (!types.isEmpty()) {
+        ImmutableList.Builder<TypeElement> newTypes = ImmutableList.builder();
+        for (TypeElement t : types) {
+          TypeMirror candidateType = typeUtils.erasure(t.asType());
+          if (typeUtils.isAssignable(candidateType, methodContainerType)) {
+            ExecutableElement tMethod = methodInType(t, method);
+            if (tMethod != null) {
+              return tMethod;
+            }
+            newTypes.addAll(superinterfaces(t));
+          }
+          if (t.getKind().isClass()) {
+            TypeElement sup = superclass(t);
+            if (sup != null) {
+              newTypes.add(sup);
+            }
+          }
+        }
+        types = newTypes.build();
+      }
+      return null;
+    }
+
+    /**
+     * Returns the method from within the given type that has the same erased signature as the given
+     * method, or null if there is no such method.
+     */
+    private ExecutableElement methodInType(TypeElement type, ExecutableElement method) {
+      int nParams = method.getParameters().size();
+      List<TypeMirror> params = erasedParameterTypes(method, type);
+      if (params == null) {
+        return null;
+      }
+      methods:
+      for (ExecutableElement tMethod : ElementFilter.methodsIn(type.getEnclosedElements())) {
+        if (tMethod.getSimpleName().equals(method.getSimpleName())
+            && tMethod.getParameters().size() == nParams) {
+          for (int i = 0; i < nParams; i++) {
+            TypeMirror tParamType = typeUtils.erasure(tMethod.getParameters().get(i).asType());
+            if (!typeUtils.isSameType(params.get(i), tParamType)) {
+              continue methods;
+            }
+          }
+          return tMethod;
+        }
+      }
+      return null;
+    }
+
+    private TypeElement superclass(TypeElement type) {
+      TypeMirror sup = type.getSuperclass();
+      if (sup.getKind() == TypeKind.DECLARED) {
+        return MoreElements.asType(typeUtils.asElement(sup));
+      } else {
+        return null;
+      }
+    }
+
+    private ImmutableList<TypeElement> superinterfaces(TypeElement type) {
+      ImmutableList.Builder<TypeElement> types = ImmutableList.builder();
+      for (TypeMirror sup : type.getInterfaces()) {
+        types.add(MoreElements.asType(typeUtils.asElement(sup)));
+      }
+      return types.build();
+    }
+
+    private TypeElement asTypeElement(TypeMirror typeMirror) {
+      DeclaredType declaredType = MoreTypes.asDeclared(typeMirror);
+      Element element = declaredType.asElement();
+      return MoreElements.asType(element);
     }
   }
 }

--- a/common/src/test/java/com/google/auto/common/OverridesTest.java
+++ b/common/src/test/java/com/google/auto/common/OverridesTest.java
@@ -16,46 +16,109 @@
 package com.google.auto.common;
 
 import static com.google.common.truth.Truth.assertThat;
+import static javax.lang.model.util.ElementFilter.methodsIn;
 
+import com.google.common.base.Charsets;
+import com.google.common.base.Converter;
 import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Range;
+import com.google.common.io.Files;
 import com.google.common.truth.Expect;
 import com.google.testing.compile.CompilationRule;
+import java.io.File;
 import java.util.AbstractCollection;
 import java.util.AbstractList;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.RoundEnvironment;
+import javax.annotation.processing.SupportedAnnotationTypes;
+import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeElement;
-import javax.lang.model.util.ElementFilter;
+import javax.lang.model.element.VariableElement;
+import javax.lang.model.type.ArrayType;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.type.TypeVariable;
+import javax.lang.model.type.TypeVisitor;
 import javax.lang.model.util.Elements;
+import javax.lang.model.util.SimpleTypeVisitor6;
 import javax.lang.model.util.Types;
+import javax.tools.JavaCompiler;
+import javax.tools.JavaFileObject;
+import javax.tools.StandardJavaFileManager;
+import org.eclipse.jdt.internal.compiler.tool.EclipseCompiler;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
 import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.runners.Parameterized;
+import org.junit.runners.model.Statement;
 
 /**
+ * Tests that the {@link Overrides} class has behaviour consistent with javac. We test this in
+ * two ways: once with {@link Overrides.ExplicitOverrides} using javac's own {@link Elements} and
+ * {@link Types}, and once with it using the version of those objects from the Eclipse compiler
+ * (ecj).
+ *
  * @author emcmanus@google.com (Éamonn McManus)
  */
-@RunWith(JUnit4.class)
+@RunWith(Parameterized.class)
 public class OverridesTest {
+  @Parameterized.Parameters(name = "{0}")
+  public static List<Object[]> data() {
+    return ImmutableList.copyOf(new Object[][] {{CompilerType.JAVAC}, {CompilerType.ECJ}});
+  }
+
   @Rule public CompilationRule compilation = new CompilationRule();
+  @Rule public EcjCompilationRule ecjCompilation = new EcjCompilationRule();
   @Rule public Expect expect = Expect.create();
+
+  public enum CompilerType {
+    JAVAC {
+      @Override
+      void initUtils(OverridesTest test) {
+        test.typeUtils = test.compilation.getTypes();
+        test.elementUtils = test.compilation.getElements();
+      }
+    },
+    ECJ {
+      @Override
+      void initUtils(OverridesTest test) {
+        test.typeUtils = test.ecjCompilation.types;
+        test.elementUtils = test.ecjCompilation.elements;
+      }
+    };
+
+    abstract void initUtils(OverridesTest test);
+  }
+  private final CompilerType compilerType;
 
   private Types typeUtils;
   private Elements elementUtils;
-  private Overrides nativeOverrides;
-  private Overrides explicitOverrides;
+  private Elements javacElementUtils;
+  private Overrides javacOverrides;
+  private Overrides.ExplicitOverrides explicitOverrides;
+
+  public OverridesTest(CompilerType compilerType) {
+    this.compilerType = compilerType;
+  }
 
   @Before
   public void initializeTestElements() {
-    elementUtils = compilation.getElements();
-    typeUtils = compilation.getTypes();
-    nativeOverrides = new Overrides.NativeOverrides(elementUtils);
-    explicitOverrides = new Overrides.ExplicitOverrides(typeUtils, elementUtils);
+    javacElementUtils = compilation.getElements();
+    javacOverrides = new Overrides.NativeOverrides(javacElementUtils);
+    compilerType.initUtils(this);
+    explicitOverrides = new Overrides.ExplicitOverrides(typeUtils);
   }
 
   static class TypesForInheritance {
@@ -238,29 +301,353 @@ public class OverridesTest {
     assertThat(testClasses).isNotEmpty();
     ImmutableSet.Builder<TypeElement> testTypesBuilder = ImmutableSet.builder();
     for (Class<?> testClass : testClasses) {
-      testTypesBuilder.add(elementUtils.getTypeElement(testClass.getCanonicalName()));
+      testTypesBuilder.add(getTypeElement(testClass));
     }
     ImmutableSet<TypeElement> testTypes = testTypesBuilder.build();
     ImmutableSet.Builder<ExecutableElement> testMethodsBuilder = ImmutableSet.builder();
     for (TypeElement testType : testTypes) {
-      testMethodsBuilder.addAll(ElementFilter.methodsIn(testType.getEnclosedElements()));
+      testMethodsBuilder.addAll(methodsIn(testType.getEnclosedElements()));
     }
     ImmutableSet<ExecutableElement> testMethods = testMethodsBuilder.build();
     for (TypeElement in : testTypes) {
-      List<ExecutableElement> inMethods = ElementFilter.methodsIn(elementUtils.getAllMembers(in));
+      TypeElement javacIn = javacType(in);
+      List<ExecutableElement> inMethods = methodsIn(elementUtils.getAllMembers(in));
       for (ExecutableElement overrider : inMethods) {
+        ExecutableElement javacOverrider = javacMethod(overrider);
         for (ExecutableElement overridden : testMethods) {
-          boolean expected = nativeOverrides.overrides(overrider, overridden, in);
-          boolean actual = explicitOverrides.overrides(overrider, overridden, in);
-          expect
-              .withFailureMessage(
-                  "%s.%s overrides %s.%s in %s",
-                  overrider.getEnclosingElement(), overrider,
-                  overridden.getEnclosingElement(), overridden,
-                  in)
-              .that(actual).isEqualTo(expected);
+          ExecutableElement javacOverridden = javacMethod(overridden);
+          boolean javacSays = javacOverrides.overrides(javacOverrider, javacOverridden, javacIn);
+          boolean weSay = explicitOverrides.overrides(overrider, overridden, in);
+          if (javacSays != weSay) {
+            expect.fail(
+                "%s.%s overrides %s.%s in %s: javac says %s, we say %s",
+                overrider.getEnclosingElement(), overrider,
+                overridden.getEnclosingElement(), overridden,
+                in,
+                javacSays, weSay);
+          }
         }
       }
     }
   }
+
+  private TypeElement getTypeElement(Class<?> c) {
+    return elementUtils.getTypeElement(c.getCanonicalName());
+  }
+
+  private ExecutableElement getMethod(TypeElement in, String name, TypeKind... parameterTypeKinds) {
+    ExecutableElement found = null;
+    methods:
+    for (ExecutableElement method : methodsIn(in.getEnclosedElements())) {
+      if (method.getSimpleName().contentEquals(name)
+          && method.getParameters().size() == parameterTypeKinds.length) {
+        for (int i = 0; i < parameterTypeKinds.length; i++) {
+          if (method.getParameters().get(i).asType().getKind() != parameterTypeKinds[i]) {
+            continue methods;
+          }
+        }
+        assertThat(found).isNull();
+        found = method;
+      }
+    }
+    assertThat(found).isNotNull();
+    return found;
+  }
+
+  // These skeletal parallels to the real collection classes ensure that the test is independent
+  // of the details of those classes, for example whether List<E> redeclares add(E) even though
+  // it also inherits it from Collection<E>.
+
+  private interface XCollection<E> {
+    boolean add(E e);
+  }
+
+  private interface XList<E> extends XCollection<E> {}
+
+  private abstract static class XAbstractCollection<E> implements XCollection<E> {
+    @Override
+    public boolean add(E e) {
+      return false;
+    }
+  }
+
+  private abstract static class XAbstractList<E>
+      extends XAbstractCollection<E> implements XList<E> {
+    @Override
+    public boolean add(E e) {
+      return true;
+    }
+  }
+
+  private abstract static class XStringList extends XAbstractList<String> {}
+
+  private abstract static class XAbstractStringList implements XList<String> {}
+
+  private abstract static class XNumberList<E extends Number> extends XAbstractList<E> {}
+
+  // Parameter of add(E) in StringList is String.
+  // That means that we successfully recorded E[AbstractList] = String and E[List] = E[AbstractList]
+  // and String made it all the way through.
+  @Test
+  public void methodParameters_StringList() {
+    TypeElement xAbstractList = getTypeElement(XAbstractList.class);
+    TypeElement xStringList = getTypeElement(XStringList.class);
+    TypeElement string = getTypeElement(String.class);
+
+    ExecutableElement add = getMethod(xAbstractList, "add", TypeKind.TYPEVAR);
+    List<TypeMirror> params = explicitOverrides.erasedParameterTypes(add, xStringList);
+    List<TypeMirror> expectedParams = ImmutableList.of(string.asType());
+    assertTypeListsEqual(params, expectedParams);
+  }
+
+  // Parameter of add(E) in AbstractStringList is String.
+  // That means that we successfully recorded E[List] = String and E[Collection] = E[List].
+  @Test
+  public void methodParameters_AbstractStringList() {
+    TypeElement xCollection = getTypeElement(XCollection.class);
+    TypeElement xAbstractStringList = getTypeElement(XAbstractStringList.class);
+    TypeElement string = getTypeElement(String.class);
+
+    ExecutableElement add = getMethod(xCollection, "add", TypeKind.TYPEVAR);
+
+    List<TypeMirror> params = explicitOverrides.erasedParameterTypes(add, xAbstractStringList);
+    List<TypeMirror> expectedParams = ImmutableList.of(string.asType());
+    assertTypeListsEqual(params, expectedParams);
+  }
+
+  // Parameter of add(E) in NumberList is Number.
+  // That means that we successfully recorded E[AbstractList] = Number and on from
+  // there, with Number being used because it is the erasure of <E extends Number>.
+  @Test
+  public void methodParams_NumberList() {
+    TypeElement xCollection = getTypeElement(XCollection.class);
+    TypeElement xNumberList = getTypeElement(XNumberList.class);
+    TypeElement number = getTypeElement(Number.class);
+
+    ExecutableElement add = getMethod(xCollection, "add", TypeKind.TYPEVAR);
+
+    List<TypeMirror> params = explicitOverrides.erasedParameterTypes(add, xNumberList);
+    List<TypeMirror> expectedParams = ImmutableList.of(number.asType());
+    assertTypeListsEqual(params, expectedParams);
+  }
+
+  // This is derived from a class that provoked a StackOverflowError in an earlier version.
+  private abstract static class StringToRangeConverter<T extends Comparable<T>>
+      extends Converter<String, Range<T>> {
+    @Override
+    protected String doBackward(Range<T> b) {
+      return null;
+    }
+  }
+
+  @Test
+  public void methodParams_RecursiveBound() {
+    TypeElement stringToRangeConverter = getTypeElement(StringToRangeConverter.class);
+    TypeElement range = getTypeElement(Range.class);
+    ExecutableElement valueConverter =
+        getMethod(stringToRangeConverter, "doBackward", TypeKind.DECLARED);
+    List<TypeMirror> params =
+        explicitOverrides.erasedParameterTypes(valueConverter, stringToRangeConverter);
+    List<TypeMirror> expectedParams =
+        ImmutableList.<TypeMirror>of(typeUtils.erasure(range.asType()));
+    assertTypeListsEqual(params, expectedParams);
+  }
+
+  @Test
+  public void methodFromSuperclasses() {
+    TypeElement xAbstractCollection = getTypeElement(XAbstractCollection.class);
+    TypeElement xAbstractList = getTypeElement(XAbstractList.class);
+    TypeElement xAbstractStringList = getTypeElement(XAbstractStringList.class);
+    TypeElement xStringList = getTypeElement(XStringList.class);
+
+    ExecutableElement add = getMethod(xAbstractCollection, "add", TypeKind.TYPEVAR);
+
+    ExecutableElement addInAbstractStringList =
+        explicitOverrides.methodFromSuperclasses(xAbstractStringList, add);
+    assertThat(addInAbstractStringList).isNull();
+
+    ExecutableElement addInStringList =
+        explicitOverrides.methodFromSuperclasses(xStringList, add);
+    assertThat(addInStringList.getEnclosingElement()).isEqualTo(xAbstractList);
+  }
+
+  @Test
+  public void methodFromSuperinterfaces() {
+    TypeElement xCollection = getTypeElement(XCollection.class);
+    TypeElement xAbstractList = getTypeElement(XAbstractList.class);
+    TypeElement xAbstractStringList = getTypeElement(XAbstractStringList.class);
+    TypeElement xNumberList = getTypeElement(XNumberList.class);
+    TypeElement xList = getTypeElement(XList.class);
+
+    ExecutableElement add = getMethod(xCollection, "add", TypeKind.TYPEVAR);
+
+    ExecutableElement addInAbstractStringList =
+        explicitOverrides.methodFromSuperinterfaces(xAbstractStringList, add);
+    assertThat(addInAbstractStringList.getEnclosingElement()).isEqualTo(xCollection);
+
+    ExecutableElement addInNumberList =
+        explicitOverrides.methodFromSuperinterfaces(xNumberList, add);
+    assertThat(addInNumberList.getEnclosingElement()).isEqualTo(xAbstractList);
+
+    ExecutableElement addInList =
+        explicitOverrides.methodFromSuperinterfaces(xList, add);
+    assertThat(addInList.getEnclosingElement()).isEqualTo(xCollection);
+  }
+
+  private void assertTypeListsEqual(List<TypeMirror> actual, List<TypeMirror> expected) {
+    assertThat(actual.size()).isEqualTo(expected.size());
+    for (int i = 0; i < actual.size(); i++) {
+      assertThat(typeUtils.isSameType(actual.get(i), expected.get(i))).isTrue();
+    }
+  }
+
+  // TODO(emcmanus): replace this with something from compile-testing when that's available.
+  /**
+   * An equivalent to {@link CompilationRule} that uses ecj (the Eclipse compiler) instead of javac.
+   * If the parameterized test is not selecting ecj then this rule has no effect.
+   */
+  public class EcjCompilationRule implements TestRule {
+    Elements elements;
+    Types types;
+
+    @Override
+    public Statement apply(Statement base, Description description) {
+      if (!compilerType.equals(CompilerType.ECJ)) {
+        return base;
+      }
+      return new EcjCompilationStatement(base);
+    }
+  }
+
+  private class EcjCompilationStatement extends Statement {
+    private final Statement statement;
+
+    EcjCompilationStatement(Statement base) {
+      this.statement = base;
+    }
+
+    @Override
+    public void evaluate() throws Throwable {
+      File tmpDir = File.createTempFile("OverridesTest", "dir");
+      tmpDir.delete();
+      tmpDir.mkdir();
+      File dummySourceFile = new File(tmpDir, "Dummy.java");
+      try {
+        Files.write("class Dummy {}", dummySourceFile, Charsets.UTF_8);
+        evaluate(dummySourceFile);
+      } finally {
+        dummySourceFile.delete();
+        tmpDir.delete();
+      }
+    }
+
+    private void evaluate(File dummySourceFile) throws Throwable {
+      JavaCompiler compiler = new EclipseCompiler();
+      StandardJavaFileManager fileManager =
+          compiler.getStandardFileManager(null, null, Charsets.UTF_8);
+      Iterable<? extends JavaFileObject> sources = fileManager.getJavaFileObjects(dummySourceFile);
+      JavaCompiler.CompilationTask task =
+          compiler.getTask(null, null, null, null, null, sources);
+      EcjTestProcessor processor = new EcjTestProcessor(statement);
+      task.setProcessors(ImmutableList.of(processor));
+      assertThat(task.call()).isTrue();
+      processor.maybeThrow();
+    }
+  }
+
+  @SupportedAnnotationTypes("*")
+  private class EcjTestProcessor extends AbstractProcessor {
+    private final Statement statement;
+    private Throwable thrown;
+
+    EcjTestProcessor(Statement statement) {
+      this.statement = statement;
+    }
+
+    @Override
+    public SourceVersion getSupportedSourceVersion() {
+      return SourceVersion.latest();
+    }
+
+    @Override
+    public boolean process(
+        Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+      if (roundEnv.processingOver()) {
+        ecjCompilation.elements = processingEnv.getElementUtils();
+        ecjCompilation.types = processingEnv.getTypeUtils();
+        try {
+          statement.evaluate();
+        } catch (Throwable t) {
+          thrown = t;
+        }
+      }
+      return false;
+    }
+
+    void maybeThrow() throws Throwable {
+      if (thrown != null) {
+        throw thrown;
+      }
+    }
+  }
+
+  private TypeElement javacType(TypeElement type) {
+    return javacElementUtils.getTypeElement(type.getQualifiedName().toString());
+  }
+
+  private ExecutableElement javacMethod(ExecutableElement method) {
+    if (elementUtils == javacElementUtils) {
+      return method;
+    }
+    TypeElement containingType = MoreElements.asType(method.getEnclosingElement());
+    TypeElement javacContainingType = javacType(containingType);
+    List<ExecutableElement> candidates = new ArrayList<ExecutableElement>();
+    methods:
+    for (ExecutableElement javacMethod : methodsIn(javacContainingType.getEnclosedElements())) {
+      if (javacMethod.getSimpleName().contentEquals(method.getSimpleName())
+          && javacMethod.getParameters().size() == method.getParameters().size()) {
+        for (int i = 0; i < method.getParameters().size(); i++) {
+          VariableElement parameter = method.getParameters().get(i);
+          VariableElement javacParameter = javacMethod.getParameters().get(i);
+          if (!erasedToString(parameter.asType()).equals(erasedToString(javacParameter.asType()))) {
+            continue methods;
+          }
+        }
+        candidates.add(javacMethod);
+      }
+    }
+    if (candidates.size() == 1) {
+      return candidates.get(0);
+    } else {
+      throw new IllegalStateException(
+          "Expected one javac method matching " + method + " but found " + candidates);
+    }
+  }
+
+  private static String erasedToString(TypeMirror type) {
+    return ERASED_STRING_TYPE_VISITOR.visit(type);
+  }
+
+  private static final TypeVisitor<String, Void> ERASED_STRING_TYPE_VISITOR =
+      new SimpleTypeVisitor6<String, Void>() {
+    @Override
+    protected String defaultAction(TypeMirror e, Void p) {
+      return e.toString();
+    }
+
+    @Override
+    public String visitArray(ArrayType t, Void p) {
+      return visit(t.getComponentType()) + "[]";
+    }
+
+    @Override
+    public String visitDeclared(DeclaredType t, Void p) {
+      return MoreElements.asType(t.asElement()).getQualifiedName().toString();
+    }
+
+    @Override
+    public String visitTypeVariable(TypeVariable t, Void p) {
+      return visit(t.getUpperBound());
+    }
+  };
 }

--- a/value/src/it/functional/src/test/java/com/google/auto/value/AutoValueTest.java
+++ b/value/src/it/functional/src/test/java/com/google/auto/value/AutoValueTest.java
@@ -2107,6 +2107,38 @@ public class AutoValueTest extends TestCase {
         .isEqualTo("OneTwoThreeFourImpl{one=one, two=two, three=false, four=4}");
   }
 
+  static class VersionId {}
+
+  static class ItemVersionId extends VersionId {}
+
+  interface VersionedPersistent {
+    VersionId getVersionId();
+  }
+
+  interface Item extends VersionedPersistent {
+    @Override
+    ItemVersionId getVersionId();
+  }
+
+  @AutoValue
+  abstract static class FakeItem implements Item {
+    static Builder builder() {
+      return new AutoValue_AutoValueTest_FakeItem.Builder();
+    }
+
+    @AutoValue.Builder
+    abstract static class Builder {
+      abstract Builder setVersionId(ItemVersionId x);
+      abstract FakeItem build();
+    }
+  }
+
+  public void testParentInterfaceOverridesGrandparent() {
+    ItemVersionId version = new ItemVersionId();
+    FakeItem fakeItem = FakeItem.builder().setVersionId(version).build();
+    assertThat(fakeItem.getVersionId()).isSameAs(version);
+  }
+
   /** Fake ApkVersionCode class. */
   public static class ApkVersionCode {}
 

--- a/value/src/test/java/com/google/auto/value/processor/TemplateVarsTest.java
+++ b/value/src/test/java/com/google/auto/value/processor/TemplateVarsTest.java
@@ -15,20 +15,32 @@
  */
 package com.google.auto.value.processor;
 
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.fail;
+
 import com.google.auto.value.processor.escapevelocity.Template;
 import com.google.common.collect.ImmutableList;
+import com.google.common.reflect.Reflection;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.Reader;
 import java.io.StringReader;
+import java.net.URLClassLoader;
 import java.util.List;
-import junit.framework.TestCase;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.concurrent.Callable;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
 /**
  * Tests for FieldReader.
  *
  * @author emcmanus@google.com (Éamonn McManus)
  */
-public class TemplateVarsTest extends TestCase {
+@RunWith(JUnit4.class)
+public class TemplateVarsTest {
   static class HappyVars extends TemplateVars {
     Integer integer;
     String string;
@@ -49,17 +61,19 @@ public class TemplateVarsTest extends TestCase {
     }
   }
 
+  @Test
   public void testHappy() {
     HappyVars happy = new HappyVars();
     happy.integer = 23;
     happy.string = "wibble";
     happy.list = ImmutableList.of(5, 17, 23);
-    assertEquals("hatstand", HappyVars.IGNORED_STATIC_FINAL);  // just to avoid unused warning
+    assertThat(HappyVars.IGNORED_STATIC_FINAL).isEqualTo("hatstand");  // avoids unused warning
     String expectedText = "integer=23 string=wibble list=[5, 17, 23]";
     String actualText = happy.toText();
-    assertEquals(expectedText, actualText);
+    assertThat(actualText).isEqualTo(expectedText);
   }
 
+  @Test
   public void testUnset() {
     HappyVars sad = new HappyVars();
     sad.integer = 23;
@@ -73,6 +87,7 @@ public class TemplateVarsTest extends TestCase {
 
   static class SubSub extends HappyVars {}
 
+  @Test
   public void testSubSub() {
     try {
       new SubSub();
@@ -83,13 +98,14 @@ public class TemplateVarsTest extends TestCase {
 
   static class Private extends TemplateVars {
     Integer integer;
-    private String string;
+    private String unusedString;
 
     @Override Template parsedTemplate() {
       throw new UnsupportedOperationException();
     }
   }
 
+  @Test
   public void testPrivate() {
     try {
       new Private();
@@ -107,6 +123,7 @@ public class TemplateVarsTest extends TestCase {
     }
   }
 
+  @Test
   public void testStatic() {
     try {
       new Static();
@@ -124,11 +141,88 @@ public class TemplateVarsTest extends TestCase {
     }
   }
 
+  @Test
   public void testPrimitive() {
     try {
       new Primitive();
       fail("Did not get expected exception");
     } catch (IllegalArgumentException expected) {
+    }
+  }
+
+  // This is a complicated test that tries to simulate the failure that is worked around in
+  // Template.parsedTemplateForResource. That failure means that the InputStream returned by
+  // ClassLoader.getResourceAsStream sometimes throws IOException while it is being read. To
+  // simulate that, we make a second ClassLoader with the same configuration as the one that
+  // runs this test, and we override getResourceAsStream so that it wraps the returned InputStream
+  // in a BrokenInputStream, which throws an exception after a certain number of characters.
+  // We check that that exception was indeed seen, and that we did indeed try to read the resource
+  // we're interested in, and that we succeeded in loading a Template nevertheless.
+  @Test
+  public void testBrokenInputStream() throws Exception {
+    URLClassLoader myLoader = (URLClassLoader) getClass().getClassLoader();
+    URLClassLoader shadowLoader = new ShadowLoader(myLoader);
+    Runnable brokenInputStreamTest =
+        (Runnable) shadowLoader
+            .loadClass(BrokenInputStreamTest.class.getName())
+            .getConstructor()
+            .newInstance();
+    brokenInputStreamTest.run();
+  }
+
+  private static class ShadowLoader extends URLClassLoader implements Callable<Set<String>> {
+    private final Set<String> result = new TreeSet<String>();
+
+    ShadowLoader(URLClassLoader original) {
+      super(original.getURLs(), original.getParent());
+    }
+
+    @Override
+    public Set<String> call() throws Exception {
+      return result;
+    }
+
+    @Override
+    public InputStream getResourceAsStream(String resource) {
+      result.add(resource);
+      return new BrokenInputStream(super.getResourceAsStream(resource));
+    }
+
+    private class BrokenInputStream extends InputStream {
+      private final InputStream original;
+      private int count = 0;
+
+      BrokenInputStream(InputStream original) {
+        this.original = original;
+      }
+
+      @Override
+      public int read() throws IOException {
+        if (++count > 10) {
+          result.add("threw");
+          throw new IOException("BrokenInputStream");
+        }
+        return original.read();
+      }
+    }
+  }
+
+  public static class BrokenInputStreamTest implements Runnable {
+    @Override
+    public void run() {
+      Template template = TemplateVars.parsedTemplateForResource("autovalue.vm");
+      assertThat(template).isNotNull();
+      String resourceName =
+          Reflection.getPackageName(getClass()).replace('.', '/') + "/autovalue.vm";
+      @SuppressWarnings("unchecked")
+      Callable<Set<String>> myLoader = (Callable<Set<String>>) getClass().getClassLoader();
+      try {
+        Set<String> result = myLoader.call();
+        assertThat(result).contains(resourceName);
+        assertThat(result).contains("threw");
+      } catch (Exception e) {
+        throw new AssertionError(e);
+      }
     }
   }
 }


### PR DESCRIPTION
* [common] Fix a number of incompatibilities between javac and ecj in the area of overrides, by reworking the logic of the explicit override implementation.

* [value] Add a workaround to Template.parsedTemplateForResource that triggers fall-back logic if we hit a JDK bug that causes spurious IOExceptions when reading resources from jars. Also, rewrite TemplateVarsTest to use JUnit4 and Truth. Fixes https://github.com/google/auto/issues/365.