### PR TITLE
Moe Sync

### DIFF
--- a/common/src/test/java/com/google/auto/common/AnnotationMirrorsTest.java
+++ b/common/src/test/java/com/google/auto/common/AnnotationMirrorsTest.java
@@ -199,8 +199,10 @@ public class AnnotationMirrorsTest {
     try {
       AnnotationMirrors.getAnnotationValue(annotationOn(TestClassBlah.class), "a");
     } catch (IllegalArgumentException e) {
-      assertThat(e).hasMessage(
-          "@com.google.auto.common.AnnotationMirrorsTest.Outer does not define an element a()");
+      assertThat(e)
+          .hasMessageThat()
+          .isEqualTo(
+              "@com.google.auto.common.AnnotationMirrorsTest.Outer does not define an element a()");
       return;
     }
     fail("Should have thrown.");

--- a/service/annotations/src/main/java/com/google/auto/service/AutoService.java
+++ b/service/annotations/src/main/java/com/google/auto/service/AutoService.java
@@ -23,12 +23,11 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 /**
- * An annotation for service providers as described in {@link java.util.ServiceLoader}. The {@link
- * com.google.auto.service.processor.AutoServiceProcessor} generates the configuration files which
- * allows service providers to be loaded with {@link java.util.ServiceLoader#load(Class)}.
+ * An annotation for service providers as described in {@link java.util.ServiceLoader}. The
+ * annotation processor generates the configuration files that allow the annotated class to be
+ * loaded with {@link java.util.ServiceLoader#load(Class)}.
  *
- * <p>Service providers assert that they conform to the service provider specification.
- * Specifically, they must:
+ * <p>The annotated class must conform to the service provider specification. Specifically, it must:
  *
  * <ul>
  *   <li>be a non-inner, non-anonymous, concrete class

--- a/value/src/it/functional/src/test/java/com/google/auto/value/AutoValueJava8Test.java
+++ b/value/src/it/functional/src/test/java/com/google/auto/value/AutoValueJava8Test.java
@@ -793,34 +793,4 @@ public class AutoValueJava8Test {
     OptionalExtends t = OptionalExtends.builder().setPredicate(predicate).build();
     assertThat(t.predicate()).hasValue(predicate);
   }
-
-  // This example historically compiled because the check for static methods was incomplete.
-  // Since Optional.of(T) erases to Optional.of(Object), we accepted Optional<Integer> as an
-  // argument to Optional.of in order to produce the Optional<? extends Number>. That's wrong,
-  // but when emitting code we considered that since the LHS and RHS were both Optional, we didn't
-  // need to use Optional.of but could just assign them, and it ended up working. So essentially
-  // two bugs related to the abuse of erasure canceled each other out.
-  // Now that we have more precise checking, we need to check assignability rather than equality
-  // between setter parameter and getter return, at least for cases like this.
-  @AutoValue
-  abstract static class OptionalWildcard {
-    abstract Optional<? extends Number> maybeNumber();
-
-    static Builder builder() {
-      return new AutoValue_AutoValueJava8Test_OptionalWildcard.Builder();
-    }
-
-    @AutoValue.Builder
-    abstract static class Builder {
-      abstract Builder setMaybeNumber(Optional<Integer> n);
-      abstract OptionalWildcard build();
-    }
-  }
-
-  @Test
-  public void testOptionalWildcard() {
-    Optional<Integer> five = Optional.of(5);
-    OptionalWildcard t = OptionalWildcard.builder().setMaybeNumber(five).build();
-    assertThat(t.maybeNumber()).hasValue(5);
-  }
 }

--- a/value/src/it/functional/src/test/java/com/google/auto/value/AutoValueJava8Test.java
+++ b/value/src/it/functional/src/test/java/com/google/auto/value/AutoValueJava8Test.java
@@ -525,13 +525,13 @@ public class AutoValueJava8Test {
       builder.list();
       fail("Attempt to retrieve unset list property should have failed");
     } catch (IllegalStateException e) {
-      assertThat(e).hasMessage("Property \"list\" has not been set");
+      assertThat(e).hasMessageThat().isEqualTo("Property \"list\" has not been set");
     }
     try {
       builder.ints();
       fail("Attempt to retrieve unset ints property should have failed");
     } catch (IllegalStateException e) {
-      assertThat(e).hasMessage("Property \"ints\" has not been set");
+      assertThat(e).hasMessageThat().isEqualTo("Property \"ints\" has not been set");
     }
 
     builder.setList(names);
@@ -599,7 +599,7 @@ public class AutoValueJava8Test {
       builder.getList();
       fail("Attempt to retrieve unset list property should have failed");
     } catch (IllegalStateException e) {
-      assertThat(e).hasMessage("Property \"list\" has not been set");
+      assertThat(e).hasMessageThat().isEqualTo("Property \"list\" has not been set");
     }
 
     builder.setList(names);

--- a/value/src/it/functional/src/test/java/com/google/auto/value/AutoValueTest.java
+++ b/value/src/it/functional/src/test/java/com/google/auto/value/AutoValueTest.java
@@ -1923,7 +1923,7 @@ public class AutoValueTest {
       if (omitIdentifiers) {
         assertThat(e).hasMessageThat().isNull();
       } else {
-        assertThat(e).hasMessage("Property \"list\" has not been set");
+        assertThat(e).hasMessageThat().isEqualTo("Property \"list\" has not been set");
       }
     }
     try {
@@ -1933,7 +1933,7 @@ public class AutoValueTest {
       if (omitIdentifiers) {
         assertThat(e).hasMessageThat().isNull();
       } else {
-        assertThat(e).hasMessage("Property \"ints\" has not been set");
+        assertThat(e).hasMessageThat().isEqualTo("Property \"ints\" has not been set");
       }
     }
 
@@ -2014,7 +2014,7 @@ public class AutoValueTest {
       if (omitIdentifiers) {
         assertThat(e).hasMessageThat().isNull();
       } else {
-        assertThat(e).hasMessage("Property \"list\" has not been set");
+        assertThat(e).hasMessageThat().isEqualTo("Property \"list\" has not been set");
       }
     }
 
@@ -2307,7 +2307,7 @@ public class AutoValueTest {
       if (omitIdentifiers) {
         assertThat(e).hasMessageThat().isNull();
       } else {
-        assertThat(e).hasMessage("Cannot set things after calling thingsBuilder()");
+        assertThat(e).hasMessageThat().isEqualTo("Cannot set things after calling thingsBuilder()");
       }
     }
   }

--- a/value/src/it/functional/src/test/java/com/google/auto/value/AutoValueTest.java
+++ b/value/src/it/functional/src/test/java/com/google/auto/value/AutoValueTest.java
@@ -3071,4 +3071,57 @@ public class AutoValueTest {
     GenericExtends g = GenericExtends.builder().setMetrics(ints).build();
     assertThat(g.metrics()).isEqualTo(ints);
   }
+
+  abstract static class Parent<T> {
+    abstract List<T> getList();
+  }
+
+  @AutoValue
+  abstract static class Child extends Parent<String> {
+    static Builder builder() {
+      return new AutoValue_AutoValueTest_Child.Builder();
+    }
+
+    @AutoValue.Builder
+    abstract static class Builder {
+      abstract Builder setList(List<String> list);
+      abstract Child build();
+    }
+  }
+
+  @Test
+  public void nonGenericExtendsGeneric() {
+    List<String> list = ImmutableList.of("foo", "bar", "baz");
+    Child child = Child.builder().setList(list).build();
+    assertThat(child.getList()).containsExactlyElementsIn(list).inOrder();
+  }
+
+  abstract static class AbstractGenericParentWithBuilder<T> {
+    abstract T foo();
+
+    abstract static class Builder<T, B extends Builder<T, B>> {
+      abstract B foo(T s);
+    }
+  }
+
+  @AutoValue
+  abstract static class ChildOfAbstractGenericParentWithBuilder<T>
+      extends AbstractGenericParentWithBuilder<T> {
+    static <T> Builder<T> builder() {
+      return new AutoValue_AutoValueTest_ChildOfAbstractGenericParentWithBuilder.Builder<T>();
+    }
+
+    @AutoValue.Builder
+    abstract static class Builder<T>
+        extends AbstractGenericParentWithBuilder.Builder<T, Builder<T>> {
+      abstract ChildOfAbstractGenericParentWithBuilder<T> build();
+    }
+  }
+
+  @Test
+  public void genericExtendsGeneric() {
+    ChildOfAbstractGenericParentWithBuilder<String> child =
+        ChildOfAbstractGenericParentWithBuilder.<String>builder().foo("foo").build();
+    assertThat(child.foo()).isEqualTo("foo");
+  }
 }

--- a/value/src/main/java/com/google/auto/value/processor/BuilderMethodClassifier.java
+++ b/value/src/main/java/com/google/auto/value/processor/BuilderMethodClassifier.java
@@ -423,15 +423,6 @@ class BuilderMethodClassifier {
     if (typeUtils.isSameType(parameterType, targetType)) {
       return true;
     }
-    if (typeUtils.isSameType(typeUtils.erasure(parameterType), typeUtils.erasure(targetType))
-        && typeUtils.isAssignable(parameterType, targetType)) {
-      // This funky check matches some cases that were allowed using the old erasure-based logic,
-      // while still avoiding the generation of incorrect code. For example, we allowed
-      // an Optional<? extends Foo> to be set from an Optional<Foo>.
-      // We could just allow the parameter type to be assignable-to rather than equivalent-to in
-      // general, but let's not make that semantic change right now.
-      return true;
-    }
 
     // Parameter type is not equal to property type, but might be convertible with copyOf.
     ImmutableList<ExecutableElement> copyOfMethods = copyOfMethods(targetType);

--- a/value/src/main/java/com/google/auto/value/processor/TypeVariables.java
+++ b/value/src/main/java/com/google/auto/value/processor/TypeVariables.java
@@ -15,16 +15,27 @@
  */
 package com.google.auto.value.processor;
 
+import com.google.auto.common.MoreElements;
+import com.google.auto.common.MoreTypes;
+import com.google.common.base.Equivalence;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import java.util.Collection;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.TypeParameterElement;
+import javax.lang.model.type.ArrayType;
 import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
+import javax.lang.model.type.TypeVariable;
+import javax.lang.model.type.WildcardType;
 import javax.lang.model.util.Elements;
+import javax.lang.model.util.SimpleTypeVisitor8;
 import javax.lang.model.util.Types;
 
 /**
@@ -83,11 +94,6 @@ final class TypeVariables {
     // What we're doing is only valid if the type parameters are "the same". The check here even
     // requires the names to be the same. The logic would still work without that, but we impose
     // that requirement elsewhere and it means we can check in this simple way.
-
-    if (sourceTypeParameters.isEmpty()) {
-      return methods.stream()
-          .collect(ImmutableMap.toImmutableMap(m -> m, ExecutableElement::getReturnType));
-    }
     EclipseHack eclipseHack = new EclipseHack(elementUtils, typeUtils);
     TypeMirror[] targetTypeParameterMirrors = new TypeMirror[targetTypeParameters.size()];
     for (int i = 0; i < targetTypeParameters.size(); i++) {
@@ -98,5 +104,145 @@ final class TypeVariables {
         .collect(
             ImmutableMap.toImmutableMap(
                 m -> m, m -> eclipseHack.methodReturnType(m, parallelSource)));
+  }
+
+  /**
+   * Tests whether a given parameter can be given to a static method like
+   * {@code ImmutableMap.copyOf} to produce a value that can be assigned to the given target type.
+   *
+   * <p>For example, suppose we have this method in {@code ImmutableMap}:<br>
+   * {@code static <K, V> ImmutableMap<K, V> copyOf(Map<? extends K, ? extends V>)}<br>
+   * and we want to know if we can do this:
+   *
+   * <pre>
+   * {@code ImmutableMap<String, Integer> actualParameter = ...;}
+   * {@code ImmutableMap<String, Number> target = ImmutableMap.copyOf(actualParameter);}
+   * </pre>
+   *
+   * We will infer {@code K=String}, {@code V=Number} based on the target type, and then rewrite the
+   * formal parameter type from<br>
+   * {@code Map<? extends K, ? extends V>} to<br>
+   * {@code Map<? extends String, ? extends Number>}. Then we can check whether
+   * {@code actualParameter} is assignable to that.
+   *
+   * <p>The logic makes some simplifying assumptions, which are met for the {@code copyOf} and
+   * {@code of} methods that we use this for. The method must be static, it must have exactly one
+   * parameter, and it must have type parameters without bounds that are the same as the type
+   * parameters of its return type. We can see that these assumptions are met for the
+   * {@code ImmutableMap.copyOf} example above.
+   */
+  static boolean canAssignStaticMethodResult(
+      ExecutableElement method,
+      TypeMirror actualParameterType,
+      TypeMirror targetType,
+      Types typeUtils) {
+    if (!targetType.getKind().equals(TypeKind.DECLARED)
+        || !method.getModifiers().contains(Modifier.STATIC)
+        || method.getParameters().size() != 1) {
+      return false;
+    }
+    List<? extends TypeParameterElement> typeParameters = method.getTypeParameters();
+    List<? extends TypeMirror> targetTypeArguments =
+        MoreTypes.asDeclared(targetType).getTypeArguments();
+    if (typeParameters.size() != targetTypeArguments.size()) {
+      return false;
+    }
+    Map<Equivalence.Wrapper<TypeVariable>, TypeMirror> typeVariables = new LinkedHashMap<>();
+    for (int i = 0; i < typeParameters.size(); i++) {
+      TypeVariable v = MoreTypes.asTypeVariable(typeParameters.get(i).asType());
+      typeVariables.put(MoreTypes.equivalence().wrap(v), targetTypeArguments.get(i));
+    }
+    TypeMirror formalParameterType = method.getParameters().get(0).asType();
+    SubstitutionVisitor substitutionVisitor = new SubstitutionVisitor(typeVariables, typeUtils);
+    TypeMirror substitutedParameterType = substitutionVisitor.visit(formalParameterType, null);
+    if (substitutedParameterType.getKind().equals(TypeKind.WILDCARD)) {
+      // If the target type is Optional<? extends Foo> then <T> T Optional.of(T) will give us
+      // ? extends Foo here, and typeUtils.isAssignable will return false. But we can in fact
+      // give a Foo as an argument, so we just replace ? extends Foo with Foo.
+      WildcardType wildcard = MoreTypes.asWildcard(substitutedParameterType);
+      if (wildcard.getExtendsBound() != null) {
+        substitutedParameterType = wildcard.getExtendsBound();
+      }
+    }
+    return typeUtils.isAssignable(actualParameterType, substitutedParameterType);
+  }
+
+  /**
+   * Rewrites types such that references to type variables in the given map are replaced by the
+   * values of those variables.
+   */
+  private static class SubstitutionVisitor extends SimpleTypeVisitor8<TypeMirror, Void> {
+    private final Map<Equivalence.Wrapper<TypeVariable>, TypeMirror> typeVariables;
+    private final Types typeUtils;
+
+    SubstitutionVisitor(
+        Map<Equivalence.Wrapper<TypeVariable>, TypeMirror> typeVariables,
+        Types typeUtils) {
+      this.typeVariables = ImmutableMap.copyOf(typeVariables);
+      this.typeUtils = typeUtils;
+    }
+
+    @Override protected TypeMirror defaultAction(TypeMirror t, Void p) {
+      return t;
+    }
+
+    @Override public TypeMirror visitTypeVariable(TypeVariable t, Void p) {
+      TypeMirror substituted = typeVariables.get(MoreTypes.equivalence().wrap(t));
+      return (substituted == null) ? t : substituted;
+    }
+
+    @Override public TypeMirror visitDeclared(DeclaredType t, Void p) {
+      List<? extends TypeMirror> typeArguments = t.getTypeArguments();
+      TypeMirror[] substitutedTypeArguments = new TypeMirror[typeArguments.size()];
+      for (int i = 0; i < typeArguments.size(); i++) {
+        substitutedTypeArguments[i] = visit(typeArguments.get(i));
+      }
+      return typeUtils.getDeclaredType(
+          MoreElements.asType(t.asElement()), substitutedTypeArguments);
+    }
+
+    @Override public TypeMirror visitWildcard(WildcardType t, Void p) {
+      TypeMirror ext = visitOrNull(t.getExtendsBound());
+      if (ext != null && ext.getKind().equals(TypeKind.WILDCARD)) {
+        // An example of where this happens is if we have this method in ImmutableSet:
+        //    static <E> ImmutableSet<E> copyOf(Collection<? extends E>)
+        // and we want to know if we can do this (where T is parameter of the enclosing class):
+        //    ImmutableSet<T> actualParameter = ...
+        //    ImmutableSet<? extends T> target = ImmutableSet.copyOf(actualParameter);
+        // We will infer E=<? extends T> and rewrite the formal parameter type to
+        // Collection<? extends ? extends T>, which we must simplify to Collection<? extends T>.
+        return ext;
+      }
+      return typeUtils.getWildcardType(ext, visitOrNull(t.getSuperBound()));
+    }
+
+    @Override public TypeMirror visitArray(ArrayType t, Void p) {
+      TypeMirror comp = visit(t.getComponentType());
+      if (comp.getKind().equals(TypeKind.WILDCARD)) {
+        // An example of where this happens is if we have this method in ImmutableSet:
+        //    static <E> ImmutableSet<E> copyOf(E[])
+        // and we want to know if we can do this:
+        //    String[] actualParameter = ...
+        //    ImmutableSet<? extends T> target = ImmutableSet.copyOf(actualParameter);
+        // We will infer E=<? extends T> and rewrite the formal parameter type to
+        // <? extends T>[], which we must simplify to T[].
+        // TODO: what if getExtendsBound() returns null?
+        comp = MoreTypes.asWildcard(comp).getExtendsBound();
+      }
+      return typeUtils.getArrayType(comp);
+    }
+
+    // We'd like to override visitIntersectionType here for completeness, but Types has no method
+    // to fabricate a new IntersectionType. Anyway, currently IntersectionType can only occur as
+    // the result of TypeVariable.getUpperBound(), but the TypeMirror we're starting from is not
+    // that, and if we encounter a TypeVariable during our visit we don't visit its upper bound.
+
+    private TypeMirror visitOrNull(TypeMirror t) {
+      if (t == null) {
+        return null;
+      } else {
+        return visit(t);
+      }
+    }
   }
 }

