### PR TITLE
Change exception used

### DIFF
--- a/value/src/main/java/com/google/auto/value/processor/autoannotation.vm
+++ b/value/src/main/java/com/google/auto/value/processor/autoannotation.vm
@@ -58,7 +58,7 @@ final class $className implements $annotationName {
   #if (!$members[$p].kind.primitive)
 
     if ($p == null) {
-      throw new NullPointerException("Null $p");
+      throw new IllegalArgumentException("Null $p");
     }
 
   #end


### PR DESCRIPTION
NullPointerException is for null reference access, not for parameter validation, and in general should not be throwed by user code. Use some other exception, like IllegalArgumentException or IllegalStateException depending on circumstances.