### PR TITLE
Moe Sync

### DIFF
--- a/value/src/it/functional/src/test/java/com/google/auto/value/AutoOneOfJava8Test.java
+++ b/value/src/it/functional/src/test/java/com/google/auto/value/AutoOneOfJava8Test.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2018 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.auto.value;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.reflect.AnnotatedType;
+import java.lang.reflect.Method;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Tests for Java8-specific {@code @AutoOneOf} behaviour.
+ *
+ * @author emcmanus@google.com (Éamonn McManus)
+ */
+@RunWith(JUnit4.class)
+public class AutoOneOfJava8Test {
+  @AutoOneOf(EqualsNullable.Kind.class)
+  public abstract static class EqualsNullable {
+
+    @Target(ElementType.TYPE_USE)
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface Nullable {}
+
+    public enum Kind {THING}
+    public abstract Kind kind();
+    public abstract String thing();
+
+    public static EqualsNullable ofThing(String thing) {
+      return AutoOneOf_AutoOneOfJava8Test_EqualsNullable.thing(thing);
+    }
+
+    @Override
+    public abstract boolean equals(@Nullable Object x);
+
+    @Override
+    public abstract int hashCode();
+  }
+
+  /**
+   * Tests that a type annotation on the parameter of {@code equals(Object)} is copied into the
+   * implementation class.
+   */
+  @Test
+  public void equalsNullable() throws ReflectiveOperationException {
+    if (BugDetector.typeVisitorDropsAnnotations()) {
+      System.err.println("TYPE VISITORS DO NOT SEE TYPE ANNOTATIONS, SKIPPING TEST");
+      return;
+    }
+    EqualsNullable x = EqualsNullable.ofThing("foo");
+    Class<? extends EqualsNullable> c = x.getClass();
+    Method equals = c.getMethod("equals", Object.class);
+    assertThat(equals.getDeclaringClass()).isNotSameAs(EqualsNullable.class);
+    AnnotatedType parameterType = equals.getAnnotatedParameterTypes()[0];
+    assertThat(parameterType.isAnnotationPresent(EqualsNullable.Nullable.class))
+        .isTrue();
+  }
+}

--- a/value/src/it/functional/src/test/java/com/google/auto/value/BugDetector.java
+++ b/value/src/it/functional/src/test/java/com/google/auto/value/BugDetector.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2018 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.auto.value;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.testing.compile.CompilationSubject.assertThat;
+
+import com.google.testing.compile.Compilation;
+import com.google.testing.compile.Compiler;
+import com.google.testing.compile.JavaFileObjects;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.RoundEnvironment;
+import javax.annotation.processing.SupportedAnnotationTypes;
+import javax.annotation.processing.SupportedSourceVersion;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.ElementFilter;
+import javax.lang.model.util.SimpleTypeVisitor8;
+import javax.tools.JavaFileObject;
+
+/**
+ * Detects javac bugs that might prevent tests from working.
+ *
+ * @author emcmanus@google.com (Éamonn McManus)
+ */
+final class BugDetector {
+  private BugDetector() {}
+
+  /**
+   * Returns true if {@link TypeMirror#accept} gives the unannotated type to the type visitor. It
+   * should obviously receive the type that {@code accept} was called on, but in at least some
+   * Java 8 versions it ends up being the unannotated one.
+   */
+  // I have not been able to find a reference for this bug.
+  static boolean typeVisitorDropsAnnotations() {
+    JavaFileObject testClass = JavaFileObjects.forSourceLines(
+        "com.example.Test",
+        "package com.example;",
+        "",
+        "import java.lang.annotation.*;",
+        "",
+        "abstract class Test {",
+        "  @Target(ElementType.TYPE_USE)",
+        "  @interface Nullable {}",
+        "",
+        "  @Override public abstract boolean equals(@Nullable Object x);",
+        "}");
+    BugDetectorProcessor bugDetectorProcessor = new BugDetectorProcessor();
+    Compilation compilation =
+        Compiler.javac().withProcessors(bugDetectorProcessor).compile(testClass);
+    assertThat(compilation).succeeded();
+    return bugDetectorProcessor.typeAnnotationsNotReturned;
+  }
+
+  @SupportedAnnotationTypes("*")
+  @SupportedSourceVersion(SourceVersion.RELEASE_8)
+  private static class BugDetectorProcessor extends AbstractProcessor {
+    volatile boolean typeAnnotationsNotReturned;
+
+    @Override
+    public boolean process(
+        Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+      if (!roundEnv.processingOver()) {
+        TypeElement test = processingEnv.getElementUtils().getTypeElement("com.example.Test");
+        ExecutableElement equals = ElementFilter.methodsIn(test.getEnclosedElements()).get(0);
+        assertThat(equals.getSimpleName().toString()).isEqualTo("equals");
+        TypeMirror parameterType = equals.getParameters().get(0).asType();
+        List<AnnotationMirror> annotationsFromVisitor =
+            parameterType.accept(new BugDetectorVisitor(), null);
+        typeAnnotationsNotReturned = annotationsFromVisitor.isEmpty();
+      }
+      return false;
+    }
+
+    private static class BugDetectorVisitor
+        extends SimpleTypeVisitor8<List<AnnotationMirror>, Void> {
+      @Override
+      public List<AnnotationMirror> visitDeclared(DeclaredType t, Void p) {
+        return Collections.unmodifiableList(t.getAnnotationMirrors());
+      }
+    }
+  }
+}

