### PR TITLE
Allow extensions to declare their own options/supported annotations

### DIFF
--- a/value/src/main/java/com/google/auto/value/extension/AutoValueExtension.java
+++ b/value/src/main/java/com/google/auto/value/extension/AutoValueExtension.java
@@ -22,7 +22,6 @@ import java.util.Map;
 import java.util.Set;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.annotation.processing.Processor;
-import javax.annotation.processing.SupportedAnnotationTypes;
 import javax.annotation.processing.SupportedOptions;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeElement;
@@ -189,27 +188,6 @@ public abstract class AutoValueExtension {
       } else {
         return ImmutableSet.copyOf(so.value());
       }
-  }
-
-  /**
-   * Analogous to {@link Processor#getSupportedAnnotationTypes()}, here to allow extensions to
-   * report their own.
-   *
-   * <p>By default - if the extension class is annotated with {@link
-   * SupportedAnnotationTypes}, this will return an unmodifiable set with the
-   * same set of strings as the annotation. If the class is not so
-   * annotated, an empty set is returned.
-   *
-   * @return the names of the annotation types supported by this extension
-   * @see SupportedAnnotationTypes
-   */
-  public Set<String> getSupportedAnnotationTypes() {
-    SupportedAnnotationTypes sat = this.getClass().getAnnotation(SupportedAnnotationTypes.class);
-    if  (sat == null) {
-      return Collections.emptySet();
-    } else {
-      return ImmutableSet.copyOf(sat.value());
-    }
   }
 
   /**

--- a/value/src/main/java/com/google/auto/value/extension/AutoValueExtension.java
+++ b/value/src/main/java/com/google/auto/value/extension/AutoValueExtension.java
@@ -208,7 +208,7 @@ public abstract class AutoValueExtension {
    */
   public Set<String> getSupportedOptions() {
       SupportedOptions so = this.getClass().getAnnotation(SupportedOptions.class);
-      if  (so == null) {
+      if (so == null) {
         return Collections.emptySet();
       } else {
         return ImmutableSet.copyOf(so.value());

--- a/value/src/main/java/com/google/auto/value/extension/AutoValueExtension.java
+++ b/value/src/main/java/com/google/auto/value/extension/AutoValueExtension.java
@@ -15,10 +15,14 @@
  */
 package com.google.auto.value.extension;
 
+import com.google.common.collect.ImmutableSet;
+
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 import javax.annotation.processing.ProcessingEnvironment;
+import javax.annotation.processing.SupportedAnnotationTypes;
+import javax.annotation.processing.SupportedOptions;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeElement;
 
@@ -162,6 +166,100 @@ public abstract class AutoValueExtension {
    */
   public IncrementalExtensionType incrementalType(ProcessingEnvironment processingEnvironment) {
     return IncrementalExtensionType.UNKNOWN;
+  }
+
+  /**
+   * Returns the options recognized by this extension.  An
+   * implementation of the processing tool must provide a way to
+   * pass extension-specific options distinctly from options passed
+   * to the tool itself, see {@link ProcessingEnvironment#getOptions
+   * getOptions}.
+   *
+   * <p>Each string returned in the set must be a period separated
+   * sequence of {@linkplain
+   * javax.lang.model.SourceVersion#isIdentifier identifiers}:
+   *
+   * <blockquote>
+   * <dl>
+   * <dt><i>SupportedOptionString:</i>
+   * <dd><i>Identifiers</i>
+   *
+   * <dt><i>Identifiers:</i>
+   * <dd> <i>Identifier</i>
+   * <dd> <i>Identifier</i> {@code .} <i>Identifiers</i>
+   *
+   * <dt><i>Identifier:</i>
+   * <dd>Syntactic identifier, including keywords and literals
+   * </dl>
+   * </blockquote>
+   *
+   * <p> A tool might use this information to determine if any
+   * options provided by a user are unrecognized by any extension,
+   * in which case it may wish to report a warning.
+   *
+   * <p>If the extension class is annotated with {@link
+   * SupportedOptions}, return an unmodifiable set with the same set
+   * of strings as the annotation.  If the class is not so
+   * annotated, an empty set is returned.
+   *
+   * @return the set of options recognized by this extension or an
+   *         empty collection if none
+   * @see SupportedOptions
+   */
+  public Set<String> getSupportedOptions() {
+      SupportedOptions so = this.getClass().getAnnotation(SupportedOptions.class);
+      if  (so == null) {
+        return Collections.emptySet();
+      } else {
+        return ImmutableSet.copyOf(so.value());
+      }
+  }
+
+  /**
+   * Returns the names of the annotation types supported by this
+   * extension.  An element of the result may be the canonical
+   * (fully qualified) name of a supported annotation type.
+   * Alternately it may be of the form &quot;<tt><i>name</i>.*</tt>&quot;
+   * representing the set of all annotation types with canonical
+   * names beginning with &quot;<tt><i>name.</i></tt>&quot;.  Finally, {@code
+   * "*"} by itself represents the set of all annotation types,
+   * including the empty set.  Note that a extension should not
+   * claim {@code "*"} unless it is actually processing all files;
+   * claiming unnecessary annotations may cause a performance
+   * slowdown in some environments.
+   *
+   * <p>Each string returned in the set must be accepted by the
+   * following grammar:
+   *
+   * <blockquote>
+   * <dl>
+   * <dt><i>SupportedAnnotationTypeString:</i>
+   * <dd><i>TypeName</i> <i>DotStar</i><sub><i>opt</i></sub>
+   * <dd><tt>*</tt>
+   *
+   * <dt><i>DotStar:</i>
+   * <dd><tt>.</tt> <tt>*</tt>
+   * </dl>
+   * </blockquote>
+   *
+   * where <i>TypeName</i> is as defined in
+   * <cite>The Java&trade; Language Specification</cite>.
+   *
+   * <p>If the extension class is annotated with {@link
+   * SupportedAnnotationTypes}, return an unmodifiable set with the
+   * same set of strings as the annotation.  If the class is not so
+   * annotated, an empty set is returned.
+   *
+   * @return the names of the annotation types supported by this extension
+   * @see SupportedAnnotationTypes
+   */
+  public Set<String> getSupportedAnnotationTypes() {
+    SupportedAnnotationTypes sat = this.getClass().getAnnotation(SupportedAnnotationTypes.class);
+    if  (sat == null) {
+      return Collections.emptySet();
+    } else {
+      return ImmutableSet.copyOf(sat.value());
+    }
   }
 
   /**

--- a/value/src/main/java/com/google/auto/value/extension/AutoValueExtension.java
+++ b/value/src/main/java/com/google/auto/value/extension/AutoValueExtension.java
@@ -173,9 +173,9 @@ public abstract class AutoValueExtension {
    * Analogous to {@link Processor#getSupportedOptions()}, here to allow extensions to report their
    * own.
    *
-   * <p>If the extension class is annotated with {@link
-   * SupportedOptions}, return an unmodifiable set with the same set
-   * of strings as the annotation.  If the class is not so
+   * <p>By default - if the extension class is annotated with {@link
+   * SupportedOptions}, this will return an unmodifiable set with the same set
+   * of strings as the annotation. If the class is not so
    * annotated, an empty set is returned.
    *
    * @return the set of options recognized by this extension or an
@@ -195,9 +195,9 @@ public abstract class AutoValueExtension {
    * Analogous to {@link Processor#getSupportedAnnotationTypes()}, here to allow extensions to
    * report their own.
    *
-   * <p>If the extension class is annotated with {@link
-   * SupportedAnnotationTypes}, return an unmodifiable set with the
-   * same set of strings as the annotation.  If the class is not so
+   * <p>By default - if the extension class is annotated with {@link
+   * SupportedAnnotationTypes}, this will return an unmodifiable set with the
+   * same set of strings as the annotation. If the class is not so
    * annotated, an empty set is returned.
    *
    * @return the names of the annotation types supported by this extension

--- a/value/src/main/java/com/google/auto/value/extension/AutoValueExtension.java
+++ b/value/src/main/java/com/google/auto/value/extension/AutoValueExtension.java
@@ -21,6 +21,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 import javax.annotation.processing.ProcessingEnvironment;
+import javax.annotation.processing.Processor;
 import javax.annotation.processing.SupportedAnnotationTypes;
 import javax.annotation.processing.SupportedOptions;
 import javax.lang.model.element.ExecutableElement;
@@ -169,33 +170,8 @@ public abstract class AutoValueExtension {
   }
 
   /**
-   * Returns the options recognized by this extension.  An
-   * implementation of the processing tool must provide a way to
-   * pass extension-specific options distinctly from options passed
-   * to the tool itself, see {@link ProcessingEnvironment#getOptions
-   * getOptions}.
-   *
-   * <p>Each string returned in the set must be a period separated
-   * sequence of {@linkplain
-   * javax.lang.model.SourceVersion#isIdentifier identifiers}:
-   *
-   * <blockquote>
-   * <dl>
-   * <dt><i>SupportedOptionString:</i>
-   * <dd><i>Identifiers</i>
-   *
-   * <dt><i>Identifiers:</i>
-   * <dd> <i>Identifier</i>
-   * <dd> <i>Identifier</i> {@code .} <i>Identifiers</i>
-   *
-   * <dt><i>Identifier:</i>
-   * <dd>Syntactic identifier, including keywords and literals
-   * </dl>
-   * </blockquote>
-   *
-   * <p> A tool might use this information to determine if any
-   * options provided by a user are unrecognized by any extension,
-   * in which case it may wish to report a warning.
+   * Analogous to {@link Processor#getSupportedOptions()}, here to allow extensions to report their
+   * own.
    *
    * <p>If the extension class is annotated with {@link
    * SupportedOptions}, return an unmodifiable set with the same set
@@ -216,34 +192,8 @@ public abstract class AutoValueExtension {
   }
 
   /**
-   * Returns the names of the annotation types supported by this
-   * extension.  An element of the result may be the canonical
-   * (fully qualified) name of a supported annotation type.
-   * Alternately it may be of the form &quot;<tt><i>name</i>.*</tt>&quot;
-   * representing the set of all annotation types with canonical
-   * names beginning with &quot;<tt><i>name.</i></tt>&quot;.  Finally, {@code
-   * "*"} by itself represents the set of all annotation types,
-   * including the empty set.  Note that a extension should not
-   * claim {@code "*"} unless it is actually processing all files;
-   * claiming unnecessary annotations may cause a performance
-   * slowdown in some environments.
-   *
-   * <p>Each string returned in the set must be accepted by the
-   * following grammar:
-   *
-   * <blockquote>
-   * <dl>
-   * <dt><i>SupportedAnnotationTypeString:</i>
-   * <dd><i>TypeName</i> <i>DotStar</i><sub><i>opt</i></sub>
-   * <dd><tt>*</tt>
-   *
-   * <dt><i>DotStar:</i>
-   * <dd><tt>.</tt> <tt>*</tt>
-   * </dl>
-   * </blockquote>
-   *
-   * where <i>TypeName</i> is as defined in
-   * <cite>The Java&trade; Language Specification</cite>.
+   * Analogous to {@link Processor#getSupportedAnnotationTypes()}, here to allow extensions to
+   * report their own.
    *
    * <p>If the extension class is annotated with {@link
    * SupportedAnnotationTypes}, return an unmodifiable set with the

--- a/value/src/main/java/com/google/auto/value/extension/memoized/processor/MemoizeExtension.java
+++ b/value/src/main/java/com/google/auto/value/extension/memoized/processor/MemoizeExtension.java
@@ -57,10 +57,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-
 import javax.annotation.processing.Messager;
 import javax.annotation.processing.ProcessingEnvironment;
-import javax.annotation.processing.SupportedAnnotationTypes;
 import javax.lang.model.SourceVersion;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.ExecutableElement;
@@ -73,7 +71,6 @@ import javax.lang.model.util.Types;
 import javax.tools.Diagnostic.Kind;
 
 /** An extension that implements the {@link Memoized} contract. */
-@SupportedAnnotationTypes(MEMOIZED_NAME)
 @AutoService(AutoValueExtension.class)
 public final class MemoizeExtension extends AutoValueExtension {
   private static final ImmutableSet<String> DO_NOT_PULL_DOWN_ANNOTATIONS =

--- a/value/src/main/java/com/google/auto/value/extension/memoized/processor/MemoizeExtension.java
+++ b/value/src/main/java/com/google/auto/value/extension/memoized/processor/MemoizeExtension.java
@@ -57,8 +57,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+
 import javax.annotation.processing.Messager;
 import javax.annotation.processing.ProcessingEnvironment;
+import javax.annotation.processing.SupportedAnnotationTypes;
 import javax.lang.model.SourceVersion;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.ExecutableElement;
@@ -71,6 +73,7 @@ import javax.lang.model.util.Types;
 import javax.tools.Diagnostic.Kind;
 
 /** An extension that implements the {@link Memoized} contract. */
+@SupportedAnnotationTypes(MEMOIZED_NAME)
 @AutoService(AutoValueExtension.class)
 public final class MemoizeExtension extends AutoValueExtension {
   private static final ImmutableSet<String> DO_NOT_PULL_DOWN_ANNOTATIONS =

--- a/value/src/main/java/com/google/auto/value/processor/AutoValueProcessor.java
+++ b/value/src/main/java/com/google/auto/value/processor/AutoValueProcessor.java
@@ -46,6 +46,7 @@ import java.util.Set;
 
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.annotation.processing.Processor;
+import javax.annotation.processing.SupportedAnnotationTypes;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
@@ -63,6 +64,7 @@ import net.ltgt.gradle.incap.IncrementalAnnotationProcessorType;
  * @see <a href="https://github.com/google/auto/tree/master/value">AutoValue User's Guide</a>
  * @author Éamonn McManus
  */
+@SupportedAnnotationTypes(AUTO_VALUE_NAME)
 @AutoService(Processor.class)
 @IncrementalAnnotationProcessor(IncrementalAnnotationProcessorType.DYNAMIC)
 public class AutoValueProcessor extends AutoValueOrOneOfProcessor {
@@ -125,17 +127,6 @@ public class AutoValueProcessor extends AutoValueOrOneOfProcessor {
         extensions = ImmutableList.of();
       }
     }
-  }
-
-  @Override
-  public Set<String> getSupportedAnnotationTypes() {
-    return ImmutableSet.<String>builder()
-        .add(AUTO_VALUE_NAME)
-        .addAll(extensions.stream()
-            .map(AutoValueExtension::getSupportedAnnotationTypes)
-            .flatMap(Set::stream)
-            .collect(toImmutableSet()))
-        .build();
   }
 
   @Override

--- a/value/src/test/java/com/google/auto/value/processor/ExtensionTest.java
+++ b/value/src/test/java/com/google/auto/value/processor/ExtensionTest.java
@@ -661,7 +661,7 @@ public class ExtensionTest {
   }
 
   @SupportedOptions(CustomAnnotation.CUSTOM_OPTION)
-  @SupportedAnnotationTypes("com.google.auto.value.processor.ExtensionTest$CustomAnnotation")
+  @SupportedAnnotationTypes("com.google.auto.value.processor.ExtensionTest.CustomAnnotation")
   static class ExtensionWithAnnotatedOptions extends AutoValueExtension {
 
     @Override

--- a/value/src/test/java/com/google/auto/value/processor/ExtensionTest.java
+++ b/value/src/test/java/com/google/auto/value/processor/ExtensionTest.java
@@ -40,7 +40,6 @@ import java.util.Set;
 import java.util.jar.JarOutputStream;
 import java.util.zip.ZipEntry;
 import javax.annotation.processing.Filer;
-import javax.annotation.processing.SupportedAnnotationTypes;
 import javax.annotation.processing.SupportedOptions;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeElement;
@@ -632,12 +631,9 @@ public class ExtensionTest {
     ExtensionWithAnnotatedOptions extension = new ExtensionWithAnnotatedOptions();
 
     // Ensure default annotation support works
-    assertTrue(extension.getSupportedAnnotationTypes().contains(CustomAnnotation.class.getCanonicalName()));
     assertTrue(extension.getSupportedOptions().contains(CustomAnnotation.CUSTOM_OPTION));
 
     // Ensure it's carried over to the AutoValue processor
-    assertTrue(new AutoValueProcessor(ImmutableList.of(extension)).getSupportedAnnotationTypes()
-        .contains(CustomAnnotation.class.getCanonicalName()));
     assertTrue(new AutoValueProcessor(ImmutableList.of(extension)).getSupportedOptions()
         .contains(CustomAnnotation.CUSTOM_OPTION));
   }
@@ -650,8 +646,6 @@ public class ExtensionTest {
     ExtensionWithImplementedOptions extension = new ExtensionWithImplementedOptions();
 
     // Ensure it's carried over to the AutoValue processor
-    assertTrue(new AutoValueProcessor(ImmutableList.of(extension)).getSupportedAnnotationTypes()
-        .contains(CustomAnnotation.class.getCanonicalName()));
     assertTrue(new AutoValueProcessor(ImmutableList.of(extension)).getSupportedOptions()
         .contains(CustomAnnotation.CUSTOM_OPTION));
   }
@@ -661,7 +655,6 @@ public class ExtensionTest {
   }
 
   @SupportedOptions(CustomAnnotation.CUSTOM_OPTION)
-  @SupportedAnnotationTypes("com.google.auto.value.processor.ExtensionTest.CustomAnnotation")
   static class ExtensionWithAnnotatedOptions extends AutoValueExtension {
 
     @Override
@@ -675,11 +668,6 @@ public class ExtensionTest {
     @Override
     public Set<String> getSupportedOptions() {
       return ImmutableSet.of(CustomAnnotation.CUSTOM_OPTION);
-    }
-
-    @Override
-    public Set<String> getSupportedAnnotationTypes() {
-      return ImmutableSet.of(CustomAnnotation.class.getCanonicalName());
     }
 
     @Override


### PR DESCRIPTION
This is a proposal API improvement to allow extensions to supply their own processing options and supported annotations.

Examples of this include the auto-value-gson and auto-value-moshi extensions, both of which have separate annotations that they can consumer during processing.

Example issue of where this affects users today: https://github.com/rharter/auto-value-gson/issues/128

~~The `@Memoized` extension today would also benefit from this~~ Reverted, as it doesn't actually need it since it's just looked up on the properties as-needed rather than fetched via processor APIs.

From a high level, this is designed exactly like the APIs in `Processor` itself, and borrows the automatic-annotation-resolving `AbstractProcessor` implementation for default behavior.