### PR TITLE
Moe Sync

### DIFF
--- a/value/src/main/java/com/google/auto/value/extension/AutoValueExtension.java
+++ b/value/src/main/java/com/google/auto/value/extension/AutoValueExtension.java
@@ -15,10 +15,12 @@
  */
 package com.google.auto.value.extension;
 
-import java.util.Collections;
+import com.google.common.collect.ImmutableSet;
 import java.util.Map;
 import java.util.Set;
 import javax.annotation.processing.ProcessingEnvironment;
+import javax.annotation.processing.Processor;
+import javax.annotation.processing.SupportedOptions;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeElement;
 
@@ -165,6 +167,26 @@ public abstract class AutoValueExtension {
   }
 
   /**
+   * Analogous to {@link Processor#getSupportedOptions()}, here to allow extensions to report their
+   * own.
+   *
+   * <p>By default, if the extension class is annotated with {@link SupportedOptions}, this will
+   * return a set with the strings in the annotation. If the class is not so annotated, an empty set
+   * is returned.
+   *
+   * @return the set of options recognized by this extension or an empty set if none
+   * @see SupportedOptions
+   */
+  public Set<String> getSupportedOptions() {
+    SupportedOptions so = this.getClass().getAnnotation(SupportedOptions.class);
+    if (so == null) {
+      return ImmutableSet.of();
+    } else {
+      return ImmutableSet.copyOf(so.value());
+    }
+  }
+
+  /**
    * Determines whether this Extension applies to the given context.
    *
    * @param context The Context of the code generation for this class.
@@ -210,7 +232,7 @@ public abstract class AutoValueExtension {
    * @param context the Context of the code generation for this class.
    */
   public Set<String> consumeProperties(Context context) {
-    return Collections.emptySet();
+    return ImmutableSet.of();
   }
 
   /**
@@ -232,7 +254,7 @@ public abstract class AutoValueExtension {
    * @param context the Context of the code generation for this class.
    */
   public Set<ExecutableElement> consumeMethods(Context context) {
-    return Collections.emptySet();
+    return ImmutableSet.of();
   }
 
   /**

--- a/value/src/main/java/com/google/auto/value/processor/AutoOneOfProcessor.java
+++ b/value/src/main/java/com/google/auto/value/processor/AutoOneOfProcessor.java
@@ -259,6 +259,9 @@ public class AutoOneOfProcessor extends AutoValueOrOneOfProcessor {
 
   @Override
   Optional<String> nullableAnnotationForMethod(ExecutableElement propertyMethod) {
+    if (nullableAnnotationFor(propertyMethod, propertyMethod.getReturnType()).isPresent()) {
+      errorReporter().reportError("@AutoOneOf properties cannot be @Nullable", propertyMethod);
+    }
     return Optional.empty();
   }
 

--- a/value/src/main/java/com/google/auto/value/processor/AutoValueOrOneOfProcessor.java
+++ b/value/src/main/java/com/google/auto/value/processor/AutoValueOrOneOfProcessor.java
@@ -52,6 +52,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.Set;
 import java.util.function.Predicate;
 import javax.annotation.processing.AbstractProcessor;
@@ -517,6 +518,47 @@ abstract class AutoValueOrOneOfProcessor extends AbstractProcessor {
 
   private static boolean gettersAllPrefixed(Set<ExecutableElement> methods) {
     return prefixedGettersIn(methods).size() == methods.size();
+  }
+
+  /**
+   * Returns an appropriate annotation spelling to indicate the nullability of an element. If the
+   * return value is a non-empty Optional, that indicates that the element is nullable, and the
+   * string should be used to annotate it. If the return value is an empty Optional, the element is
+   * not nullable. The return value can be {@code Optional.of("")}, which indicates that the element
+   * is nullable but that the nullability comes from a type annotation. In this case, the annotation
+   * will appear when the type is written, and must not be specified again. If the Optional contains
+   * a present non-empty string then that string will end with a space.
+   *
+   * @param element the element that might be {@code @Nullable}, either a method or a parameter.
+   * @param elementType the relevant type of the element: the return type for a method, or the
+   *     parameter type for a parameter.
+   */
+  static Optional<String> nullableAnnotationFor(Element element, TypeMirror elementType) {
+    List<? extends AnnotationMirror> typeAnnotations = elementType.getAnnotationMirrors();
+    if (nullableAnnotationIndex(typeAnnotations).isPresent()) {
+      return Optional.of("");
+    }
+    List<? extends AnnotationMirror> elementAnnotations = element.getAnnotationMirrors();
+    OptionalInt nullableAnnotationIndex = nullableAnnotationIndex(elementAnnotations);
+    if (nullableAnnotationIndex.isPresent()) {
+      ImmutableList<String> annotations = annotationStrings(elementAnnotations);
+      return Optional.of(annotations.get(nullableAnnotationIndex.getAsInt()) + " ");
+    } else {
+      return Optional.empty();
+    }
+  }
+
+  private static OptionalInt nullableAnnotationIndex(List<? extends AnnotationMirror> annotations) {
+    for (int i = 0; i < annotations.size(); i++) {
+      if (isNullable(annotations.get(i))) {
+        return OptionalInt.of(i);
+      }
+    }
+    return OptionalInt.empty();
+  }
+
+  private static boolean isNullable(AnnotationMirror annotation) {
+    return annotation.getAnnotationType().asElement().getSimpleName().contentEquals("Nullable");
   }
 
   /**

--- a/value/src/main/java/com/google/auto/value/processor/AutoValueProcessor.java
+++ b/value/src/main/java/com/google/auto/value/processor/AutoValueProcessor.java
@@ -129,22 +129,28 @@ public class AutoValueProcessor extends AutoValueOrOneOfProcessor {
 
   @Override
   public Set<String> getSupportedOptions() {
+    ImmutableSet.Builder<String> builder = ImmutableSet.builder();
     AutoValueExtension.IncrementalExtensionType incrementalType =
         extensions.stream()
             .map(e -> e.incrementalType(processingEnv))
             .min(Comparator.naturalOrder())
             .orElse(AutoValueExtension.IncrementalExtensionType.ISOLATING);
+    builder.add(OMIT_IDENTIFIERS_OPTION).addAll(optionsFor(incrementalType));
+    for (AutoValueExtension extension : extensions) {
+      builder.addAll(extension.getSupportedOptions());
+    }
+    return builder.build();
+  }
+
+  private static ImmutableSet<String> optionsFor(
+      AutoValueExtension.IncrementalExtensionType incrementalType) {
     switch (incrementalType) {
       case ISOLATING:
-        return ImmutableSet.of(
-            OMIT_IDENTIFIERS_OPTION,
-            IncrementalAnnotationProcessorType.ISOLATING.getProcessorOption());
+        return ImmutableSet.of(IncrementalAnnotationProcessorType.ISOLATING.getProcessorOption());
       case AGGREGATING:
-        return ImmutableSet.of(
-            OMIT_IDENTIFIERS_OPTION,
-            IncrementalAnnotationProcessorType.AGGREGATING.getProcessorOption());
+        return ImmutableSet.of(IncrementalAnnotationProcessorType.AGGREGATING.getProcessorOption());
       case UNKNOWN:
-        return ImmutableSet.of(OMIT_IDENTIFIERS_OPTION);
+        return ImmutableSet.of();
     }
     throw new AssertionError(incrementalType);
   }

--- a/value/src/main/java/com/google/auto/value/processor/AutoValueProcessor.java
+++ b/value/src/main/java/com/google/auto/value/processor/AutoValueProcessor.java
@@ -38,7 +38,6 @@ import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
-import java.util.OptionalInt;
 import java.util.ServiceConfigurationError;
 import java.util.ServiceLoader;
 import java.util.Set;
@@ -46,7 +45,6 @@ import javax.annotation.processing.ProcessingEnvironment;
 import javax.annotation.processing.Processor;
 import javax.annotation.processing.SupportedAnnotationTypes;
 import javax.lang.model.element.AnnotationMirror;
-import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeElement;
@@ -435,47 +433,6 @@ public class AutoValueProcessor extends AutoValueOrOneOfProcessor {
   @Override
   Optional<String> nullableAnnotationForMethod(ExecutableElement propertyMethod) {
     return nullableAnnotationFor(propertyMethod, propertyMethod.getReturnType());
-  }
-
-  /**
-   * Returns an appropriate annotation spelling to indicate the nullability of an element. If the
-   * return value is a non-empty Optional, that indicates that the element is nullable, and the
-   * string should be used to annotate it. If the return value is an empty Optional, the element is
-   * not nullable. The return value can be {@code Optional.of("")}, which indicates that the element
-   * is nullable but that the nullability comes from a type annotation. In this case, the annotation
-   * will appear when the type is written, and must not be specified again. If the Optional contains
-   * a present non-empty string then that string will end with a space.
-   *
-   * @param element the element that might be {@code @Nullable}, either a method or a parameter.
-   * @param elementType the relevant type of the element: the return type for a method, or the
-   *     parameter type for a parameter.
-   */
-  static Optional<String> nullableAnnotationFor(Element element, TypeMirror elementType) {
-    List<? extends AnnotationMirror> typeAnnotations = elementType.getAnnotationMirrors();
-    if (nullableAnnotationIndex(typeAnnotations).isPresent()) {
-      return Optional.of("");
-    }
-    List<? extends AnnotationMirror> elementAnnotations = element.getAnnotationMirrors();
-    OptionalInt nullableAnnotationIndex = nullableAnnotationIndex(elementAnnotations);
-    if (nullableAnnotationIndex.isPresent()) {
-      ImmutableList<String> annotations = annotationStrings(elementAnnotations);
-      return Optional.of(annotations.get(nullableAnnotationIndex.getAsInt()) + " ");
-    } else {
-      return Optional.empty();
-    }
-  }
-
-  private static OptionalInt nullableAnnotationIndex(List<? extends AnnotationMirror> annotations) {
-    for (int i = 0; i < annotations.size(); i++) {
-      if (isNullable(annotations.get(i))) {
-        return OptionalInt.of(i);
-      }
-    }
-    return OptionalInt.empty();
-  }
-
-  private static boolean isNullable(AnnotationMirror annotation) {
-    return annotation.getAnnotationType().asElement().getSimpleName().contentEquals("Nullable");
   }
 
   static ImmutableSet<ExecutableElement> prefixedGettersIn(Iterable<ExecutableElement> methods) {

--- a/value/src/main/java/com/google/auto/value/processor/BuilderSpec.java
+++ b/value/src/main/java/com/google/auto/value/processor/BuilderSpec.java
@@ -305,7 +305,7 @@ class BuilderSpec {
       primitiveParameter = parameterType.getKind().isPrimitive();
       this.parameterTypeString = parameterTypeString(setter, parameterType);
       Optional<String> maybeNullable =
-          AutoValueProcessor.nullableAnnotationFor(parameterElement, parameterType);
+          AutoValueOrOneOfProcessor.nullableAnnotationFor(parameterElement, parameterType);
       this.nullableAnnotation = maybeNullable.orElse("");
       boolean nullable = maybeNullable.isPresent();
       this.copyOf = copyOfString(propertyType, parameterType, typeUtils, nullable);

--- a/value/src/test/java/com/google/auto/value/processor/AutoOneOfCompilationTest.java
+++ b/value/src/test/java/com/google/auto/value/processor/AutoOneOfCompilationTest.java
@@ -348,4 +348,34 @@ public class AutoOneOfCompilationTest {
         .inFile(javaFileObject)
         .onLineContaining("frob");
   }
+
+  @Test
+  public void cantBeNullable() {
+    JavaFileObject javaFileObject =
+        JavaFileObjects.forSourceLines(
+            "foo.bar.Pet",
+            "package foo.bar;",
+            "",
+            "import com.google.auto.value.AutoOneOf;",
+            "",
+            "@AutoOneOf(Pet.Kind.class)",
+            "public abstract class Pet {",
+            "  @interface Nullable {}",
+            "",
+            "  public enum Kind {",
+            "    DOG,",
+            "    CAT,",
+            "  }",
+            "  public abstract Kind getKind();",
+            "  public abstract @Nullable String dog();",
+            "  public abstract String cat();",
+            "}");
+    Compilation compilation =
+        javac().withProcessors(new AutoOneOfProcessor()).compile(javaFileObject);
+    assertThat(compilation)
+        .hadErrorContaining("@AutoOneOf properties cannot be @Nullable")
+        .inFile(javaFileObject)
+        .onLineContaining("@Nullable String dog()");
+
+  }
 }


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Allow AutoValue extensions to declare supported options.

The options will then be returned by AutoValueProcessor.getSupportedOptions().

This change is based on code by Zac Sweers. Closes https://github.com/google/auto/pull/680.

RELNOTES=AutoValue extensions can now declare supported options.

1234e5f6be4b17ed207394d1ea1880de9013b426

-------

<p> Make it a compilation error for an @AutoOneOf property to be @Nullable.

The generated code already rejects null values, whether or not @Nullable is present, so this just lets users know earlier that what they are trying is not going to work.

RELNOTES=It is a compilation error for an @AutoOneOf property to be @Nullable since null values are not in fact accepted.

d588bc07e42c892b9fb23f49834eb167be91ce15