### PR TITLE
Fix coding example

### DIFF
--- a/service/README.md
+++ b/service/README.md
@@ -23,7 +23,7 @@ package foo.bar;
 import javax.annotation.processing.Processor;
 
 @AutoService(Processor.class)
-final class MyProcessor extends Processor {
+final class MyProcessor implements Processor {
   // …
 }
 ```


### PR DESCRIPTION
Add 'implements' to declaration of MyProcessor, since Processor cannot be extended by a class.
An alternative declaration would be `final class MyProcessor extends AbstractProcessor`.