### PR TITLE
Sync 2017 05 30

### DIFF
--- a/service/README.md
+++ b/service/README.md
@@ -23,7 +23,7 @@ package foo.bar;
 import javax.annotation.processing.Processor;
 
 @AutoService(Processor.class)
-final class MyProcessor extends Processor {
+final class MyProcessor implements Processor {
   // …
 }
 ```

--- a/value/src/main/java/com/google/auto/value/AutoValue.java
+++ b/value/src/main/java/com/google/auto/value/AutoValue.java
@@ -77,10 +77,32 @@ public @interface AutoValue {
    * Specifies that AutoValue should copy any annotations from the annotated element to the
    * generated class. This annotation supports classes and methods.
    *
-   * <p>The following annotations are excluded: 1. AutoValue and its nested annotations. 2. Any
-   * annotation appearing in the {@link AutoValue.CopyAnnotations#exclude} field. 3. Any class
-   * annotation which is itself annotated with the {@link java.lang.annotation.Inherited}
-   * meta-annotation.
+   * <p>The following annotations are excluded:
+   *
+   * <ol>
+   * <li>AutoValue and its nested annotations;
+   * <li>any annotation appearing in the {@link AutoValue.CopyAnnotations#exclude} field;
+   * <li>any class annotation which is itself annotated with the
+   *     {@link java.lang.annotation.Inherited} meta-annotation.
+   * </ol>
+   *
+   * <p>When the <i>type</i> of an {@code @AutoValue} property method has annotations, those are
+   * part of the type, so they are always copied to the implementation of the method.
+   * {@code @CopyAnnotations} has no effect here. For example, suppose {@code @Confidential} is a
+   * {@link java.lang.annotation.ElementType#TYPE_USE TYPE_USE} annotation: <pre>
+   *
+   *   &#64;AutoValue
+   *   abstract class Person {
+   *     static Person create(&#64;Confidential String name, int id) {
+   *       return new AutoValue_Person(name, id);
+   *     }
+   *
+   *     abstract &#64;Confidential String name();
+   *     abstract int id();
+   *   }</pre>
+   *
+   * Then the implementation of the {@code name()} method will also have return type
+   * {@code @Confidential String}.
    *
    * @author Carmi Grushko
    */

--- a/value/src/main/java/com/google/auto/value/processor/BuilderMethodClassifier.java
+++ b/value/src/main/java/com/google/auto/value/processor/BuilderMethodClassifier.java
@@ -305,7 +305,7 @@ class BuilderMethodClassifier {
       ExecutableElement builderGetter, ExecutableElement originalGetter) {
     String propertyName = getterToPropertyName.get(originalGetter);
     TypeMirror builderGetterType = builderMethodReturnType(builderGetter);
-    String builderGetterTypeString = typeSimplifier.simplify(builderGetterType);
+    String builderGetterTypeString = typeSimplifier.simplifyWithAnnotations(builderGetterType);
     TypeMirror originalGetterType = originalGetter.getReturnType();
     if (TYPE_EQUIVALENCE.equivalent(builderGetterType, originalGetterType)) {
       builderGetters.put(

--- a/value/src/main/java/com/google/auto/value/processor/BuilderSpec.java
+++ b/value/src/main/java/com/google/auto/value/processor/BuilderSpec.java
@@ -315,7 +315,7 @@ class BuilderSpec {
       this.name = setter.getSimpleName().toString();
       TypeMirror parameterType = Iterables.getOnlyElement(setter.getParameters()).asType();
       primitiveParameter = parameterType.getKind().isPrimitive();
-      String simplifiedParameterType = typeSimplifier.simplify(parameterType);
+      String simplifiedParameterType = typeSimplifier.simplifyWithAnnotations(parameterType);
       if (setter.isVarArgs()) {
         simplifiedParameterType = simplifiedParameterType.replaceAll("\\[\\]$", "...");
       }

--- a/value/src/main/java/com/google/auto/value/processor/PropertyBuilderClassifier.java
+++ b/value/src/main/java/com/google/auto/value/processor/PropertyBuilderClassifier.java
@@ -243,7 +243,7 @@ class PropertyBuilderClassifier {
     }
     ExecutableElement builderMaker = maybeBuilderMaker.get();
 
-    String barBuilderType = typeSimplifier.simplify(barBuilderTypeMirror);
+    String barBuilderType = typeSimplifier.simplifyWithAnnotations(barBuilderTypeMirror);
     String rawBarType = typeSimplifier.simplifyRaw(barTypeMirror);
     String initializer = (builderMaker.getKind() == ElementKind.CONSTRUCTOR)
         ? "new " + barBuilderType + "()"


### PR DESCRIPTION
* Include type annotations in types where appropriate. This fixes, among other things, a problem whereby annotations on nested types were incorrectly spelled `@Nullable Outer.Inner` instead of `Outer.@Nullable Inner` as required.

* Fix `@AutoService` example to reflect the fact that javax.annotation.processing.Processor is an interface, not a class.