### PR TITLE
Catch Inflater NPE in templatevars

### DIFF
--- a/value/src/main/java/com/google/auto/value/processor/TemplateVars.java
+++ b/value/src/main/java/com/google/auto/value/processor/TemplateVars.java
@@ -135,7 +135,12 @@ abstract class TemplateVars {
   private static Template templateFromInputStream(InputStream in)
       throws UnsupportedEncodingException, IOException {
     Reader reader = new BufferedReader(new InputStreamReader(in, "UTF-8"));
-    return Template.parseFrom(reader);
+    try {
+      return Template.parseFrom(reader);
+    } catch (NullPointerException e) {
+      // Inflater for zips will throw an NPE if the Inflater stream is closed. It's silly.
+      throw new IOException(e);
+    }
   }
 
   // This is an ugly workaround for https://bugs.openjdk.java.net/browse/JDK-6947916, as


### PR DESCRIPTION
We started seeing the IO issues that #393 was intending to fix again, this time because there's apparently an NPE that gets thrown when the stream is closed ಠ_ಠ.

```
Caused by: java.lang.NullPointerException: Inflater has been closed
	at java.util.zip.Inflater.ensureOpen(Inflater.java:389)
	at java.util.zip.Inflater.inflate(Inflater.java:257)
	at java.util.zip.InflaterInputStream.read(InflaterInputStream.java:152)
	at java.io.FilterInputStream.read(FilterInputStream.java:133)
	at sun.nio.cs.StreamDecoder.readBytes(StreamDecoder.java:284)
	at sun.nio.cs.StreamDecoder.implRead(StreamDecoder.java:326)
	at sun.nio.cs.StreamDecoder.read(StreamDecoder.java:178)
	at java.io.InputStreamReader.read(InputStreamReader.java:184)
	at java.io.BufferedReader.read1(BufferedReader.java:210)
	at java.io.BufferedReader.read(BufferedReader.java:286)
	at java.io.BufferedReader.fill(BufferedReader.java:161)
	at java.io.BufferedReader.read(BufferedReader.java:182)
	at java.io.LineNumberReader.read(LineNumberReader.java:126)
	at com.google.auto.value.processor.escapevelocity.Parser.next(Parser.java:140)
	at com.google.auto.value.processor.escapevelocity.Parser.<init>(Parser.java:83)
	at com.google.auto.value.processor.escapevelocity.Template.parseFrom(Template.java:56)
	at com.google.auto.value.processor.TemplateVars.templateFromInputStream(TemplateVars.java:138)
	at com.google.auto.value.processor.TemplateVars.parsedTemplateForResource(TemplateVars.java:112)
	at com.google.auto.value.processor.AutoValueTemplateVars.<clinit>(AutoValueTemplateVars.java:192)
```