### PR TITLE
Moe Sync

### DIFF
--- a/value/annotations/pom.xml
+++ b/value/annotations/pom.xml
@@ -25,13 +25,12 @@
   </parent>
 
   <groupId>com.google.auto.value</groupId>
-  <artifactId>auto-value-pom-aggregator</artifactId>
+  <artifactId>auto-value-annotations</artifactId>
   <version>HEAD-SNAPSHOT</version>
-  <name>AutoValue</name>
+  <name>AutoValue Annotations</name>
   <description>
     Immutable value-type code generation for Java 1.6+.
   </description>
-  <packaging>pom</packaging>
 
   <scm>
     <url>http://github.com/google/auto</url>
@@ -39,19 +38,38 @@
     <developerConnection>scm:git:ssh://git@github.com/google/auto.git</developerConnection>
     <tag>HEAD</tag>
   </scm>
-
-  <modules>
-    <module>annotations</module>
-    <module>processor</module>
-  </modules>
-
   <build>
+    <sourceDirectory>../src/main/java</sourceDirectory>
     <plugins>
       <plugin>
-        <!-- Used to run the functional tests -->
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <includes>
+            <include>com/google/auto/value/*</include>
+            <include>com/google/auto/value/extension/memoized/*</include>
+          </includes>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-invoker-plugin</artifactId>
       </plugin>
     </plugins>
   </build>
+  <profiles>
+    <profile>
+      <id>disable-java8-doclint</id>
+      <activation>
+        <jdk>[1.8,)</jdk>
+      </activation>
+      <properties>
+        <additionalparam>-Xdoclint:none</additionalparam>
+      </properties>
+    </profile>
+  </profiles>
 </project>

--- a/value/processor/pom.xml
+++ b/value/processor/pom.xml
@@ -1,0 +1,176 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (C) 2012 Google, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.google.auto</groupId>
+    <artifactId>auto-parent</artifactId>
+    <version>6</version>
+  </parent>
+
+  <groupId>com.google.auto.value</groupId>
+  <artifactId>auto-value</artifactId>
+  <version>HEAD-SNAPSHOT</version>
+  <name>AutoValue Processor</name>
+  <description>
+    Immutable value-type code generation for Java 1.6+.
+  </description>
+
+  <scm>
+    <url>http://github.com/google/auto</url>
+    <connection>scm:git:git://github.com/google/auto.git</connection>
+    <developerConnection>scm:git:ssh://git@github.com/google/auto.git</developerConnection>
+    <tag>HEAD</tag>
+  </scm>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.auto</groupId>
+      <artifactId>auto-common</artifactId>
+      <version>0.10</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.auto.service</groupId>
+      <artifactId>auto-service</artifactId>
+      <version>1.0-rc4</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.squareup</groupId>
+      <artifactId>javapoet</artifactId>
+    </dependency>
+    <!-- test dependencies -->
+    <dependency>
+      <groupId>com.google.auto.value</groupId>
+      <artifactId>auto-value-annotations</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.velocity</groupId>
+      <artifactId>velocity</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava-testlib</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.truth</groupId>
+      <artifactId>truth</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.testing.compile</groupId>
+      <artifactId>compile-testing</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <sourceDirectory>../src/main/java</sourceDirectory>
+    <testSourceDirectory>../src/test/java</testSourceDirectory>
+
+    <resources>
+      <resource>
+        <directory>../src/main/java</directory>
+        <includes>
+          <include>**/*.vm</include>
+        </includes>
+      </resource>
+    </resources>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <includes>
+            <include>com/google/auto/value/processor/**/*.java</include>
+            <include>com/google/auto/value/extension/memoized/processor/**/*.java</include>
+          </includes>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-invoker-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.immutables.tools</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <minimizeJar>true</minimizeJar>
+              <artifactSet>
+                <excludes>
+                  <exclude>com.google.code.findbugs:jsr305</exclude>
+                </excludes>
+              </artifactSet>
+              <relocations>
+                <relocation>
+                  <pattern>org.objectweb</pattern>
+                  <shadedPattern>autovalue.shaded.org.objectweb$</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>com.google</pattern>
+                  <shadedPattern>autovalue.shaded.com.google$</shadedPattern>
+                  <excludes>
+                    <exclude>com.google.auto.value.**</exclude>
+                  </excludes>
+                </relocation>
+                <relocation>
+                  <pattern>com.squareup.javapoet</pattern>
+                  <shadedPattern>autovalue.shaded.com.squareup.javapoet$</shadedPattern>
+                </relocation>
+              </relocations>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+  <profiles>
+    <profile>
+      <id>disable-java8-doclint</id>
+      <activation>
+        <jdk>[1.8,)</jdk>
+      </activation>
+      <properties>
+        <additionalparam>-Xdoclint:none</additionalparam>
+      </properties>
+    </profile>
+  </profiles>
+</project>

