### PR TITLE
Update the Gradle instructions

### DIFF
--- a/value/userguide/index.md
+++ b/value/userguide/index.md
@@ -87,8 +87,8 @@ these instructions][tbroyer-apt] and then use it in the `build.gradle` script:
 
 ```groovy
 dependencies {
-  compileOnly "com.google.auto.value:auto-value:1.2"
-  apt         "com.google.auto.value:auto-value:1.2"
+  provided 'com.google.auto.value:auto-value:1.2'
+  annotationProcessor 'com.google.auto.value:auto-value:1.2'
 }
 ```
 


### PR DESCRIPTION
The previous instruction compileOnly and apt did not work for me in an new Android project created with latest Android Studio Beta.