### PR TITLE
Output the full exception trace if ServiceLoader fails when looking for AutoValue extensions.

### DIFF
--- a/value/src/main/java/com/google/auto/value/processor/AutoValueProcessor.java
+++ b/value/src/main/java/com/google/auto/value/processor/AutoValueProcessor.java
@@ -26,6 +26,7 @@ import com.google.auto.service.AutoService;
 import com.google.auto.value.extension.AutoValueExtension;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
+import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableBiMap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableListMultimap;
@@ -118,7 +119,7 @@ public class AutoValueProcessor extends AutoValueOrOneOfProcessor {
         if (t instanceof ServiceConfigurationError) {
           warning.append(" This may be due to a corrupt jar file in the compiler's classpath.");
         }
-        warning.append(" Exception: ").append(t);
+        warning.append("\n").append(Throwables.getStackTraceAsString(t));
         errorReporter().reportWarning(warning.toString(), null);
         extensions = ImmutableList.of();
       }

--- a/value/src/test/java/com/google/auto/value/processor/ExtensionTest.java
+++ b/value/src/test/java/com/google/auto/value/processor/ExtensionTest.java
@@ -616,7 +616,7 @@ public class ExtensionTest {
             .processedWith(new AutoValueProcessor(badJarLoader))
             .compilesWithoutError();
     success.withWarningContaining(
-        "This may be due to a corrupt jar file in the compiler's classpath. Exception: "
+        "This may be due to a corrupt jar file in the compiler's classpath.\n  "
             + ServiceConfigurationError.class.getName());
     success
         .and()


### PR DESCRIPTION
See https://github.com/google/auto/issues/718.

RELNOTES=More detailed exception information if AutoValue extensions cannot be loaded.

-------------
Created by MOE: https://github.com/google/moe
MOE_MIGRATED_REVID=241929228