### PR TITLE
Remove a couple of references to ReflectiveOperationException, …

### DIFF
--- a/value/src/main/java/com/google/auto/value/processor/escapevelocity/ReferenceNode.java
+++ b/value/src/main/java/com/google/auto/value/processor/escapevelocity/ReferenceNode.java
@@ -413,7 +413,7 @@ abstract class ReferenceNode extends ExpressionNode {
       String pkg = packageNameOf(c);
       Object module = CLASS_GET_MODULE_METHOD.invoke(c);
       return (Boolean) MODULE_IS_EXPORTED_METHOD.invoke(module, pkg);
-    } catch (ReflectiveOperationException e) {
+    } catch (Exception e) {
       return false;
     }
   }
@@ -428,7 +428,7 @@ abstract class ReferenceNode extends ExpressionNode {
       classGetModuleMethod = Class.class.getMethod("getModule");
       Class<?> moduleClass = classGetModuleMethod.getReturnType();
       moduleIsExportedMethod = moduleClass.getMethod("isExported", String.class);
-    } catch (ReflectiveOperationException e) {
+    } catch (Exception e) {
       classGetModuleMethod = null;
       moduleIsExportedMethod = null;
     }


### PR DESCRIPTION
…which did not exist on Java 6. Fixes https://github.com/google/auto/issues/418.

We will probably stop supporting compilation on platforms earlier than Java 8, after we release AutoValue 1.4. We will continue to support compilation *for* earlier platforms, with appropriate `-source -target -bootclasspath` options, but we won't support compilation using those platforms' compilers. That means that the annotation processor will be able to use Java 8 classes and constructs.

-------------
Created by MOE: https://github.com/google/moe
MOE_MIGRATED_REVID=143109682