### PR TITLE
Adds support for Factory depending on another Factory (fixes #297)

### DIFF
--- a/factory/src/main/java/com/google/auto/factory/processor/Classes.java
+++ b/factory/src/main/java/com/google/auto/factory/processor/Classes.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2018 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.auto.factory.processor;
+
+public class Classes {
+
+  static CharSequence getSimpleName(CharSequence fullyQualifiedName) {
+    int lastDot = lastIndexOf(fullyQualifiedName, '.');
+    return fullyQualifiedName.subSequence(lastDot + 1, fullyQualifiedName.length());
+  }
+
+  static String getPackage(CharSequence fullyQualifiedName) {
+    int lastDot = lastIndexOf(fullyQualifiedName, '.');
+    return fullyQualifiedName.subSequence(0, lastDot).toString();
+  }
+
+  private static int lastIndexOf(CharSequence charSequence, char c) {
+    for (int i = charSequence.length() - 1; i >= 0; i--) {
+      if (charSequence.charAt(i) == c) {
+        return i;
+      }
+    }
+    return -1;
+  }
+}

--- a/factory/src/test/java/com/google/auto/factory/processor/AutoFactoryProcessorTest.java
+++ b/factory/src/test/java/com/google/auto/factory/processor/AutoFactoryProcessorTest.java
@@ -433,6 +433,16 @@ public class AutoFactoryProcessorTest {
         .generatesSources(loadExpectedFile("expected/OnlyPrimitivesFactory.java"));
   }
 
+  @Test public void dependendFactory() {
+    assertThat(
+            JavaFileObjects.forResource("good/PublicClass.java"),
+            JavaFileObjects.forResource("good/SimpleClassDependingOnFactory.java"))
+        .processedWith(new AutoFactoryProcessor())
+        .compilesWithoutError()
+        .and()
+        .generatesSources(loadExpectedFile("expected/SimpleClassDependingOnFactoryFactory.java"));
+  }
+
   private JavaFileObject loadExpectedFile(String resourceName) {
     try {
       List<String> sourceLines = Resources.readLines(Resources.getResource(resourceName), UTF_8);

--- a/factory/src/test/resources/expected/SimpleClassDependingOnFactoryFactory.java
+++ b/factory/src/test/resources/expected/SimpleClassDependingOnFactoryFactory.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2018 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package tests.sample;
+
+import javax.annotation.processing.Generated;
+import javax.inject.Inject;
+import javax.inject.Provider;
+import tests.PublicClassFactory;
+
+@Generated(
+  value = "com.google.auto.factory.processor.AutoFactoryProcessor",
+  comments = "https://github.com/google/auto/tree/master/factory"
+)
+final class SimpleClassDependingOnFactoryFactory {
+  private final Provider<PublicClassFactory> depAProvider;
+
+  @Inject
+  SimpleClassDependingOnFactoryFactory(Provider<PublicClassFactory> depAProvider) {
+    this.depAProvider = checkNotNull(depAProvider, 1);
+  }
+
+  SimpleClassDependingOnFactory create() {
+    return new SimpleClassDependingOnFactory(checkNotNull(depAProvider.get(), 1));
+  }  
+
+  private static <T> T checkNotNull(T reference, int argumentIndex) {
+    if (reference == null) {
+      throw new NullPointerException(
+          "@AutoFactory method argument is null but is not marked @Nullable. Argument index: "
+              + argumentIndex);
+    }
+    return reference;
+  }
+}

--- a/factory/src/test/resources/good/SimpleClassDependingOnFactory.java
+++ b/factory/src/test/resources/good/SimpleClassDependingOnFactory.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2018 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package tests.sample;
+
+import com.google.auto.factory.AutoFactory;
+import com.google.auto.factory.Provided;
+import tests.PublicClassFactory;
+
+@AutoFactory
+final class SimpleClassDependingOnFactory {
+  private final PublicClassFactory depA;
+
+  SimpleClassDependingOnFactory(@Provided PublicClassFactory depA) {
+    this.depA = depA;
+  }
+}


### PR DESCRIPTION
This will address the issue that the composition of factories is broken.
Builds a map of factory name to to be generated factory which will be used to guess the type
Current workaround is to specify the fully qualified class name

Open Issue:
If two factories will have the same name it can not be guaranteed that the proper class will be selected