### PR TITLE
Fix support for Java 6.

### DIFF
--- a/value/src/main/java/com/google/auto/value/processor/escapevelocity/ReferenceNode.java
+++ b/value/src/main/java/com/google/auto/value/processor/escapevelocity/ReferenceNode.java
@@ -413,7 +413,9 @@ abstract class ReferenceNode extends ExpressionNode {
       String pkg = packageNameOf(c);
       Object module = CLASS_GET_MODULE_METHOD.invoke(c);
       return (Boolean) MODULE_IS_EXPORTED_METHOD.invoke(module, pkg);
-    } catch (ReflectiveOperationException e) {
+    } catch (IllegalAccessException e) {
+      return false;
+    } catch (InvocationTargetException e) {
       return false;
     }
   }
@@ -428,7 +430,7 @@ abstract class ReferenceNode extends ExpressionNode {
       classGetModuleMethod = Class.class.getMethod("getModule");
       Class<?> moduleClass = classGetModuleMethod.getReturnType();
       moduleIsExportedMethod = moduleClass.getMethod("isExported", String.class);
-    } catch (ReflectiveOperationException e) {
+    } catch (NoSuchMethodException e) {
       classGetModuleMethod = null;
       moduleIsExportedMethod = null;
     }


### PR DESCRIPTION
ReflectiveOperationException was introduced as a convenient superclass in 1.7,
but avoiding its use is trivial. Fixes #418.