### PR TITLE
We now require Java 8, so remove the @Ignore on annotationReferencesUndefinedTest

### DIFF
--- a/value/src/test/java/com/google/auto/value/processor/CompilationTest.java
+++ b/value/src/test/java/com/google/auto/value/processor/CompilationTest.java
@@ -38,7 +38,6 @@ import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.util.ElementFilter;
 import javax.tools.JavaFileObject;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -2334,11 +2333,7 @@ public class CompilationTest {
         .compilesWithoutError();
   }
 
-  // Test currently ignored because sometimes we get two UNDEFINED errors and sometimes we
-  // get no warnings if there is an error, depending on the exact JDK version. We may be
-  // able to get something a bit more solid once we require JDK 8.
   @Test
-  @Ignore
   public void annotationReferencesUndefined() {
     // Test that we don't throw an exception if asked to compile @SuppressWarnings(UNDEFINED)
     // where UNDEFINED is an undefined symbol.


### PR DESCRIPTION
-------------
Created by MOE: https://github.com/google/moe
MOE_MIGRATED_REVID=151405078