### PR TITLE
Change markdown links so they no longer have a line break between ] and (.

### DIFF
--- a/value/README.md
+++ b/value/README.md
@@ -20,5 +20,6 @@ AutoValue provides an easier way to create immutable value classes, with a lot
 less code and less room for error, while **not restricting your freedom** to
 code almost any aspect of your class exactly the way you want it.
 
-For more information, consult the [detailed documentation]
-(userguide/index.md)
+For more information, consult the
+[detailed
+documentation](userguide/index.md)

--- a/value/src/main/java/com/google/auto/value/processor/escapevelocity/README.md
+++ b/value/src/main/java/com/google/auto/value/processor/escapevelocity/README.md
@@ -335,5 +335,5 @@ post-process it. For example, if it is Java code, you could use a formatter such
 [google-java-format](https://github.com/google/google-java-format). Then you shouldn't have to
 worry about extraneous spaces.
 
-[VelocityHacks]: https://github.com/google/auto/blob/ca2384d5ad15a0c761b940384083cf5c50c6e839/value/src/main/java/com/google/auto/value/processor/TemplateVars.java#L54]
+[VelocityHacks]: https://github.com/google/auto/blob/ca2384d5ad15a0c761b940384083cf5c50c6e839/value/src/main/java/com/google/auto/value/processor/TemplateVars.java#L54
 [AutoValue]: https://github.com/google/auto/tree/master/value

--- a/value/userguide/builders-howto.md
+++ b/value/userguide/builders-howto.md
@@ -5,16 +5,16 @@ This page answers common how-to questions that may come up when using AutoValue
 **with the builder option**. You should read and understand [AutoValue with
 builders](builders.md) first.
 
-If you are not using a builder, see [Introduction](index.md) and [How do I...]
-(howto.md) instead.
+If you are not using a builder, see [Introduction](index.md) and
+[How do I...](howto.md) instead.
 
 ## Contents
 
 How do I...
 
 *   ... [use (or not use) `set` **prefixes**?](#beans)
-*   ... [use different **names** besides `builder()`/`Builder`/`build()`?]
-    (#build_names)
+*   ... [use different **names** besides
+    `builder()`/`Builder`/`build()`?](#build_names)
 *   ... [specify a **default** value for a property?](#default)
 *   ... [initialize a builder to the same property values as an **existing**
     value instance](#to_builder)
@@ -75,11 +75,11 @@ Use whichever names you like; AutoValue doesn't actually care.
 
 What should happen when a caller does not supply a value for a property before
 calling `build()`? If the property in question is [nullable](howto.md#nullable),
-it will simply default to `null` as you would expect. And if it is [Optional]
-(#optional) it will default to an empty `Optional` as you might also expect. But
-if it isn't either of those things (including if it is a primitive-valued
-property, which *can't* be null), then `build()` will throw an unchecked
-exception.
+it will simply default to `null` as you would expect. And if it is
+[Optional](#optional) it will default to an empty `Optional` as you might also
+expect. But if it isn't either of those things (including if it is a
+primitive-valued property, which *can't* be null), then `build()` will throw an
+unchecked exception.
 
 But this presents a problem, since one of the main *advantages* of a builder in
 the first place is that callers can specify only the properties they care about!
@@ -111,8 +111,8 @@ abstract class Animal {
 ```
 
 Occasionally you may want to supply a default value, but only if the property is
-not set explicitly. This is covered in the section on [normalization]
-(#normalize).
+not set explicitly. This is covered in the section on
+[normalization](#normalize).
 
 ## <a name="to_builder"></a>... initialize a builder to the same property values as an existing value instance
 
@@ -240,8 +240,8 @@ public abstract class Animal {
 
 The getter in your builder must have the same signature as the abstract property
 accessor method in the value class. It will return the value that has been set
-on the `Builder`. If no value has been set for a non-[nullable]
-(howto.md#nullable) property, `IllegalStateException` is thrown.
+on the `Builder`. If no value has been set for a
+non-[nullable](howto.md#nullable) property, `IllegalStateException` is thrown.
 
 Getters should generally only be used within the `Builder` as shown, so they are
 not public.

--- a/value/userguide/builders.md
+++ b/value/userguide/builders.md
@@ -80,18 +80,18 @@ exposing yourself to initialization-order problems.
 ## <a name="howto"></a>How do I...
 
 *   ... [use (or not use) `set` **prefixes**?](builders-howto.md#beans)
-*   ... [use different **names** besides `builder()`/`Builder`/`build()`?]
-    (builders-howto.md#build_names)
+*   ... [use different **names** besides
+    `builder()`/`Builder`/`build()`?](builders-howto.md#build_names)
 *   ... [specify a **default** value for a property?](builders-howto.md#default)
 *   ... [initialize a builder to the same property values as an **existing**
     value instance](builders-howto.md#to_builder)
 *   ... [include `with-` methods on my value class for creating slightly
     **altered** instances?](builders-howto.md#withers)
 *   ... [**validate** property values?](builders-howto.md#validate)
-*   ... [**normalize** (modify) a property value at `build` time?]
-    (builders-howto.md#normalize)
-*   ... [expose **both** a builder and a factory method?]
-    (builders-howto.md#both)
+*   ... [**normalize** (modify) a property value at `build`
+    time?](builders-howto.md#normalize)
+*   ... [expose **both** a builder and a factory
+    method?](builders-howto.md#both)
 *   ... [use a **collection**-valued property?](builders-howto.md#collection)
     *   ... [let my builder **accumulate** values for a collection-valued
         property (not require them all at once)?](builders-howto.md#accumulate)

--- a/value/userguide/howto.md
+++ b/value/userguide/howto.md
@@ -71,8 +71,8 @@ for the generated constructor's parameter names.
 AutoValue will do exactly this, but only if you are using these prefixes
 *consistently*. In that case, it infers your intended property name by first
 stripping the `get-` or `is-` prefix, then adjusting the case of what remains as
-specified by [Introspector.decapitalize]
-(http://docs.oracle.com/javase/8/docs/api/java/beans/Introspector.html#decapitalize).
+specified by
+[Introspector.decapitalize](http://docs.oracle.com/javase/8/docs/api/java/beans/Introspector.html#decapitalize).
 
 Note that, in keeping with the JavaBeans specification, the `is-` prefix is only
 allowed on `boolean`-returning methods. `get-` is allowed on any type of
@@ -165,8 +165,8 @@ concrete implementation class. We call this *underriding* the method.
 Remember when doing this that you are losing AutoValue's protections. Be careful
 to follow the basic rules of hash codes: equal objects must have equal hash
 codes *always*, and equal hash codes should imply equal objects *almost always*.
-You should now test your class more thoroughly, ideally using [`EqualsTester`]
-(http://static.javadoc.io/com.google.guava/guava-testlib/19.0/com/google/common/testing/EqualsTester.html)
+You should now test your class more thoroughly, ideally using
+[`EqualsTester`](http://static.javadoc.io/com.google.guava/guava-testlib/19.0/com/google/common/testing/EqualsTester.html)
 from [guava-testlib](http://github.com/google/guava).
 
 Best practice: mark your underriding methods `final` to make it clear to future
@@ -190,8 +190,8 @@ class PleaseOverrideExample extends SuperclassThatDefinesToString {
 
 ## <a name="create"></a>... have multiple `create` methods, or name it/them differently?
 
-Just do it! AutoValue doesn't actually care. This [best practice item]
-(practices.md#one_reference) may be relevant.
+Just do it! AutoValue doesn't actually care. This
+[best practice item](practices.md#one_reference) may be relevant.
 
 ## <a name="ignore"></a>... ignore certain properties in `equals`, etc.?
 
@@ -281,8 +281,8 @@ public class Names {
 }
 ```
 
-For more details, see the [`AutoAnnotation` javadoc]
-(http://github.com/google/auto/blob/master/value/src/main/java/com/google/auto/value/AutoAnnotation.java#L24).
+For more details, see the [`AutoAnnotation`
+javadoc](http://github.com/google/auto/blob/master/value/src/main/java/com/google/auto/value/AutoAnnotation.java#L24).
 
 ## <a name="setters"></a>... also include setter (mutator) methods?
 
@@ -296,10 +296,9 @@ might be mutated and the other not.
 ## <a name="compareTo"></a>... also generate `compareTo`?
 
 AutoValue intentionally does not provide this feature. It is better for you to
-roll your own comparison logic using the new methods added to [`Comparator`]
-(https://docs.oracle.com/javase/8/docs/api/java/util/Comparator.html) in Java 8,
-or [`ComparisonChain`]
-(http://google.github.io/guava/releases/snapshot/api/docs/com/google/common/collect/ComparisonChain.html)
+roll your own comparison logic using the new methods added to
+[`Comparator`](https://docs.oracle.com/javase/8/docs/api/java/util/Comparator.html) in Java 8,
+or [`ComparisonChain`](http://google.github.io/guava/releases/snapshot/api/docs/com/google/common/collect/ComparisonChain.html)
 from [Guava](http://github.com/google/guava).
 
 Since these mechanisms are easy to use, require very little code, and give you
@@ -345,8 +344,8 @@ constructors by *Effective Java*, Item 1.
 Interfaces are not allowed. The only advantage of interfaces we're aware of is
 that you can omit `public abstract` from the methods. That's not much. On the
 other hand, you would lose the immutability guarantee, and you'd also invite
-more of the kind of bad behavior described in [this best-practices item]
-(practices.md#simple). On balance, we don't think it's worth it.
+more of the kind of bad behavior described in [this best-practices
+item](practices.md#simple). On balance, we don't think it's worth it.
 
 ## <a name="memoize"></a>... memoize ("cache") derived properties?
 

--- a/value/userguide/index.md
+++ b/value/userguide/index.md
@@ -175,27 +175,27 @@ How do I...
 *   ... [use a property of a **mutable** type?](howto.md#mutable_property)
 *   ... [use a **custom** implementation of `equals`, etc.?](howto.md#custom)
 *   ... [**ignore** certain properties in `equals`, etc.?](howto.md#ignore)
-*   ... [have multiple **create** methods, or name it/them differently?]
-    (howto.md#create)
-*   ... [have AutoValue also implement abstract methods from my **supertypes**?]
-    (howto.md#supertypes)
+*   ... [have multiple **create** methods, or name it/them
+    differently?](howto.md#create)
+*   ... [have AutoValue also implement abstract methods from my
+    **supertypes**?](howto.md#supertypes)
 *   ... [use AutoValue with a **generic** class?](howto.md#generic)
 *   ... [make my class Java- or GWT- **serializable**?](howto.md#serialize)
-*   ... [apply an **annotation** to a generated **field**?]
-    (howto.md#annotate_field)
-*   ... [use AutoValue to **implement** an **annotation** type?]
-    (howto.md#annotation)
+*   ... [apply an **annotation** to a generated
+    **field**?](howto.md#annotate_field)
+*   ... [use AutoValue to **implement** an **annotation**
+    type?](howto.md#annotation)
 *   ... [also include **setter** (mutator) methods?](howto.md#setters)
 *   ... [also generate **`compareTo`**?](howto.md#compareTo)
-*   ... [use a **primitive array** for a property value?]
-    (howto.md#primitive_array)
+*   ... [use a **primitive array** for a property
+    value?](howto.md#primitive_array)
 *   ... [use an **object array** for a property value?](howto.md#object_array)
 *   ... [have one `@AutoValue` class **extend** another?](howto.md#inherit)
 *   ... [keep my accessor methods **private**?](howto.md#private_accessors)
 *   ... [expose a **constructor**, not factory method, as my public creation
     API?](howto.md#public_constructor)
-*   ... [use AutoValue on an **interface**, not abstract class?]
-    (howto.md#interface)
+*   ... [use AutoValue on an **interface**, not abstract
+    class?](howto.md#interface)
 *   ... [**memoize** derived properties?](howto.md#memoize)
 
 <!-- TODO(kevinb): should the above be only a selected subset? -->


### PR DESCRIPTION
Github recently stopped recognizing links like this, and pointed out <https://github.com/github/markup/issues/1026> that they are not covered by the Commonmark spec.

Some of these links might better be expressed using the link-reference style, [foo][bar] or just [foo], but for now I'm just making a whitespace change.

-------------
Created by MOE: https://github.com/google/moe
MOE_MIGRATED_REVID=150927275