--- a/value/src/main/java/com/google/auto/value/processor/AutoOneOfProcessor.java
+++ b/value/src/main/java/com/google/auto/value/processor/AutoOneOfProcessor.java
@@ -110,10 +110,12 @@ public class AutoOneOfProcessor extends AutoValueOrOneOfProcessor {
     vars.generatedClass = TypeSimplifier.simpleNameOf(subclass);
     vars.types = processingEnv.getTypeUtils();
     vars.propertyToKind = propertyToKind;
-    Set<ObjectMethod> methodsToGenerate = determineObjectMethodsToGenerate(methods);
-    vars.toString = methodsToGenerate.contains(ObjectMethod.TO_STRING);
-    vars.equals = methodsToGenerate.contains(ObjectMethod.EQUALS);
-    vars.hashCode = methodsToGenerate.contains(ObjectMethod.HASH_CODE);
+    Map<ObjectMethod, ExecutableElement> methodsToGenerate =
+        determineObjectMethodsToGenerate(methods);
+    vars.toString = methodsToGenerate.containsKey(ObjectMethod.TO_STRING);
+    vars.equals = methodsToGenerate.containsKey(ObjectMethod.EQUALS);
+    vars.hashCode = methodsToGenerate.containsKey(ObjectMethod.HASH_CODE);
+    vars.equalsParameterType = equalsParameterType(methodsToGenerate);
     defineVarsForType(autoOneOfType, vars, propertyMethods, kindGetter);
 
     String text = vars.toText();

--- a/value/src/main/java/com/google/auto/value/processor/AutoOneOfTemplateVars.java
+++ b/value/src/main/java/com/google/auto/value/processor/AutoOneOfTemplateVars.java
@@ -41,6 +41,13 @@ class AutoOneOfTemplateVars extends TemplateVars {
   /** Whether to generate a toString() method. */
   Boolean toString;
 
+  /**
+   * A string representing the parameter type declaration of the equals(Object) method, including
+   * any annotations. If {@link #equals} is false, this field is ignored (but it must still be
+   * non-null).
+   */
+  String equalsParameterType;
+
   /** The type utilities returned by {@link ProcessingEnvironment#getTypeUtils()}. */
   Types types;
 

--- a/value/src/main/java/com/google/auto/value/processor/AutoValueBuilderProcessor.java
+++ b/value/src/main/java/com/google/auto/value/processor/AutoValueBuilderProcessor.java
@@ -15,36 +15,32 @@
  */
 package com.google.auto.value.processor;
 
-import static com.google.auto.common.MoreElements.isAnnotationPresent;
+import static com.google.auto.value.processor.AutoValueOrOneOfProcessor.hasAnnotationMirror;
+import static com.google.auto.value.processor.ClassNames.AUTO_VALUE_BUILDER_NAME;
+import static com.google.auto.value.processor.ClassNames.AUTO_VALUE_NAME;
 
-import com.google.auto.common.MoreElements;
 import com.google.auto.common.SuperficialValidation;
 import com.google.auto.service.AutoService;
-import com.google.auto.value.AutoValue;
-import com.google.common.collect.ImmutableSet;
 import java.util.Set;
 import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.Processor;
 import javax.annotation.processing.RoundEnvironment;
+import javax.annotation.processing.SupportedAnnotationTypes;
 import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 import javax.tools.Diagnostic;
 
 /**
- * Annotation processor that checks that the type that {@link AutoValue.Builder} is applied to is
+ * Annotation processor that checks that the type that {@code AutoValue.Builder} is applied to is
  * nested inside an {@code @AutoValue} class. The actual code generation for builders is done in
  * {@link AutoValueProcessor}.
  *
  * @author Éamonn McManus
  */
 @AutoService(Processor.class)
+@SupportedAnnotationTypes(AUTO_VALUE_BUILDER_NAME)
 public class AutoValueBuilderProcessor extends AbstractProcessor {
-  @Override
-  public Set<String> getSupportedAnnotationTypes() {
-    return ImmutableSet.of(AutoValue.Builder.class.getCanonicalName());
-  }
-
   @Override
   public SourceVersion getSupportedSourceVersion() {
     return SourceVersion.latest();
@@ -52,8 +48,9 @@ public class AutoValueBuilderProcessor extends AbstractProcessor {
 
   @Override
   public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
-    Set<? extends Element> builderTypes =
-        roundEnv.getElementsAnnotatedWith(AutoValue.Builder.class);
+    TypeElement autoValueBuilder =
+        processingEnv.getElementUtils().getTypeElement(AUTO_VALUE_BUILDER_NAME);
+    Set<? extends Element> builderTypes = roundEnv.getElementsAnnotatedWith(autoValueBuilder);
     if (!SuperficialValidation.validateElements(builderTypes)) {
       return false;
     }
@@ -61,7 +58,7 @@ public class AutoValueBuilderProcessor extends AbstractProcessor {
       // Double-check that the annotation is there. Sometimes the compiler gets confused in case of
       // erroneous source code. SuperficialValidation should protect us against this but it doesn't
       // cost anything to check again.
-      if (isAnnotationPresent(annotatedType, AutoValue.Builder.class)) {
+      if (hasAnnotationMirror(annotatedType, AUTO_VALUE_BUILDER_NAME)) {
         validate(
             annotatedType,
             "@AutoValue.Builder can only be applied to a class or interface inside an"
@@ -73,7 +70,7 @@ public class AutoValueBuilderProcessor extends AbstractProcessor {
 
   private void validate(Element annotatedType, String errorMessage) {
     Element container = annotatedType.getEnclosingElement();
-    if (!MoreElements.isAnnotationPresent(container, AutoValue.class)) {
+    if (!hasAnnotationMirror(container, AUTO_VALUE_NAME)) {
       processingEnv.getMessager().printMessage(
           Diagnostic.Kind.ERROR, errorMessage, annotatedType);
     }

--- a/value/src/main/java/com/google/auto/value/processor/AutoValueProcessor.java
+++ b/value/src/main/java/com/google/auto/value/processor/AutoValueProcessor.java
@@ -47,6 +47,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.ServiceConfigurationError;
@@ -222,10 +223,12 @@ public class AutoValueProcessor extends AutoValueOrOneOfProcessor {
     vars.types = processingEnv.getTypeUtils();
     vars.identifiers =
         !processingEnv.getOptions().containsKey("com.google.auto.value.OmitIdentifiers");
-    Set<ObjectMethod> methodsToGenerate = determineObjectMethodsToGenerate(methods);
-    vars.toString = methodsToGenerate.contains(ObjectMethod.TO_STRING);
-    vars.equals = methodsToGenerate.contains(ObjectMethod.EQUALS);
-    vars.hashCode = methodsToGenerate.contains(ObjectMethod.HASH_CODE);
+    Map<ObjectMethod, ExecutableElement> methodsToGenerate =
+        determineObjectMethodsToGenerate(methods);
+    vars.toString = methodsToGenerate.containsKey(ObjectMethod.TO_STRING);
+    vars.hashCode = methodsToGenerate.containsKey(ObjectMethod.HASH_CODE);
+    vars.equals = methodsToGenerate.containsKey(ObjectMethod.EQUALS);
+    vars.equalsParameterType = equalsParameterType(methodsToGenerate);
     defineVarsForType(type, vars, toBuilderMethods, propertyMethods, builder);
 
     // Only copy annotations from a class if it has @AutoValue.CopyAnnotations.

--- a/value/src/main/java/com/google/auto/value/processor/AutoValueTemplateVars.java
+++ b/value/src/main/java/com/google/auto/value/processor/AutoValueTemplateVars.java
@@ -46,6 +46,13 @@ class AutoValueTemplateVars extends TemplateVars {
   Boolean toString;
 
   /**
+   * A string representing the parameter type declaration of the equals(Object) method, including
+   * any annotations. If {@link #equals} is false, this field is ignored (but it must still be
+   * non-null).
+   */
+  String equalsParameterType;
+
+  /**
    * Whether to include identifiers in strings in the generated code. If false, exception messages
    * will not mention properties by name, and {@code toString()} will include neither property
    * names nor the name of the {@code @AutoValue} class.

--- a/value/src/main/java/com/google/auto/value/processor/BuilderSpec.java
+++ b/value/src/main/java/com/google/auto/value/processor/BuilderSpec.java
@@ -16,12 +16,12 @@
 package com.google.auto.value.processor;
 
 import static com.google.auto.common.MoreElements.getLocalAndInheritedMethods;
+import static com.google.auto.value.processor.AutoValueOrOneOfProcessor.hasAnnotationMirror;
+import static com.google.auto.value.processor.ClassNames.AUTO_VALUE_BUILDER_NAME;
 import static com.google.common.collect.Sets.immutableEnumSet;
 import static java.util.stream.Collectors.toList;
 
-import com.google.auto.common.MoreElements;
 import com.google.auto.common.MoreTypes;
-import com.google.auto.value.AutoValue;
 import com.google.auto.value.processor.AutoValueOrOneOfProcessor.Property;
 import com.google.common.collect.ImmutableBiMap;
 import com.google.common.collect.ImmutableMap;
@@ -76,7 +76,7 @@ class BuilderSpec {
   Optional<Builder> getBuilder() {
     Optional<TypeElement> builderTypeElement = Optional.empty();
     for (TypeElement containedClass : ElementFilter.typesIn(autoValueClass.getEnclosedElements())) {
-      if (MoreElements.isAnnotationPresent(containedClass, AutoValue.Builder.class)) {
+      if (hasAnnotationMirror(containedClass, AUTO_VALUE_BUILDER_NAME)) {
         if (!CLASS_OR_INTERFACE.contains(containedClass.getKind())) {
           errorReporter.reportError(
               "@AutoValue.Builder can only apply to a class or an interface", containedClass);

--- a/value/src/main/java/com/google/auto/value/processor/ClassNames.java
+++ b/value/src/main/java/com/google/auto/value/processor/ClassNames.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2018 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.auto.value.processor;
+
+/**
+ * Names of classes that are referenced in the processors.
+ *
+ * @author emcmanus@google.com (Éamonn McManus)
+ */
+final class ClassNames {
+  private ClassNames() {}
+
+  static final String AUTO_ANNOTATION_NAME = "com.google.auto.value.AutoAnnotation";
+  static final String AUTO_ONE_OF_NAME = "com.google.auto.value.AutoOneOf";
+  static final String AUTO_VALUE_NAME = "com.google.auto.value.AutoValue";
+  static final String AUTO_VALUE_BUILDER_NAME = AUTO_VALUE_NAME + ".Builder";
+  static final String COPY_ANNOTATIONS_NAME = AUTO_VALUE_NAME + ".CopyAnnotations";
+}

--- a/value/src/main/java/com/google/auto/value/processor/autooneof.vm
+++ b/value/src/main/java/com/google/auto/value/processor/autooneof.vm
@@ -112,7 +112,7 @@ final class $generatedClass {
   #if ($equals)
 
     @Override
-    public boolean equals(Object x) {
+    public boolean equals($equalsParameterType x) {
       if (x instanceof $origClass) {
         $origClass$wildcardTypes that = ($origClass$wildcardTypes) x;
         return this.${kindGetter}() == that.${kindGetter}()

--- a/value/src/main/java/com/google/auto/value/processor/autovalue.vm
+++ b/value/src/main/java/com/google/auto/value/processor/autovalue.vm
@@ -125,7 +125,7 @@ $a
 #if ($equals)
 
   @Override
-  public boolean equals(`java.lang.Object` o) {
+  public boolean equals($equalsParameterType o) {
     if (o == this) {
       return true;
     }


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Remove compile-time references to annotation classes. Instead of AutoValue.class, we use the string "com.google.auto.value.AutoValue".

21d6a28bcb9feaae8ab8a8912a29f5f6c76e500e

-------

<p> Copy type annotations to the parameter of equals(Object).

If equals(Object) is being implemented because there is abstract redeclaration of it in the AutoValue class or an ancestor, and if that redeclaration has a type annotation such as @Nullable on its parameter, then the generated implementation will also have that annotation. The same applies to AutoOneOf.

We could go further and also copy annotations on the return types of equals/hashCode/toString, but for now there's no perceived need for that.

Fixes https://github.com/google/auto/issues/579.

RELNOTES=In `@AutoValue`, copy `@Nullable` from `equals(@Nullable Object)` to its implementation.

9c3893d6d6f146480be9c08f41e06581d4f27822