### PR TITLE
Explicitly narrow long to int before adding to hash.

### DIFF
--- a/value/src/main/java/com/google/auto/value/processor/autovalue.vm
+++ b/value/src/main/java/com/google/auto/value/processor/autovalue.vm
@@ -147,11 +147,11 @@ $a
     #if ($p.kind == "BYTE" || $p.kind == "SHORT" || $p.kind == "CHAR" || $p.kind == "INT")
       this.$p ##
     #elseif ($p.kind == "LONG")
-      (this.$p >>> 32) ^ this.$p ##
+      (int) ((this.$p >>> 32) ^ this.$p) ##
     #elseif ($p.kind == "FLOAT")
       Float.floatToIntBits(this.$p) ##
     #elseif ($p.kind == "DOUBLE")
-      (Double.doubleToLongBits(this.$p) >>> 32) ^ Double.doubleToLongBits(this.$p) ##
+      (int) ((Double.doubleToLongBits(this.$p) >>> 32) ^ Double.doubleToLongBits(this.$p)) ##
     #elseif ($p.kind == "BOOLEAN")
       this.$p ? 1231 : 1237 ##
     #elseif ($p.kind == "ARRAY")


### PR DESCRIPTION
The compound assignment to the hash value already performed the integer narrowing but did so implicitly. Error-prone was recently updated to detect this case and thus marked this as problematic. Rasterizing the implicit cast as explicitly makes the intent clear and resolves the warnings.

This behavior is already present in AutoAnnotation but was missing from AutoValue.

Closes #506. 