### PR TITLE
Remove JDK 7 from the Travis configuration of the Auto project on github.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,6 @@ script:
   - mvn -B -U -f build-pom.xml verify --fail-at-end -Dsource.skip=true -Dmaven.javadoc.skip=true
 
 jdk:
-  - oraclejdk7
-  - openjdk7
   - oraclejdk8
 
 env:


### PR DESCRIPTION
We no longer support running the annotation processors in this project on Java 7 or earlier, although they still generate code that can *run* on Java 6 or 7.

-------------
Created by MOE: https://github.com/google/moe
MOE_MIGRATED_REVID=151142237