### PR TITLE
Moe Sync

### DIFF
--- a/common/src/test/java/com/google/auto/common/OverridesTest.java
+++ b/common/src/test/java/com/google/auto/common/OverridesTest.java
@@ -75,12 +75,14 @@ import org.junit.runners.model.Statement;
  */
 @RunWith(Parameterized.class)
 public class OverridesTest {
+  private static final ImmutableSet<String> TOO_NEW_FOR_ECJ = ImmutableSet.of("9", "10", "11");
+
   @Parameterized.Parameters(name = "{0}")
   public static List<Object[]> data() {
     List<Object[]> compilerTypes = new ArrayList<Object[]>();
     compilerTypes.add(new Object[] {CompilerType.JAVAC});
-    if (!"9".equals(JAVA_SPECIFICATION_VERSION.value())) {
-      // TODO(emcmanus): make this test pass with ECJ on Java 9.
+    if (!TOO_NEW_FOR_ECJ.contains(JAVA_SPECIFICATION_VERSION.value())) {
+      // TODO(emcmanus): make this test pass with ECJ on Java > 8.
       // Currently it complains because it can't find java.lang.Object. Probably we need a newer
       // version of ECJ.
       compilerTypes.add(new Object[] {CompilerType.ECJ});

--- a/factory/src/it/functional/pom.xml
+++ b/factory/src/it/functional/pom.xml
@@ -17,6 +17,13 @@
 <!-- TODO(gak): see if we can manage these dependencies any better -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <parent>
+    <groupId>com.google.auto</groupId>
+    <artifactId>auto-parent</artifactId>
+    <version>7</version>
+  </parent>
+
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.auto.value.it.functional</groupId>
   <artifactId>functional</artifactId>
@@ -31,13 +38,11 @@
     <dependency>
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>
-      <version>3.0.2</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>23.4-jre</version>
     </dependency>
     <dependency>
       <groupId>com.google.inject</groupId>
@@ -58,13 +63,11 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.12</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.google.truth</groupId>
       <artifactId>truth</artifactId>
-      <version>0.36</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/service/annotations/pom.xml
+++ b/service/annotations/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.google.auto</groupId>
     <artifactId>auto-parent</artifactId>
-    <version>6</version>
+    <version>7</version>
   </parent>
 
   <groupId>com.google.auto.service</groupId>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.google.auto</groupId>
     <artifactId>auto-parent</artifactId>
-    <version>6</version>
+    <version>7</version>
   </parent>
 
   <groupId>com.google.auto.service</groupId>

--- a/service/processor/pom.xml
+++ b/service/processor/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.google.auto</groupId>
     <artifactId>auto-parent</artifactId>
-    <version>6</version>
+    <version>7</version>
   </parent>
 
   <groupId>com.google.auto.service</groupId>

--- a/value/pom.xml
+++ b/value/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.google.auto</groupId>
     <artifactId>auto-parent</artifactId>
-    <version>6</version>
+    <version>7</version>
   </parent>
 
   <groupId>com.google.auto.value</groupId>

--- a/value/src/it/functional/pom.xml
+++ b/value/src/it/functional/pom.xml
@@ -51,12 +51,10 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>23.5-jre</version>
     </dependency>
     <dependency>
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>
-      <version>3.0.2</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -67,19 +65,16 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.12</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava-testlib</artifactId>
-      <version>23.5-jre</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.google.truth</groupId>
       <artifactId>truth</artifactId>
-      <version>0.36</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/value/src/it/gwtserializer/pom.xml
+++ b/value/src/it/gwtserializer/pom.xml
@@ -65,19 +65,16 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>23.5-jre</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava-gwt</artifactId>
-      <version>23.5-jre</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.12</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Ignore ECJ test in JDK 10 and 11 since ECJ doesn't work for us in those versions of the JDK.

b3d49ff80772b508a4103fa85098c3de6c61fd6f

-------

<p> Update to auto-parent 7 to get the latest version of Guava

Along the way, also clean up some explicit versions that are set in auto-parent

Fixes https://github.com/google/auto/issues/683

ce333c488246cecd0c49c66a664c475e3ed0b0f5