### PR TITLE
Sync from Google's internal repo

### DIFF
--- a/value/pom.xml
+++ b/value/pom.xml
@@ -46,7 +46,7 @@
     <dependency>
       <groupId>com.google.auto</groupId>
       <artifactId>auto-common</artifactId>
-      <version>1.0-SNAPSHOT</version>
+      <version>0.8</version>
     </dependency>
     <dependency>
       <groupId>com.google.auto.service</groupId>

--- a/value/pom.xml
+++ b/value/pom.xml
@@ -178,4 +178,15 @@
       </plugin>
     </plugins>
   </build>
+  <profiles>
+    <profile>
+      <id>disable-java8-doclint</id>
+      <activation>
+        <jdk>[1.8,)</jdk>
+      </activation>
+      <properties>
+        <additionalparam>-Xdoclint:none</additionalparam>
+      </properties>
+    </profile>
+  </profiles>
 </project>

--- a/value/src/main/java/com/google/auto/value/processor/BuilderMethodClassifier.java
+++ b/value/src/main/java/com/google/auto/value/processor/BuilderMethodClassifier.java
@@ -416,8 +416,8 @@ class BuilderMethodClassifier {
       return canMakeCopyUsing(copyOfMethods, valueGetter, setter);
     }
     String error = String.format(
-        "Parameter type of setter method should be %s to match getter %s.%s",
-        targetType, autoValueClass, valueGetter.getSimpleName());
+        "Parameter type %s of setter method should be %s to match getter %s.%s",
+        parameterType, targetType, autoValueClass, valueGetter.getSimpleName());
     errorReporter.reportError(error, setter);
     return false;
   }

--- a/value/src/test/java/com/google/auto/value/processor/CompilationTest.java
+++ b/value/src/test/java/com/google/auto/value/processor/CompilationTest.java
@@ -1068,7 +1068,7 @@ public class CompilationTest {
         .processedWith(new AutoValueProcessor(), new AutoValueBuilderProcessor())
         .failsToCompile()
         .withErrorContaining(
-            "Parameter type of setter method should be int to match getter foo.bar.Baz.blim")
+            "Parameter type java.lang.String of setter method should be int to match getter foo.bar.Baz.blim")
         .in(javaFileObject).onLine(12);
   }
 
@@ -1165,7 +1165,7 @@ public class CompilationTest {
         .processedWith(new AutoValueProcessor(), new AutoValueBuilderProcessor())
         .failsToCompile()
         .withErrorContaining(
-            "Parameter type of setter method should be int to match getter foo.bar.Baz.getBlim")
+            "Parameter type java.lang.String of setter method should be int to match getter foo.bar.Baz.getBlim")
         .in(javaFileObject).onLine(12);
   }
 

--- a/value/userguide/extensions.md
+++ b/value/userguide/extensions.md
@@ -1,3 +1,43 @@
 # Extensions
 
-TODO
+
+AutoValue can be extended to implement new features for classes annotated with
+`@AutoValue`.
+
+## Using extensions
+
+Each extension is a class. If that class is on the `processorpath` when you
+compile your `@AutoValue` class, the extension can run.
+
+
+Some extensions are triggered by their own annotations, which you add to your
+class; others may be triggered in other ways. Consult the extension's
+documentation for usage instructions.
+
+## Writing an extension
+
+To add a feature, write a class that extends [`AutoValueExtension`], and put
+that class on the `processorpath` along with `AutoValueProcessor`.
+
+`AutoValueExtension` uses the [`ServiceLoader`] mechanism, which means:
+
+*   Your class must be public and have a public no-argument constructor.
+*   Its fully-qualified name must appear in a file called
+    `META-INF/services/com.google.auto.value.extension.AutoValueExtension` in a
+    JAR that is on the compiler's `classpath` or `processorpath`.
+
+You can use [AutoService] to make implementing the `ServiceLoader` pattern easy.
+
+Without extensions, AutoValue generates a subclass of the `@AutoValue` class.
+Extensions can work by generating a chain of subclasses, each of which alters
+behavior by overriding or implementing new methods.
+
+## TODO
+
+*   How to distribute extensions.
+*   List of known extensions.
+
+[AutoService]: https://github.com/google/auto/tree/master/service
+[`AutoValueExtension`]: https://github.com/google/auto/blob/master/value/src/main/java/com/google/auto/value/extension/AutoValueExtension.java
+[`ServiceLoader`]: http://docs.oracle.com/javase/7/docs/api/java/util/ServiceLoader.html
+


### PR DESCRIPTION
- Upgrade auto-value to use the released auto-common.
- Suppress javadoc doclint in maven, when running on java8 which both introduces the doclint, and also introduces the flag to turn it off.
- Beginning of documentation for AutoValue extensions.
- Add builder setter type to error message when type of parameter is not equivalent to target type. This is PR #394 by @gildor.
