### PR TITLE
Update gwtserializer/pom.xml to run tests in prod mode

### DIFF
--- a/value/src/it/gwtserializer/pom.xml
+++ b/value/src/it/gwtserializer/pom.xml
@@ -118,7 +118,7 @@
       <plugin>
         <groupId>net.ltgt.gwt.maven</groupId>
         <artifactId>gwt-maven-plugin</artifactId>
-        <version>1.0-rc-6</version>
+        <version>1.0-rc-7</version>
         <executions>
           <execution>
             <goals>


### PR DESCRIPTION
Running tests in prod mode is actually a side-effect of updating
the gwt-maven-plugin to 1.0-rc-6.

Also update guava to the same version as guava-gwt, remove
GWT version (redundant with dependencyManagement), and
update JUnit.