### PR TITLE
Moe Sync

### DIFF
--- a/value/src/main/java/com/google/auto/value/processor/autovalue.vm
+++ b/value/src/main/java/com/google/auto/value/processor/autovalue.vm
@@ -145,7 +145,7 @@ ${modifiers}class $subclass$formalTypes extends $origClass$actualTypes {
       $origClass$wildcardTypes that = ($origClass$wildcardTypes) o;
       return ##
           #foreach ($p in $props)
-          (#equalsThatExpression ($p))##
+          #equalsThatExpression ($p)##
             #if ($foreach.hasNext)
 
           && ##

--- a/value/src/main/java/com/google/auto/value/processor/equalshashcode.vm
+++ b/value/src/main/java/com/google/auto/value/processor/equalshashcode.vm
@@ -37,6 +37,8 @@
 ## As an example, if $p is the `foo` property and $p.kind is FLOAT,
 ## this becomes `Float.floatToIntBits(this.foo) == Float.floatToIntBits(that.foo())`
 ## or `...that.getFoo()...`.
+## The expression should be surrounded by parentheses if otherwise there might be precedence
+## problems when it is followed by &&.
 ## A reminder that trailing ## here serves to delete the newline, which we don't want in the output.
 #macro (equalsThatExpression $p)
   #if ($p.kind == "FLOAT")
@@ -49,7 +51,7 @@
     `java.util.Arrays`.equals(this.$p, ##
         (that instanceof $subclass) ? (($subclass) that).$p : that.${p.getter}()) ##
   #elseif ($p.nullable)
-    (this.$p == null) ? (that.${p.getter}() == null) : this.${p}.equals(that.${p.getter}()) ##
+    (this.$p == null ? that.${p.getter}() == null : this.${p}.equals(that.${p.getter}())) ##
   #else
     this.${p}.equals(that.${p.getter}()) ##
   #end

--- a/value/src/test/java/com/google/auto/value/processor/AutoValueCompilationTest.java
+++ b/value/src/test/java/com/google/auto/value/processor/AutoValueCompilationTest.java
@@ -101,7 +101,7 @@ public class AutoValueCompilationTest {
             "    }",
             "    if (o instanceof Baz) {",
             "      Baz that = (Baz) o;",
-            "      return (this.buh == that.buh());",
+            "      return this.buh == that.buh();",
             "    }",
             "    return false;",
             "  }",
@@ -195,9 +195,9 @@ public class AutoValueCompilationTest {
             "    }",
             "    if (o instanceof Baz) {",
             "      Baz that = (Baz) o;",
-            "      return (Arrays.equals(this.ints, (that instanceof AutoValue_Baz) "
-                + "? ((AutoValue_Baz) that).ints : that.ints()))",
-            "          && (this.arrays.equals(that.arrays()));",
+            "      return Arrays.equals(this.ints, (that instanceof AutoValue_Baz) "
+                + "? ((AutoValue_Baz) that).ints : that.ints())",
+            "          && this.arrays.equals(that.arrays());",
             "    }",
             "    return false;",
             "  }",
@@ -924,17 +924,17 @@ public class AutoValueCompilationTest {
             "    }",
             "    if (o instanceof Baz) {",
             "      Baz<?> that = (Baz<?>) o;",
-            "      return (this.anInt == that.anInt())",
-            "          && (Arrays.equals(this.aByteArray, "
+            "      return this.anInt == that.anInt()",
+            "          && Arrays.equals(this.aByteArray, "
                 + "(that instanceof AutoValue_Baz) "
-                + "? ((AutoValue_Baz) that).aByteArray : that.aByteArray()))",
-            "          && (Arrays.equals(this.aNullableIntArray, "
+                + "? ((AutoValue_Baz) that).aByteArray : that.aByteArray())",
+            "          && Arrays.equals(this.aNullableIntArray, "
                 + "(that instanceof AutoValue_Baz) "
-                + "? ((AutoValue_Baz) that).aNullableIntArray : that.aNullableIntArray()))",
-            "          && (this.aList.equals(that.aList()))",
-            "          && (this.anImmutableList.equals(that.anImmutableList()))",
-            "          && (this.anOptionalString.equals(that.anOptionalString()))",
-            "          && (this.aNestedAutoValue.equals(that.aNestedAutoValue()));",
+                + "? ((AutoValue_Baz) that).aNullableIntArray : that.aNullableIntArray())",
+            "          && this.aList.equals(that.aList())",
+            "          && this.anImmutableList.equals(that.anImmutableList())",
+            "          && this.anOptionalString.equals(that.anOptionalString())",
+            "          && this.aNestedAutoValue.equals(that.aNestedAutoValue());",
             "    }",
             "    return false;",
             "  }",

--- a/value/src/test/java/com/google/auto/value/processor/ExtensionTest.java
+++ b/value/src/test/java/com/google/auto/value/processor/ExtensionTest.java
@@ -146,7 +146,7 @@ public class ExtensionTest {
             "    }",
             "    if (o instanceof Baz) {",
             "      Baz that = (Baz) o;",
-            "      return (this.foo.equals(that.foo()));",
+            "      return this.foo.equals(that.foo());",
             "    }",
             "    return false;",
             "  }",

--- a/value/src/test/java/com/google/auto/value/processor/PropertyAnnotationsTest.java
+++ b/value/src/test/java/com/google/auto/value/processor/PropertyAnnotationsTest.java
@@ -40,12 +40,6 @@ import org.junit.runners.JUnit4;
  */
 @RunWith(JUnit4.class)
 public class PropertyAnnotationsTest {
-  private static final String PROPERTY_ANNOTATIONS_TEST =
-      PropertyAnnotationsTest.class.getName();
-  private static final String IMPORT_PROPERTY_ANNOTATIONS_TEST =
-      "import " + PROPERTY_ANNOTATIONS_TEST + ";";
-  private static final String IMPORT_JAVAX_ANNOTATION_NULLABLE =
-      "import javax.annotation.Nullable;";
   private static final String TEST_ANNOTATION =
       "@PropertyAnnotationsTest.TestAnnotation";
   private static final String TEST_ARRAY_ANNOTATION =
@@ -237,7 +231,7 @@ public class PropertyAnnotationsTest {
                   "    }",
                   "    if (o instanceof Baz) {",
                   "      Baz that = (Baz) o;",
-                  "      return (this.buh == that.buh());",
+                  "      return this.buh == that.buh();",
                   "    }",
                   "    return false;",
                   "  }",


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Remove unnecessary parentheses from the generated equals(Object) method.

Fixes https://github.com/google/auto/issues/670.

RELNOTES=Remove unnecessary parentheses from the generated equals(Object) method in @AutoValue classes.

46e0bf4c68f227136ec689a72f084cd0a4d4802b

-------

<p> Have MemoizeExtension recognise @Nullable as a type annotation.

It currently only recognises @Nullable as a method annotation, typically for javax.annotation.Nullable, but does not recognise the TYPE_USE version from the checker framework.

We also annotate the corresponding constructor parameter, though currently only for the TYPE_USE case.

While testing this I discovered that we can pick up two versions of MemoizeExtension because it changed packages. Specifically I saw Maven picking up AutoValue 1.5.3 via compile-testing. The way ServiceLoader works means that we will load and run both versions of MemoizeExtension in this case. So I added a hack to AutoValueProcessor so it will ignore the old version if it sees it.

RELNOTES=MemoizeExtension recognises @Nullable type annotations, not just method annotations.

8e13fa94c7cf9e6b5f99029c37f02d69f139585c