### PR TITLE
Moe Sync

### DIFF
--- a/value/src/main/java/com/google/auto/value/processor/autooneof.vm
+++ b/value/src/main/java/com/google/auto/value/processor/autooneof.vm
@@ -67,7 +67,7 @@ final class $generatedClass {
 #end
 
   // Parent class that each implementation will inherit from.
-  private abstract static class Parent$$formalTypes extends $origClass$actualTypes {
+  private abstract static class Parent_$formalTypes extends $origClass$actualTypes {
 
 #foreach ($p in $props)
 
@@ -83,7 +83,7 @@ final class $generatedClass {
 #foreach ($p in $props)
 
   // Implementation when the contained property is "${p}".
-  private static final class Impl_$p$formalTypes extends Parent$$actualTypes {
+  private static final class Impl_$p$formalTypes extends Parent_$actualTypes {
     private final $p.type $p;
 
     Impl_$p($p.type $p) {

--- a/value/src/test/java/com/google/auto/value/processor/AutoOneOfCompilationTest.java
+++ b/value/src/test/java/com/google/auto/value/processor/AutoOneOfCompilationTest.java
@@ -82,7 +82,7 @@ public class AutoOneOfCompilationTest {
             "  }",
             "",
             "  // Parent class that each implementation will inherit from.",
-            "  private abstract static class Parent$<V, T extends Throwable> "
+            "  private abstract static class Parent_<V, T extends Throwable> "
                 + "extends TaskResult<V, T> {",
             "    @Override",
             "    public V value() {",
@@ -97,7 +97,7 @@ public class AutoOneOfCompilationTest {
             "",
             "  // Implementation when the contained property is \"value\".",
             "  private static final class Impl_value<V, T extends Throwable> "
-                + "extends Parent$<V, T> {",
+                + "extends Parent_<V, T> {",
             "    private final V value;",
             "",
             "    Impl_value(V value) {",
@@ -138,7 +138,7 @@ public class AutoOneOfCompilationTest {
             "",
             "  // Implementation when the contained property is \"exception\".",
             "  private static final class Impl_exception<V, T extends Throwable> "
-                + "extends Parent$<V, T> {",
+                + "extends Parent_<V, T> {",
             "    private final Throwable exception;",
             "",
             "    Impl_exception(Throwable exception) {",


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Change generated AutoOneOf code to use Parent_ rather than Parent$ as an internal class name to avoid confusing Proguard.

e807665d297e9b8fa0cee9b7a9e59caad6e3f232