### PR TITLE
avoid java.beans.Introspector import

### DIFF
--- a/value/src/main/java/com/google/auto/value/processor/AutoValueOrOneOfProcessor.java
+++ b/value/src/main/java/com/google/auto/value/processor/AutoValueOrOneOfProcessor.java
@@ -36,7 +36,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import java.beans.Introspector;
 import java.io.IOException;
 import java.io.Serializable;
 import java.io.Writer;
@@ -558,7 +557,7 @@ abstract class AutoValueOrOneOfProcessor extends AbstractProcessor {
       assert name.startsWith("is");
       name = name.substring(2);
     }
-    return Introspector.decapitalize(name);
+    return PropertyNames.decapitalizeIgnoreAcronyms(name);
   }
 
   /**

--- a/value/src/main/java/com/google/auto/value/processor/BuilderMethodClassifier.java
+++ b/value/src/main/java/com/google/auto/value/processor/BuilderMethodClassifier.java
@@ -29,7 +29,6 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.LinkedListMultimap;
 import com.google.common.collect.Multimap;
-import java.beans.Introspector;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
@@ -345,7 +344,7 @@ class BuilderMethodClassifier {
       propertyName = methodName;
     } else if (valueGetter == null && methodName.startsWith("set") && methodName.length() > 3) {
       propertyNameToSetters = propertyNameToPrefixedSetters;
-      propertyName = Introspector.decapitalize(methodName.substring(3));
+      propertyName = PropertyNames.decapitalizeIgnoreAcronyms(methodName.substring(3));
       valueGetter = propertyNameToGetter.get(propertyName);
       if (valueGetter == null) {
         // If our property is defined by a getter called getOAuth() then it is called "OAuth"
@@ -354,7 +353,7 @@ class BuilderMethodClassifier {
         // is defined by a getter called oAuth() then it is called "oAuth", but you would still
         // expect to be able to set it using setOAuth(x). Hence the second try using a decapitalize
         // method without the quirky two-leading-capitals rule.
-        propertyName = decapitalize(methodName.substring(3));
+        propertyName = PropertyNames.decapitalize(methodName.substring(3));
         valueGetter = propertyNameToGetter.get(propertyName);
       }
     }

--- a/value/src/main/java/com/google/auto/value/processor/PropertyNames.java
+++ b/value/src/main/java/com/google/auto/value/processor/PropertyNames.java
@@ -1,0 +1,31 @@
+package com.google.auto.value.processor;
+
+/**
+ * Helper methods to create property names.
+ */
+final class PropertyNames {
+
+  /**
+   * Like {@link #decapitalize(String)} but returns a property name that
+   * starts with two capital letters as is (does nothing).
+   */
+  public static String decapitalizeIgnoreAcronyms(String propertyName) {
+    if (propertyName != null &&
+        propertyName.length() >= 2 &&
+        Character.isUpperCase(propertyName.charAt(0)) &&
+        Character.isUpperCase(propertyName.charAt(1))) {
+      return propertyName;
+    }
+    return decapitalize(propertyName);
+  }
+
+  /**
+   * Returns the {@code propertyName} with its first character in lower case.
+   */
+  public static String decapitalize(String propertyName) {
+    if (propertyName == null || propertyName.length() == 0) {
+      return propertyName;
+    }
+    return Character.toLowerCase(propertyName.charAt(0)) + propertyName.substring(1);
+  }
+}


### PR DESCRIPTION
Starting with JDK9, the `java.beans` package is defined inside
the `java.desktop` module which is ~10MiB in size. Applications
wanting to run on a minimized JVM (via jlink) should not need
to pull in 10MiB to use Auto.

------

I work on Bazel (https://bazel.build) and we are happy users of Auto. A Bazel binary ships with an embedded JDK and we are currently working on reducing our binary size. We can run with a JDK as small as 19 MiB, but the jdk.desktop module blows this up to 29 MiB. It would be great if we didn't have to depend on it. Thanks!

cc: @meisterT