--- a/value/src/test/java/com/google/auto/value/extension/memoized/MemoizedTest.java
+++ b/value/src/test/java/com/google/auto/value/extension/memoized/MemoizedTest.java
@@ -274,7 +274,9 @@ public class MemoizedTest {
       value.notNullableButReturnsNull();
       fail();
     } catch (NullPointerException expected) {
-      assertThat(expected).hasMessage("notNullableButReturnsNull() cannot return null");
+      assertThat(expected)
+          .hasMessageThat()
+          .isEqualTo("notNullableButReturnsNull() cannot return null");
     }
     assertThat(value.notNullableButReturnsNullCount).isEqualTo(1);
   }


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Further improve the logic for checking setter types.

In the case where the setter parameter is supposed to be the same as the getter type, we use appropriate logic to take inheritance into account. We also verify that the type of a parameter that we are thinking of feeding to ImmutableSet.copyOf (for example) will actually lead to an ImmutableSet of the right type.

RELNOTES=Improved type checking for builder setter parameters.

5245c6ac598ec0fc4f319d01787cac8a28380aa0

-------

<p> Remove the special hack that allowed Optional<? extends Foo> to be set from Optional<SubFoo>. If we are going to allow the setter parameter to be assignable-to, rather than only equal-to, the getter return type then we should do it for all types. Meanwhile this re-establishes consistency.

0f63cd6fd11b21ac74a71d2e751fff435e1b1b0e

-------

<p> Refactor exception-message assertions to use ThrowableSubject.hasMessageThat(). This replaces assertions of the form assertThat(e).hasMessage(...) and assertThat(e.getMessage()) with assertThat(e).hasMessageThat().

1549f33532f33fac382e3bfb5b1a184ec9c59d2e

-------

<p> Fix an @link now that @AutoService and its annotations are not in the same maven module

660f39cff46fa211939d8b9347ed46d5e07816da