### PR TITLE
address issue#615: support incremental annotation processing

### DIFF
--- a/value/src/main/resources/META-INF/gradle/incremental.annotation.processors
+++ b/value/src/main/resources/META-INF/gradle/incremental.annotation.processors
@@ -1,0 +1,1 @@
+com.google.auto.value.processor.AutoValueProcessor,isolating


### PR DESCRIPTION
Adresses #615 

Not sure this is all we need. It would be nice, 
1. to test it using an auto value. Does incremental annotation work using gradle 4.7 ?
2. add (at least) a unit test to make sure we pass the right originating elements tothe filer when we generate a `__AutoValue` file.
(it seems to be the case: [auto value passes the type containing the `@AutoAnnotation` annotation to the filer](value/src/main/java/com/google/auto/value/processor/AutoAnnotationProcessor.java:179))
