### PR TITLE
Change NullPointerException to IllegalArgumentException

### DIFF
--- a/value/src/main/java/com/google/auto/value/processor/autovalue.vm
+++ b/value/src/main/java/com/google/auto/value/processor/autovalue.vm
@@ -55,10 +55,10 @@ $a
     #if ($identifiers)
 
     if ($p == null) {
-      throw new NullPointerException("Null $p.name");
+      throw new IllegalArgumentException("Null $p.name");
     }
     #else
-      ## Just throw NullPointerException with no message if it's null.
+      ## Just throw IllegalArgumentException with no message if it's null.
       ## The Object cast has no effect on the code but silences an ErrorProne warning.
 
     ((Object) ${p}).getClass();
@@ -264,10 +264,10 @@ $a
         #if ($identifiers)
 
       if ($p == null) {
-        throw new NullPointerException("Null $p.name");
+        throw new IllegalArgumentException("Null $p.name");
       }
         #else
-          ## Just throw NullPointerException with no message if it's null.
+          ## Just throw IllegalArgumentException with no message if it's null.
           ## The Object cast has no effect on the code but silences an ErrorProne warning.
 
       ((Object) ${p}).getClass();


### PR DESCRIPTION
NullPointerException is for null reference access, not for parameter validation, and in general should not be throwed by user code. Use some other exception, like IllegalArgumentException or IllegalStateException depending on circumstances.