### PR TITLE
Avoid including javax/annotation/* in the shipped AutoValue jar.

### DIFF
--- a/value/pom.xml
+++ b/value/pom.xml
@@ -152,6 +152,11 @@
             </goals>
             <configuration>
               <minimizeJar>true</minimizeJar>
+              <artifactSet>
+                <excludes>
+                  <exclude>com.google.code.findbugs:jsr305</exclude>
+                </excludes>
+              </artifactSet>
               <relocations>
                 <relocation>
                   <pattern>org.objectweb</pattern>


### PR DESCRIPTION
Add a Google-internal test that checks for stray unshaded entries like those in the jar.

Fixes https://github.com/google/auto/issues/537.

-------------
Created by MOE: https://github.com/google/moe
MOE_MIGRATED_REVID=172528313