### PR TITLE
Autofactory: Support Gradle incremental annotation processing

### DIFF
--- a/factory/pom.xml
+++ b/factory/pom.xml
@@ -77,6 +77,7 @@
       <groupId>net.ltgt.gradle.incap</groupId>
       <artifactId>incap</artifactId>
       <version>0.2</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>net.ltgt.gradle.incap</groupId>

--- a/factory/pom.xml
+++ b/factory/pom.xml
@@ -73,6 +73,17 @@
       <groupId>javax.inject</groupId>
       <artifactId>javax.inject</artifactId>
     </dependency>
+    <dependency>
+      <groupId>net.ltgt.gradle.incap</groupId>
+      <artifactId>incap</artifactId>
+      <version>0.2</version>
+    </dependency>
+    <dependency>
+      <groupId>net.ltgt.gradle.incap</groupId>
+      <artifactId>incap-processor</artifactId>
+      <version>0.2</version>
+      <scope>provided</scope>
+    </dependency>
     <!-- test dependencies -->
     <dependency>
       <groupId>com.google.testing.compile</groupId>

--- a/factory/src/main/java/com/google/auto/factory/processor/AutoFactoryProcessor.java
+++ b/factory/src/main/java/com/google/auto/factory/processor/AutoFactoryProcessor.java
@@ -15,6 +15,8 @@
  */
 package com.google.auto.factory.processor;
 
+import static net.ltgt.gradle.incap.IncrementalAnnotationProcessorType.ISOLATING;
+
 import com.google.auto.common.MoreTypes;
 import com.google.auto.factory.AutoFactory;
 import com.google.auto.factory.Provided;
@@ -51,6 +53,7 @@ import javax.lang.model.util.ElementFilter;
 import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
 import javax.tools.Diagnostic.Kind;
+import net.ltgt.gradle.incap.IncrementalAnnotationProcessor;
 
 /**
  * The annotation processor that generates factories for {@link AutoFactory} annotations.
@@ -58,6 +61,7 @@ import javax.tools.Diagnostic.Kind;
  * @author Gregory Kick
  */
 @AutoService(Processor.class)
+@IncrementalAnnotationProcessor(ISOLATING)
 public final class AutoFactoryProcessor extends AbstractProcessor {
   private FactoryDescriptorGenerator factoryDescriptorGenerator;
   private AutoFactoryDeclaration.Factory declarationFactory;

--- a/factory/src/main/java/com/google/auto/factory/processor/FactoryDescriptor.java
+++ b/factory/src/main/java/com/google/auto/factory/processor/FactoryDescriptor.java
@@ -30,6 +30,7 @@ import java.util.HashSet;
 import java.util.Map.Entry;
 import java.util.Set;
 import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.Element;
 import javax.lang.model.type.TypeMirror;
 
 /**
@@ -48,6 +49,7 @@ abstract class FactoryDescriptor {
       };
 
   abstract String name();
+  abstract Element originatingElement();
   abstract TypeMirror extendingType();
   abstract ImmutableSet<TypeMirror> implementingTypes();
   abstract boolean publicType();
@@ -74,6 +76,7 @@ abstract class FactoryDescriptor {
 
   static FactoryDescriptor create(
       String name,
+      Element originatingElement,
       TypeMirror extendingType,
       ImmutableSet<TypeMirror> implementingTypes,
       boolean publicType,
@@ -131,6 +134,7 @@ abstract class FactoryDescriptor {
 
     return new AutoValue_FactoryDescriptor(
         name,
+        originatingElement,
         extendingType,
         implementingTypes,
         publicType,

--- a/factory/src/main/java/com/google/auto/factory/processor/FactoryWriter.java
+++ b/factory/src/main/java/com/google/auto/factory/processor/FactoryWriter.java
@@ -81,6 +81,8 @@ final class FactoryWriter {
       factory.addModifiers(PUBLIC);
     }
 
+    factory.addOriginatingElement(descriptor.originatingElement());
+
     factory.superclass(TypeName.get(descriptor.extendingType()));
     for (TypeMirror implementingType : descriptor.implementingTypes()) {
       factory.addSuperinterface(TypeName.get(implementingType));


### PR DESCRIPTION
Changes in this PR:
- Make the `AutoFactoryProcessor` [Isolating](https://docs.gradle.org/5.2/userguide/java_plugin.html#isolating_annotation_processors). This is done using the same library/plugin used in AutoValue.
- Propagate the originating element down to the `Filer`. Isolating processors require you to provide the originating element for each file generated with the Filer API. The change makes sure every generate file has an associated originating element, which is the target class annotated with `@AutoFactory` or the enclosing class, in case there is one or more methods/constructors annotated with `@AutoFactory`.

Should fix https://github.com/google/auto/issues/679
Relates to https://github.com/gradle/gradle/issues/5277