### PR TITLE
Moe Sync

### DIFF
--- a/value/src/it/functional/src/test/java/com/google/auto/value/AutoValueJava8Test.java
+++ b/value/src/it/functional/src/test/java/com/google/auto/value/AutoValueJava8Test.java
@@ -157,6 +157,15 @@ public class AutoValueJava8Test {
   }
 
   @Test
+  public void testNullablePropertyImplementationIsNullable() throws NoSuchMethodException {
+    Method method =
+        AutoValue_AutoValueJava8Test_NullableProperties.class.getDeclaredMethod("nullableString");
+    assertThat(method.getAnnotatedReturnType().getAnnotations())
+        .asList()
+        .contains(nullable());
+  }
+
+  @Test
   public void testNullablePropertyConstructorParameterIsNullable() throws NoSuchMethodException {
     Constructor<?> constructor =
         AutoValue_AutoValueJava8Test_NullableProperties.class.getDeclaredConstructor(
@@ -165,6 +174,44 @@ public class AutoValueJava8Test {
       assertThat(constructor.getAnnotatedParameterTypes()[0].getAnnotations())
           .asList()
           .contains(nullable());
+    } catch (AssertionError e) {
+      if (javacHandlesTypeAnnotationsCorrectly) {
+        throw e;
+      }
+    }
+  }
+
+  @AutoValue
+  abstract static class NullablePropertiesNotCopied {
+    @AutoValue.CopyAnnotations(exclude = Nullable.class)
+    abstract @Nullable String nullableString();
+
+    abstract int randomInt();
+
+    NullablePropertiesNotCopied create(String notNullableAfterAll, int randomInt) {
+      return new AutoValue_AutoValueJava8Test_NullablePropertiesNotCopied(
+          notNullableAfterAll, randomInt);
+    }
+  }
+
+  @Test
+  public void testExcludedNullablePropertyImplementation() throws NoSuchMethodException {
+    Method method = AutoValue_AutoValueJava8Test_NullablePropertiesNotCopied.class
+        .getDeclaredMethod("nullableString");
+    assertThat(method.getAnnotatedReturnType().getAnnotations())
+        .asList()
+        .doesNotContain(nullable());
+  }
+
+  @Test
+  public void testExcludedNullablePropertyConstructorParameter() throws NoSuchMethodException {
+    Constructor<?> constructor =
+        AutoValue_AutoValueJava8Test_NullablePropertiesNotCopied.class.getDeclaredConstructor(
+            String.class, int.class);
+    try {
+      assertThat(constructor.getAnnotatedParameterTypes()[0].getAnnotations())
+          .asList()
+          .doesNotContain(nullable());
     } catch (AssertionError e) {
       if (javacHandlesTypeAnnotationsCorrectly) {
         throw e;
@@ -267,6 +314,7 @@ public class AutoValueJava8Test {
   }
 
   @AutoValue
+  @SuppressWarnings("AutoValueImmutableFields")
   abstract static class PrimitiveArrays {
     @SuppressWarnings("mutable")
     abstract boolean[] booleans();
@@ -428,6 +476,7 @@ public class AutoValueJava8Test {
   }
 
   @AutoValue
+  @SuppressWarnings("AutoValueImmutableFields")
   public abstract static class BuilderWithUnprefixedGetters<T extends Comparable<T>> {
     public abstract ImmutableList<T> list();
 
@@ -501,6 +550,7 @@ public class AutoValueJava8Test {
   }
 
   @AutoValue
+  @SuppressWarnings("AutoValueImmutableFields")
   public abstract static class BuilderWithPrefixedGetters<T extends Comparable<T>> {
     public abstract ImmutableList<T> getList();
 
@@ -641,7 +691,7 @@ public class AutoValueJava8Test {
    * implementation class.
    */
   @Test
-  public void testTypeAnnotationCopiedToImplementation() throws ReflectiveOperationException {
+  public void testTypeAnnotationCopiedToImplementation() {
     @Nullable String nullableString = "blibby";
     AnnotatedTypeParameter<@Nullable String> x = AnnotatedTypeParameter.create(nullableString);
     Class<?> c = x.getClass();
@@ -674,8 +724,7 @@ public class AutoValueJava8Test {
    * implementation class.
    */
   @Test
-  public void testTypeAnnotationOnBuilderCopiedToImplementation()
-      throws ReflectiveOperationException {
+  public void testTypeAnnotationOnBuilderCopiedToImplementation() {
     AnnotatedTypeParameterWithBuilder.Builder<@Nullable String> builder =
         AnnotatedTypeParameterWithBuilder.builder();
     Class<?> c = builder.getClass();

--- a/value/src/main/java/com/google/auto/value/AutoValue.java
+++ b/value/src/main/java/com/google/auto/value/AutoValue.java
@@ -124,8 +124,10 @@ public @interface AutoValue {
    *   }</pre>
    *
    * <p>When the <i>type</i> of an {@code @AutoValue} property method has annotations, those are
-   * part of the type, so they are always copied to the implementation of the method.
-   * {@code @CopyAnnotations} has no effect here. For example, suppose {@code @Confidential} is a
+   * part of the type, so by default they are copied to the implementation of the method. But if
+   * a type annotation is mentioned in {@code exclude} then it is not copied.
+   *
+   * <p>For example, suppose {@code @Confidential} is a
    * {@link java.lang.annotation.ElementType#TYPE_USE TYPE_USE} annotation:
    *
    * <pre>
@@ -141,7 +143,15 @@ public @interface AutoValue {
    *   }</pre>
    *
    * Then the implementation of the {@code name()} method will also have return type
-   * {@code @Confidential String}.
+   * {@code @Confidential String}. But if {@code name()} were written like this...
+   *
+   * <pre>
+   *
+   *     {@code @AutoValue.CopyAnnotations(exclude = Confidential.class)}
+   *     abstract {@code @}Confidential String name();</pre>
+   *
+   * <p>...then the implementation of {@code name()} would have return type {@code String} without
+   * the annotation.
    *
    * @author Carmi Grushko
    */

--- a/value/src/main/java/com/google/auto/value/processor/TypeMirrorSet.java
+++ b/value/src/main/java/com/google/auto/value/processor/TypeMirrorSet.java
@@ -17,7 +17,6 @@ package com.google.auto.value.processor;
 
 import com.google.auto.common.MoreTypes;
 import com.google.common.base.Equivalence;
-import com.google.common.base.Equivalence.Wrapper;
 import com.google.common.collect.ImmutableList;
 import java.util.AbstractSet;
 import java.util.Collection;
@@ -32,8 +31,7 @@ import javax.lang.model.type.TypeMirror;
  * @author emcmanus@google.com (Éamonn McManus)
  */
 class TypeMirrorSet extends AbstractSet<TypeMirror> {
-  private final Set<Equivalence.Wrapper<TypeMirror>> wrappers =
-      new LinkedHashSet<Wrapper<TypeMirror>>();
+  private final Set<Equivalence.Wrapper<TypeMirror>> wrappers = new LinkedHashSet<>();
 
   TypeMirrorSet() {}
 

--- a/value/src/test/java/com/google/auto/value/processor/TemplateVarsTest.java
+++ b/value/src/test/java/com/google/auto/value/processor/TemplateVarsTest.java
@@ -248,8 +248,14 @@ public class TemplateVarsTest {
 
     @Override
     public InputStream getResourceAsStream(String resource) {
-      result.add(resource);
-      return new BrokenInputStream(super.getResourceAsStream(resource));
+      // Make sure this is actually the resource we are expecting. If we're using JaCoCo or the
+      // like, we might end up reading some other resource, and we don't want to break that.
+      if (resource.startsWith("com/google/auto")) {
+        result.add(resource);
+        return new BrokenInputStream(super.getResourceAsStream(resource));
+      } else {
+        return super.getResourceAsStream(resource);
+      }
     }
 
     private class BrokenInputStream extends InputStream {


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Update TemplateVarsTest so it doesn't interfere with JaCoCo.

6515eabd92e9d6932f59aaaf2dfe268e99561afe

-------

<p> @CopyAnnotations.exclude now affects type annotations.

Do not copy a type annotation from an abstract property method of an @AutoValue class to the implementation of that method, if there is also a @CopyAnnotations annotation that excludes the type annotation.

Fixes https://github.com/google/auto/issues/682.

RELNOTES=In AutoValue, @CopyAnnotations.exclude now affects type annotations.

3ee205b4a1ad9f866988ea785a0b620c142b9a99