### PR TITLE
typo correction in declared types equality check

### DIFF
--- a/common/src/main/java/com/google/auto/common/MoreTypes.java
+++ b/common/src/main/java/com/google/auto/common/MoreTypes.java
@@ -185,7 +185,7 @@ public final class MoreTypes {
           return true;
         }
         return aElement.equals(bElement)
-            && equal(a.getEnclosingType(), a.getEnclosingType(), newVisiting)
+            && equal(a.getEnclosingType(), b.getEnclosingType(), newVisiting)
             && equalLists(a.getTypeArguments(), b.getTypeArguments(), newVisiting);
       }
       return false;


### PR DESCRIPTION
There is a typo (originating as far as history of this repo remembers) in declared types equality check in `EqualVisitor`