--- a/value/src/it/functional/pom.xml
+++ b/value/src/it/functional/pom.xml
@@ -28,6 +28,11 @@
   <dependencies>
     <dependency>
       <groupId>com.google.auto.value</groupId>
+      <artifactId>auto-value-annotations</artifactId>
+      <version>@project.version@</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.auto.value</groupId>
       <artifactId>auto-value</artifactId>
       <version>@project.version@</version>
     </dependency>

--- a/value/src/it/gwtserializer/pom.xml
+++ b/value/src/it/gwtserializer/pom.xml
@@ -36,6 +36,11 @@
   <dependencies>
     <dependency>
       <groupId>com.google.auto.value</groupId>
+      <artifactId>auto-value-annotations</artifactId>
+      <version>@project.version@</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.auto.value</groupId>
       <artifactId>auto-value</artifactId>
       <version>@project.version@</version>
       <optional>true</optional>

--- a/value/userguide/index.md
+++ b/value/userguide/index.md
@@ -76,19 +76,29 @@ Maven users should add the following to the project's `pom.xml` file:
 ```xml
 <dependency>
   <groupId>com.google.auto.value</groupId>
+  <artifactId>auto-value-annotations</artifactId>
+  <version>1.6</version>
+</dependency>
+<dependency>
+  <groupId>com.google.auto.value</groupId>
   <artifactId>auto-value</artifactId>
-  <version>1.5</version>
+  <version>1.6</version>
   <scope>provided</scope>
 </dependency>
 ```
+
+Alternatively, instead of using the `provided` scope, you can add the second
+dependency to the
+[`annotationProcessorPaths`](https://maven.apache.org/plugins/maven-compiler-plugin/compile-mojo.html#annotationProcessorPaths)
+section.
 
 Gradle users should install the annotation processing plugin [as described in
 these instructions][tbroyer-apt] and then use it in the `build.gradle` script:
 
 ```groovy
 dependencies {
-  compileOnly "com.google.auto.value:auto-value:1.5"
-  apt         "com.google.auto.value:auto-value:1.5"
+  compileOnly "com.google.auto.value:auto-value-annotations:1.6"
+  apt         "com.google.auto.value:auto-value:1.6"
 }
 ```
 


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Create an auto-value-annotations artifact separate from the processor

Fixes https://github.com/google/auto/issues/268

I followed the instructions in https://maven.apache.org/guides/mini/guide-using-one-source-directory.html because it seemed like the easiest way forward without moving around any files.

RELNOTES=`@AutoValue`, `@AutoAnnotation`, `@AutoOneOf`, and `@Memoized` are now in a separate artifact, `auto-value-annotations`. This allows users to specify the annotations in compile scope and the processor in an annotation processing scope, without leaking the processor to a release binary. To upgrade to this version of auto-value, you'll need to add this new artifact as a dependency.

eb7b4ae7847859a2cac68a3a0e4d1ff6b25ccade