### PR TITLE
Moe Sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Save time.  Save code.  Save sanity.
 
 ## License
 
-    Copyright 2013 Google, Inc.
+    Copyright 2013 Google LLC
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (C) 2014 Google, Inc.
+  Copyright 2014 Google LLC
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/common/src/main/java/com/google/auto/common/AnnotationMirrors.java
+++ b/common/src/main/java/com/google/auto/common/AnnotationMirrors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Google, Inc.
+ * Copyright 2014 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/com/google/auto/common/AnnotationValues.java
+++ b/common/src/main/java/com/google/auto/common/AnnotationValues.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Google, Inc.
+ * Copyright 2014 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/com/google/auto/common/BasicAnnotationProcessor.java
+++ b/common/src/main/java/com/google/auto/common/BasicAnnotationProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Google, Inc.
+ * Copyright 2014 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/com/google/auto/common/GeneratedAnnotationSpecs.java
+++ b/common/src/main/java/com/google/auto/common/GeneratedAnnotationSpecs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Google, Inc.
+ * Copyright 2017 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/com/google/auto/common/GeneratedAnnotations.java
+++ b/common/src/main/java/com/google/auto/common/GeneratedAnnotations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Google, Inc.
+ * Copyright 2017 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/com/google/auto/common/MoreElements.java
+++ b/common/src/main/java/com/google/auto/common/MoreElements.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Google, Inc.
+ * Copyright 2013 Google LLC
  * Copyright (C) 2013 Square, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/common/src/main/java/com/google/auto/common/MoreTypes.java
+++ b/common/src/main/java/com/google/auto/common/MoreTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Google, Inc.
+ * Copyright 2014 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/com/google/auto/common/Overrides.java
+++ b/common/src/main/java/com/google/auto/common/Overrides.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Google, Inc.
+ * Copyright 2016 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/com/google/auto/common/SimpleAnnotationMirror.java
+++ b/common/src/main/java/com/google/auto/common/SimpleAnnotationMirror.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Google, Inc.
+ * Copyright 2017 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/com/google/auto/common/SimpleTypeAnnotationValue.java
+++ b/common/src/main/java/com/google/auto/common/SimpleTypeAnnotationValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Google, Inc.
+ * Copyright 2017 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/com/google/auto/common/SuperficialValidation.java
+++ b/common/src/main/java/com/google/auto/common/SuperficialValidation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Google, Inc.
+ * Copyright 2014 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/com/google/auto/common/Visibility.java
+++ b/common/src/main/java/com/google/auto/common/Visibility.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Google, Inc.
+ * Copyright 2014 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/test/java/com/google/auto/common/AnnotationMirrorsTest.java
+++ b/common/src/test/java/com/google/auto/common/AnnotationMirrorsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Google, Inc.
+ * Copyright 2014 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/test/java/com/google/auto/common/BasicAnnotationProcessorTest.java
+++ b/common/src/test/java/com/google/auto/common/BasicAnnotationProcessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Google, Inc.
+ * Copyright 2014 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/test/java/com/google/auto/common/GeneratedAnnotationsTest.java
+++ b/common/src/test/java/com/google/auto/common/GeneratedAnnotationsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Google, Inc.
+ * Copyright 2018 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/test/java/com/google/auto/common/MoreElementsTest.java
+++ b/common/src/test/java/com/google/auto/common/MoreElementsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Google, Inc.
+ * Copyright 2014 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/test/java/com/google/auto/common/MoreTypesIsTypeOfTest.java
+++ b/common/src/test/java/com/google/auto/common/MoreTypesIsTypeOfTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Google, Inc.
+ * Copyright 2014 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/test/java/com/google/auto/common/MoreTypesIsTypeOfTest.java
+++ b/common/src/test/java/com/google/auto/common/MoreTypesIsTypeOfTest.java
@@ -16,7 +16,7 @@
 package com.google.auto.common;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
-import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -51,11 +51,11 @@ public class MoreTypesIsTypeOfTest {
 
   @Test public void isTypeOf_DeclaredType() {
     assertTrue(MoreTypes.isType(typeElementFor(TestType.class).asType()));
-    assertThat(MoreTypes.isTypeOf(TestType.class, typeElementFor(TestType.class).asType()))
-        .named("mirror represents the TestType")
+    assertWithMessage("mirror represents the TestType")
+        .that(MoreTypes.isTypeOf(TestType.class, typeElementFor(TestType.class).asType()))
         .isTrue();
-    assertThat(MoreTypes.isTypeOf(String.class, typeElementFor(TestType.class).asType()))
-        .named("mirror does not represent a String")
+    assertWithMessage("mirror does not represent a String")
+        .that(MoreTypes.isTypeOf(String.class, typeElementFor(TestType.class).asType()))
         .isFalse();
   }
 
@@ -66,8 +66,8 @@ public class MoreTypesIsTypeOfTest {
   @Test public void isTypeOf_ArrayType() {
     assertTrue(MoreTypes.isType(typeElementFor(ArrayType.class).asType()));
     TypeMirror type = extractReturnTypeFromHolder(typeElementFor(ArrayType.class));
-    assertThat(MoreTypes.isTypeOf(new String[] {}.getClass(), type))
-        .named("array mirror represents an array Class object")
+    assertWithMessage("array mirror represents an array Class object")
+        .that(MoreTypes.isTypeOf(new String[] {}.getClass(), type))
         .isTrue();
   }
 
@@ -78,7 +78,7 @@ public class MoreTypesIsTypeOfTest {
   @Test public void isTypeOf_PrimitiveBoolean() {
     assertTrue(MoreTypes.isType(typeElementFor(PrimitiveBoolean.class).asType()));
     TypeMirror type = extractReturnTypeFromHolder(typeElementFor(PrimitiveBoolean.class));
-    assertThat(MoreTypes.isTypeOf(Boolean.TYPE, type)).named("mirror of a boolean").isTrue();
+    assertWithMessage("mirror of a boolean").that(MoreTypes.isTypeOf(Boolean.TYPE, type)).isTrue();
   }
 
   private interface PrimitiveByte {
@@ -88,7 +88,7 @@ public class MoreTypesIsTypeOfTest {
   @Test public void isTypeOf_PrimitiveByte() {
     assertTrue(MoreTypes.isType(typeElementFor(PrimitiveByte.class).asType()));
     TypeMirror type = extractReturnTypeFromHolder(typeElementFor(PrimitiveByte.class));
-    assertThat(MoreTypes.isTypeOf(Byte.TYPE, type)).named("mirror of a byte").isTrue();
+    assertWithMessage("mirror of a byte").that(MoreTypes.isTypeOf(Byte.TYPE, type)).isTrue();
   }
 
   private interface PrimitiveChar {
@@ -98,7 +98,7 @@ public class MoreTypesIsTypeOfTest {
   @Test public void isTypeOf_PrimitiveChar() {
     assertTrue(MoreTypes.isType(typeElementFor(PrimitiveChar.class).asType()));
     TypeMirror type = extractReturnTypeFromHolder(typeElementFor(PrimitiveChar.class));
-    assertThat(MoreTypes.isTypeOf(Character.TYPE, type)).named("mirror of a char").isTrue();
+    assertWithMessage("mirror of a char").that(MoreTypes.isTypeOf(Character.TYPE, type)).isTrue();
   }
 
   private interface PrimitiveDouble {
@@ -108,7 +108,7 @@ public class MoreTypesIsTypeOfTest {
   @Test public void isTypeOf_PrimitiveDouble() {
     assertTrue(MoreTypes.isType(typeElementFor(PrimitiveDouble.class).asType()));
     TypeMirror type = extractReturnTypeFromHolder(typeElementFor(PrimitiveDouble.class));
-    assertThat(MoreTypes.isTypeOf(Double.TYPE, type)).named("mirror of a double").isTrue();
+    assertWithMessage("mirror of a double").that(MoreTypes.isTypeOf(Double.TYPE, type)).isTrue();
   }
 
   private interface PrimitiveFloat {
@@ -118,7 +118,7 @@ public class MoreTypesIsTypeOfTest {
   @Test public void isTypeOf_PrimitiveFloat() {
     assertTrue(MoreTypes.isType(typeElementFor(PrimitiveFloat.class).asType()));
     TypeMirror type = extractReturnTypeFromHolder(typeElementFor(PrimitiveFloat.class));
-    assertThat(MoreTypes.isTypeOf(Float.TYPE, type)).named("mirror of a float").isTrue();
+    assertWithMessage("mirror of a float").that(MoreTypes.isTypeOf(Float.TYPE, type)).isTrue();
   }
 
   private interface PrimitiveInt {
@@ -128,7 +128,7 @@ public class MoreTypesIsTypeOfTest {
   @Test public void isTypeOf_PrimitiveInt() {
     assertTrue(MoreTypes.isType(typeElementFor(PrimitiveInt.class).asType()));
     TypeMirror type = extractReturnTypeFromHolder(typeElementFor(PrimitiveInt.class));
-    assertThat(MoreTypes.isTypeOf(Integer.TYPE, type)).named("mirror of a int").isTrue();
+    assertWithMessage("mirror of a int").that(MoreTypes.isTypeOf(Integer.TYPE, type)).isTrue();
   }
 
   private interface PrimitiveLong {
@@ -138,7 +138,7 @@ public class MoreTypesIsTypeOfTest {
   @Test public void isTypeOf_PrimitiveLong() {
     assertTrue(MoreTypes.isType(typeElementFor(PrimitiveLong.class).asType()));
     TypeMirror type = extractReturnTypeFromHolder(typeElementFor(PrimitiveLong.class));
-    assertThat(MoreTypes.isTypeOf(Long.TYPE, type)).named("mirror of a long").isTrue();
+    assertWithMessage("mirror of a long").that(MoreTypes.isTypeOf(Long.TYPE, type)).isTrue();
   }
 
   private interface PrimitiveShort {
@@ -148,7 +148,7 @@ public class MoreTypesIsTypeOfTest {
   @Test public void isTypeOf_PrimitiveShort() {
     assertTrue(MoreTypes.isType(typeElementFor(PrimitiveShort.class).asType()));
     TypeMirror type = extractReturnTypeFromHolder(typeElementFor(PrimitiveShort.class));
-    assertThat(MoreTypes.isTypeOf(Short.TYPE, type)).named("mirror of a short").isTrue();
+    assertWithMessage("mirror of a short").that(MoreTypes.isTypeOf(Short.TYPE, type)).isTrue();
   }
 
   private interface PrimitiveVoid {
@@ -158,7 +158,7 @@ public class MoreTypesIsTypeOfTest {
   @Test public void isTypeOf_void() {
     assertTrue(MoreTypes.isType(typeElementFor(PrimitiveVoid.class).asType()));
     TypeMirror primitive = extractReturnTypeFromHolder(typeElementFor(PrimitiveVoid.class));
-    assertThat(MoreTypes.isTypeOf(Void.TYPE, primitive)).named("mirror of a void").isTrue();
+    assertWithMessage("mirror of a void").that(MoreTypes.isTypeOf(Void.TYPE, primitive)).isTrue();
   }
 
   private interface DeclaredVoid {
@@ -168,7 +168,7 @@ public class MoreTypesIsTypeOfTest {
   @Test public void isTypeOf_Void() {
     assertTrue(MoreTypes.isType(typeElementFor(DeclaredVoid.class).asType()));
     TypeMirror declared = extractReturnTypeFromHolder(typeElementFor(DeclaredVoid.class));
-    assertThat(MoreTypes.isTypeOf(Void.class, declared)).named("mirror of a void").isTrue();
+    assertWithMessage("mirror of a void").that(MoreTypes.isTypeOf(Void.class, declared)).isTrue();
   }
 
   @Test public void isTypeOf_fail() {

--- a/common/src/test/java/com/google/auto/common/MoreTypesTest.java
+++ b/common/src/test/java/com/google/auto/common/MoreTypesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Google, Inc.
+ * Copyright 2014 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/test/java/com/google/auto/common/OverridesTest.java
+++ b/common/src/test/java/com/google/auto/common/OverridesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Google, Inc.
+ * Copyright 2016 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/test/java/com/google/auto/common/SimpleAnnotationMirrorTest.java
+++ b/common/src/test/java/com/google/auto/common/SimpleAnnotationMirrorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Google, Inc.
+ * Copyright 2017 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/test/java/com/google/auto/common/SimpleTypeAnnotationValueTest.java
+++ b/common/src/test/java/com/google/auto/common/SimpleTypeAnnotationValueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Google, Inc.
+ * Copyright 2017 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/test/java/com/google/auto/common/SuperficialValidationTest.java
+++ b/common/src/test/java/com/google/auto/common/SuperficialValidationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Google, Inc.
+ * Copyright 2014 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/test/java/com/google/auto/common/SuperficialValidationTest.java
+++ b/common/src/test/java/com/google/auto/common/SuperficialValidationTest.java
@@ -17,6 +17,7 @@ package com.google.auto.common;
 
 import static com.google.common.truth.Truth.assertAbout;
 import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
 import static com.google.testing.compile.JavaSourceSubjectFactory.javaSource;
 
 import com.google.common.collect.ImmutableSet;
@@ -261,14 +262,18 @@ public class SuperficialValidationTest {
         "}");
     assertAbout(javaSource())
         .that(javaFileObject)
-        .processedWith(new AssertingProcessor() {
-          @Override void runAssertions() {
-            TypeElement testClassElement =
-                processingEnv.getElementUtils().getTypeElement("test.Outer.TestClass");
-            assertThat(SuperficialValidation.validateElement(testClassElement))
-                .named("testClassElement is valid").isFalse();
-          }
-        }).failsToCompile();
+        .processedWith(
+            new AssertingProcessor() {
+              @Override
+              void runAssertions() {
+                TypeElement testClassElement =
+                    processingEnv.getElementUtils().getTypeElement("test.Outer.TestClass");
+                assertWithMessage("testClassElement is valid")
+                    .that(SuperficialValidation.validateElement(testClassElement))
+                    .isFalse();
+              }
+            })
+        .failsToCompile();
   }
 
   private abstract static class AssertingProcessor extends AbstractProcessor {

--- a/common/src/test/java/com/google/auto/common/VisibilityTest.java
+++ b/common/src/test/java/com/google/auto/common/VisibilityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Google, Inc.
+ * Copyright 2014 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/factory/README.md
+++ b/factory/README.md
@@ -83,7 +83,7 @@ artifact as an "optional" dependency:
 License
 -------
 
-    Copyright 2013 Google, Inc.
+    Copyright 2013 Google LLC
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/factory/pom.xml
+++ b/factory/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (C) 2012 Google, Inc.
+  Copyright 2012 Google LLC
   Copyright (C) 2012 Square, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");

--- a/factory/src/it/functional/pom.xml
+++ b/factory/src/it/functional/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (C) 2013 Google, Inc.
+  Copyright 2013 Google LLC
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/factory/src/it/functional/src/main/java/com/google/auto/factory/DaggerModule.java
+++ b/factory/src/it/functional/src/main/java/com/google/auto/factory/DaggerModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Google, Inc.
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/factory/src/it/functional/src/main/java/com/google/auto/factory/Dependency.java
+++ b/factory/src/it/functional/src/main/java/com/google/auto/factory/Dependency.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Google, Inc.
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/factory/src/it/functional/src/main/java/com/google/auto/factory/DependencyImpl.java
+++ b/factory/src/it/functional/src/main/java/com/google/auto/factory/DependencyImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Google, Inc.
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/factory/src/it/functional/src/main/java/com/google/auto/factory/FactoryComponent.java
+++ b/factory/src/it/functional/src/main/java/com/google/auto/factory/FactoryComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Google, Inc.
+ * Copyright 2015 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/factory/src/it/functional/src/main/java/com/google/auto/factory/FactoryGenerated.java
+++ b/factory/src/it/functional/src/main/java/com/google/auto/factory/FactoryGenerated.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Google, Inc.
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/factory/src/it/functional/src/main/java/com/google/auto/factory/FactoryInterface.java
+++ b/factory/src/it/functional/src/main/java/com/google/auto/factory/FactoryInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Google, Inc.
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/factory/src/it/functional/src/main/java/com/google/auto/factory/GuiceModule.java
+++ b/factory/src/it/functional/src/main/java/com/google/auto/factory/GuiceModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Google, Inc.
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/factory/src/it/functional/src/main/java/com/google/auto/factory/QualifiedDependencyImpl.java
+++ b/factory/src/it/functional/src/main/java/com/google/auto/factory/QualifiedDependencyImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Google, Inc.
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/factory/src/it/functional/src/main/java/com/google/auto/factory/Qualifier.java
+++ b/factory/src/it/functional/src/main/java/com/google/auto/factory/Qualifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Google, Inc.
+ * Copyright 2015 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/factory/src/main/java/com/google/auto/factory/AutoFactory.java
+++ b/factory/src/main/java/com/google/auto/factory/AutoFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Google, Inc.
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/factory/src/main/java/com/google/auto/factory/Provided.java
+++ b/factory/src/main/java/com/google/auto/factory/Provided.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Google, Inc.
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/factory/src/main/java/com/google/auto/factory/processor/AnnotationValues.java
+++ b/factory/src/main/java/com/google/auto/factory/processor/AnnotationValues.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Google, Inc.
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/factory/src/main/java/com/google/auto/factory/processor/AutoFactoryDeclaration.java
+++ b/factory/src/main/java/com/google/auto/factory/processor/AutoFactoryDeclaration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Google, Inc.
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/factory/src/main/java/com/google/auto/factory/processor/AutoFactoryProcessor.java
+++ b/factory/src/main/java/com/google/auto/factory/processor/AutoFactoryProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Google, Inc.
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/factory/src/main/java/com/google/auto/factory/processor/Elements2.java
+++ b/factory/src/main/java/com/google/auto/factory/processor/Elements2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Google, Inc.
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/factory/src/main/java/com/google/auto/factory/processor/FactoryDescriptor.java
+++ b/factory/src/main/java/com/google/auto/factory/processor/FactoryDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Google, Inc.
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/factory/src/main/java/com/google/auto/factory/processor/FactoryDescriptorGenerator.java
+++ b/factory/src/main/java/com/google/auto/factory/processor/FactoryDescriptorGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Google, Inc.
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/factory/src/main/java/com/google/auto/factory/processor/FactoryMethodDescriptor.java
+++ b/factory/src/main/java/com/google/auto/factory/processor/FactoryMethodDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Google, Inc.
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/factory/src/main/java/com/google/auto/factory/processor/FactoryWriter.java
+++ b/factory/src/main/java/com/google/auto/factory/processor/FactoryWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Google, Inc.
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/factory/src/main/java/com/google/auto/factory/processor/ImplementationMethodDescriptor.java
+++ b/factory/src/main/java/com/google/auto/factory/processor/ImplementationMethodDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Google, Inc.
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/factory/src/main/java/com/google/auto/factory/processor/Key.java
+++ b/factory/src/main/java/com/google/auto/factory/processor/Key.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Google, Inc.
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/factory/src/main/java/com/google/auto/factory/processor/Mirrors.java
+++ b/factory/src/main/java/com/google/auto/factory/processor/Mirrors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Google, Inc.
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/factory/src/main/java/com/google/auto/factory/processor/Parameter.java
+++ b/factory/src/main/java/com/google/auto/factory/processor/Parameter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Google, Inc.
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/factory/src/main/java/com/google/auto/factory/processor/ProvidedChecker.java
+++ b/factory/src/main/java/com/google/auto/factory/processor/ProvidedChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Google, Inc.
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/factory/src/main/java/com/google/auto/factory/processor/ProviderField.java
+++ b/factory/src/main/java/com/google/auto/factory/processor/ProviderField.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Google, Inc.
+ * Copyright 2016 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/factory/src/main/java/com/google/auto/factory/processor/package-info.java
+++ b/factory/src/main/java/com/google/auto/factory/processor/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Google, Inc.
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/factory/src/test/java/com/google/auto/factory/processor/AutoFactoryDeclarationTest.java
+++ b/factory/src/test/java/com/google/auto/factory/processor/AutoFactoryDeclarationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Google, Inc.
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/factory/src/test/java/com/google/auto/factory/processor/AutoFactoryProcessorTest.java
+++ b/factory/src/test/java/com/google/auto/factory/processor/AutoFactoryProcessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Google, Inc.
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/factory/src/test/resources/bad/EnumSupertype.java
+++ b/factory/src/test/resources/bad/EnumSupertype.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Google, Inc.
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/factory/src/test/resources/bad/FinalSupertype.java
+++ b/factory/src/test/resources/bad/FinalSupertype.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Google, Inc.
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/factory/src/test/resources/bad/GenericClass.java
+++ b/factory/src/test/resources/bad/GenericClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Google, Inc.
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/factory/src/test/resources/bad/InterfaceSupertype.java
+++ b/factory/src/test/resources/bad/InterfaceSupertype.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Google, Inc.
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/factory/src/test/resources/bad/InvalidCustomName.java
+++ b/factory/src/test/resources/bad/InvalidCustomName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Google, Inc.
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/factory/src/test/resources/bad/MixedFinals.java
+++ b/factory/src/test/resources/bad/MixedFinals.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Google, Inc.
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/factory/src/test/resources/bad/ProvidedButNoAutoFactory.java
+++ b/factory/src/test/resources/bad/ProvidedButNoAutoFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Google, Inc.
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/factory/src/test/resources/bad/ProvidedOnMethodParameter.java
+++ b/factory/src/test/resources/bad/ProvidedOnMethodParameter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Google, Inc.
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/factory/src/test/resources/expected/CheckerFrameworkNullableFactory.java
+++ b/factory/src/test/resources/expected/CheckerFrameworkNullableFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Google, Inc.
+ * Copyright 2016 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/factory/src/test/resources/expected/ClassUsingQualifierWithArgsFactory.java
+++ b/factory/src/test/resources/expected/ClassUsingQualifierWithArgsFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Google, Inc.
+ * Copyright 2015 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/factory/src/test/resources/expected/ConstructorAnnotatedFactory.java
+++ b/factory/src/test/resources/expected/ConstructorAnnotatedFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Google, Inc.
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/factory/src/test/resources/expected/ConstructorAnnotatedNonFinalFactory.java
+++ b/factory/src/test/resources/expected/ConstructorAnnotatedNonFinalFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Google, Inc.
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/factory/src/test/resources/expected/CustomNamedFactory.java
+++ b/factory/src/test/resources/expected/CustomNamedFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Google, Inc.
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/factory/src/test/resources/expected/CustomNullableFactory.java
+++ b/factory/src/test/resources/expected/CustomNullableFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Google, Inc.
+ * Copyright 2016 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/factory/src/test/resources/expected/FactoryExtendingAbstractClassFactory.java
+++ b/factory/src/test/resources/expected/FactoryExtendingAbstractClassFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Google, Inc.
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/factory/src/test/resources/expected/FactoryImplementingCreateMethod_ConcreteClassFactory.java
+++ b/factory/src/test/resources/expected/FactoryImplementingCreateMethod_ConcreteClassFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Google, Inc.
+ * Copyright 2016 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/factory/src/test/resources/expected/FactoryImplementingGenericInterfaceExtensionFactory.java
+++ b/factory/src/test/resources/expected/FactoryImplementingGenericInterfaceExtensionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Google, Inc.
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/factory/src/test/resources/expected/MixedDepsImplementingInterfacesFactory.java
+++ b/factory/src/test/resources/expected/MixedDepsImplementingInterfacesFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Google, Inc.
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/factory/src/test/resources/expected/MultipleFactoriesConflictingParameterNamesFactory.java
+++ b/factory/src/test/resources/expected/MultipleFactoriesConflictingParameterNamesFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Google, Inc.
+ * Copyright 2016 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/factory/src/test/resources/expected/MultipleFactoriesImplementingInterface_ClassAFactory.java
+++ b/factory/src/test/resources/expected/MultipleFactoriesImplementingInterface_ClassAFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Google, Inc.
+ * Copyright 2015 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/factory/src/test/resources/expected/MultipleFactoriesImplementingInterface_ClassBFactory.java
+++ b/factory/src/test/resources/expected/MultipleFactoriesImplementingInterface_ClassBFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Google, Inc.
+ * Copyright 2015 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/factory/src/test/resources/expected/MultipleProvidedParamsSameKeyFactory.java
+++ b/factory/src/test/resources/expected/MultipleProvidedParamsSameKeyFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Google, Inc.
+ * Copyright 2016 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/factory/src/test/resources/expected/NestedClassCustomNamedFactory.java
+++ b/factory/src/test/resources/expected/NestedClassCustomNamedFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Google, Inc.
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/factory/src/test/resources/expected/NestedClasses_SimpleNestedClassFactory.java
+++ b/factory/src/test/resources/expected/NestedClasses_SimpleNestedClassFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Google, Inc.
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/factory/src/test/resources/expected/OnlyPrimitivesFactory.java
+++ b/factory/src/test/resources/expected/OnlyPrimitivesFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Google, Inc.
+ * Copyright 2017 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/factory/src/test/resources/expected/ProviderArgumentToCreateMethodFactory.java
+++ b/factory/src/test/resources/expected/ProviderArgumentToCreateMethodFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Google, Inc.
+ * Copyright 2016 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/factory/src/test/resources/expected/PublicClassFactory.java
+++ b/factory/src/test/resources/expected/PublicClassFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Google, Inc.
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/factory/src/test/resources/expected/SimpleClassFactory.java
+++ b/factory/src/test/resources/expected/SimpleClassFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Google, Inc.
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/factory/src/test/resources/expected/SimpleClassImplementingMarkerFactory.java
+++ b/factory/src/test/resources/expected/SimpleClassImplementingMarkerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Google, Inc.
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/factory/src/test/resources/expected/SimpleClassImplementingSimpleInterfaceFactory.java
+++ b/factory/src/test/resources/expected/SimpleClassImplementingSimpleInterfaceFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Google, Inc.
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/factory/src/test/resources/expected/SimpleClassMixedDepsFactory.java
+++ b/factory/src/test/resources/expected/SimpleClassMixedDepsFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Google, Inc.
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/factory/src/test/resources/expected/SimpleClassNonFinalFactory.java
+++ b/factory/src/test/resources/expected/SimpleClassNonFinalFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Google, Inc.
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/factory/src/test/resources/expected/SimpleClassNullableParametersFactory.java
+++ b/factory/src/test/resources/expected/SimpleClassNullableParametersFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Google, Inc.
+ * Copyright 2016 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/factory/src/test/resources/expected/SimpleClassPassedDepsFactory.java
+++ b/factory/src/test/resources/expected/SimpleClassPassedDepsFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Google, Inc.
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/factory/src/test/resources/expected/SimpleClassProvidedDepsFactory.java
+++ b/factory/src/test/resources/expected/SimpleClassProvidedDepsFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Google, Inc.
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/factory/src/test/resources/expected/SimpleClassProvidedProviderDepsFactory.java
+++ b/factory/src/test/resources/expected/SimpleClassProvidedProviderDepsFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Google, Inc.
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/factory/src/test/resources/expected/SimpleClassVarargsFactory.java
+++ b/factory/src/test/resources/expected/SimpleClassVarargsFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Google, Inc.
+ * Copyright 2016 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/factory/src/test/resources/good/CheckerFrameworkNullable.java
+++ b/factory/src/test/resources/good/CheckerFrameworkNullable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Google, Inc.
+ * Copyright 2016 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/factory/src/test/resources/good/ClassUsingQualifierWithArgs.java
+++ b/factory/src/test/resources/good/ClassUsingQualifierWithArgs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Google, Inc.
+ * Copyright 2015 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/factory/src/test/resources/good/ConstructorAnnotated.java
+++ b/factory/src/test/resources/good/ConstructorAnnotated.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Google, Inc.
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/factory/src/test/resources/good/ConstructorAnnotatedNonFinal.java
+++ b/factory/src/test/resources/good/ConstructorAnnotatedNonFinal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Google, Inc.
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/factory/src/test/resources/good/CustomNullable.java
+++ b/factory/src/test/resources/good/CustomNullable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Google, Inc.
+ * Copyright 2016 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/factory/src/test/resources/good/FactoryExtendingAbstractClass.java
+++ b/factory/src/test/resources/good/FactoryExtendingAbstractClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Google, Inc.
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/factory/src/test/resources/good/FactoryExtendingAbstractClassWithConstructorParams.java
+++ b/factory/src/test/resources/good/FactoryExtendingAbstractClassWithConstructorParams.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Google, Inc.
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/factory/src/test/resources/good/FactoryExtendingAbstractClassWithMultipleConstructors.java
+++ b/factory/src/test/resources/good/FactoryExtendingAbstractClassWithMultipleConstructors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Google, Inc.
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/factory/src/test/resources/good/FactoryImplementingCreateMethod.java
+++ b/factory/src/test/resources/good/FactoryImplementingCreateMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Google, Inc.
+ * Copyright 2016 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/factory/src/test/resources/good/FactoryImplementingGenericInterfaceExtension.java
+++ b/factory/src/test/resources/good/FactoryImplementingGenericInterfaceExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Google, Inc.
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/factory/src/test/resources/good/MixedDepsImplementingInterfaces.java
+++ b/factory/src/test/resources/good/MixedDepsImplementingInterfaces.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Google, Inc.
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/factory/src/test/resources/good/MultipleFactoriesConflictingParameterNames.java
+++ b/factory/src/test/resources/good/MultipleFactoriesConflictingParameterNames.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Google, Inc.
+ * Copyright 2016 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/factory/src/test/resources/good/MultipleFactoriesImplementingInterface.java
+++ b/factory/src/test/resources/good/MultipleFactoriesImplementingInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Google, Inc.
+ * Copyright 2015 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/factory/src/test/resources/good/MultipleProvidedParamsSameKey.java
+++ b/factory/src/test/resources/good/MultipleProvidedParamsSameKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Google, Inc.
+ * Copyright 2016 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/factory/src/test/resources/good/NestedClasses.java
+++ b/factory/src/test/resources/good/NestedClasses.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Google, Inc.
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/factory/src/test/resources/good/OnlyPrimitives.java
+++ b/factory/src/test/resources/good/OnlyPrimitives.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Google, Inc.
+ * Copyright 2017 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/factory/src/test/resources/good/ProviderArgumentToCreateMethod.java
+++ b/factory/src/test/resources/good/ProviderArgumentToCreateMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Google, Inc.
+ * Copyright 2016 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/factory/src/test/resources/good/PublicClass.java
+++ b/factory/src/test/resources/good/PublicClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Google, Inc.
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/factory/src/test/resources/good/SimpleClass.java
+++ b/factory/src/test/resources/good/SimpleClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Google, Inc.
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/factory/src/test/resources/good/SimpleClassCustomName.java
+++ b/factory/src/test/resources/good/SimpleClassCustomName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Google, Inc.
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/factory/src/test/resources/good/SimpleClassImplementingMarker.java
+++ b/factory/src/test/resources/good/SimpleClassImplementingMarker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Google, Inc.
+ * Copyright 2013 Google LLC
  * 
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/factory/src/test/resources/good/SimpleClassImplementingSimpleInterface.java
+++ b/factory/src/test/resources/good/SimpleClassImplementingSimpleInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Google, Inc.
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/factory/src/test/resources/good/SimpleClassMixedDeps.java
+++ b/factory/src/test/resources/good/SimpleClassMixedDeps.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Google, Inc.
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/factory/src/test/resources/good/SimpleClassNonFinal.java
+++ b/factory/src/test/resources/good/SimpleClassNonFinal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Google, Inc.
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/factory/src/test/resources/good/SimpleClassNullableParameters.java
+++ b/factory/src/test/resources/good/SimpleClassNullableParameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Google, Inc.
+ * Copyright 2016 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/factory/src/test/resources/good/SimpleClassPassedDeps.java
+++ b/factory/src/test/resources/good/SimpleClassPassedDeps.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Google, Inc.
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/factory/src/test/resources/good/SimpleClassProvidedDeps.java
+++ b/factory/src/test/resources/good/SimpleClassProvidedDeps.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Google, Inc.
+ * Copyright 2013 Google LLC
  * 
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/factory/src/test/resources/good/SimpleClassProvidedProviderDeps.java
+++ b/factory/src/test/resources/good/SimpleClassProvidedProviderDeps.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Google, Inc.
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/factory/src/test/resources/good/SimpleClassVarargs.java
+++ b/factory/src/test/resources/good/SimpleClassVarargs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Google, Inc.
+ * Copyright 2016 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/factory/src/test/resources/support/AQualifier.java
+++ b/factory/src/test/resources/support/AQualifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Google, Inc.
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/factory/src/test/resources/support/BQualifier.java
+++ b/factory/src/test/resources/support/BQualifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Google, Inc.
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/factory/src/test/resources/support/QualifierWithArgs.java
+++ b/factory/src/test/resources/support/QualifierWithArgs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Google, Inc.
+ * Copyright 2015 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (C) 2013 Google, Inc.
+  Copyright 2013 Google LLC
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -58,7 +58,7 @@
   </licenses>
 
   <organization>
-    <name>Google, Inc.</name>
+    <name>Google LLC</name>
     <url>http://www.google.com</url>
   </organization>
 

--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
       <dependency>
         <groupId>com.google.truth</groupId>
         <artifactId>truth</artifactId>
-        <version>0.36</version>
+        <version>0.44</version>
       </dependency>
       <dependency>
         <groupId>junit</groupId>

--- a/service/README.md
+++ b/service/README.md
@@ -63,7 +63,7 @@ artifact as an "optional" dependency:
 License
 -------
 
-    Copyright 2013 Google, Inc.
+    Copyright 2013 Google LLC
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/service/annotations/pom.xml
+++ b/service/annotations/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (C) 2013 Google, Inc.
+  Copyright 2013 Google LLC
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/service/annotations/src/main/java/com/google/auto/service/AutoService.java
+++ b/service/annotations/src/main/java/com/google/auto/service/AutoService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008 Google, Inc.
+ * Copyright 2008 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (C) 2013 Google, Inc.
+  Copyright 2013 Google LLC
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/service/processor/pom.xml
+++ b/service/processor/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (C) 2013 Google, Inc.
+  Copyright 2013 Google LLC
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/service/processor/src/main/java/com/google/auto/service/processor/AutoServiceProcessor.java
+++ b/service/processor/src/main/java/com/google/auto/service/processor/AutoServiceProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008 Google, Inc.
+ * Copyright 2008 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/service/processor/src/main/java/com/google/auto/service/processor/ServicesFiles.java
+++ b/service/processor/src/main/java/com/google/auto/service/processor/ServicesFiles.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008 Google, Inc.
+ * Copyright 2008 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/service/processor/src/main/java/com/google/auto/service/processor/package-info.java
+++ b/service/processor/src/main/java/com/google/auto/service/processor/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Google, Inc.
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/service/processor/src/test/java/com/google/auto/service/processor/AutoServiceProcessorTest.java
+++ b/service/processor/src/test/java/com/google/auto/service/processor/AutoServiceProcessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008 Google, Inc.
+ * Copyright 2008 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/service/processor/src/test/resources/test/AnotherService.java
+++ b/service/processor/src/test/resources/test/AnotherService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008 Google, Inc.
+ * Copyright 2008 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/service/processor/src/test/resources/test/AnotherServiceProvider.java
+++ b/service/processor/src/test/resources/test/AnotherServiceProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008 Google, Inc.
+ * Copyright 2008 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/service/processor/src/test/resources/test/Enclosing.java
+++ b/service/processor/src/test/resources/test/Enclosing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008 Google, Inc.
+ * Copyright 2008 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/service/processor/src/test/resources/test/MultiServiceProvider.java
+++ b/service/processor/src/test/resources/test/MultiServiceProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Google, Inc.
+ * Copyright 2017 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/service/processor/src/test/resources/test/NoServices.java
+++ b/service/processor/src/test/resources/test/NoServices.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008 Google, Inc.
+ * Copyright 2008 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/service/processor/src/test/resources/test/SomeService.java
+++ b/service/processor/src/test/resources/test/SomeService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008 Google, Inc.
+ * Copyright 2008 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/service/processor/src/test/resources/test/SomeServiceProvider1.java
+++ b/service/processor/src/test/resources/test/SomeServiceProvider1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008 Google, Inc.
+ * Copyright 2008 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/service/processor/src/test/resources/test/SomeServiceProvider2.java
+++ b/service/processor/src/test/resources/test/SomeServiceProvider2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008 Google, Inc.
+ * Copyright 2008 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/annotations/pom.xml
+++ b/value/annotations/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (C) 2012 Google, Inc.
+  Copyright 2012 Google LLC
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/value/pom.xml
+++ b/value/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (C) 2012 Google, Inc.
+  Copyright 2012 Google LLC
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/value/processor/pom.xml
+++ b/value/processor/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (C) 2012 Google, Inc.
+  Copyright 2012 Google LLC
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/value/src/it/functional/pom.xml
+++ b/value/src/it/functional/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (C) 2013 Google, Inc.
+  Copyright 2013 Google LLC
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/value/src/it/functional/src/main/java/PackagelessNestedValueType.java
+++ b/value/src/it/functional/src/main/java/PackagelessNestedValueType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Google Inc.
+ * Copyright 2012 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/it/functional/src/main/java/PackagelessValueType.java
+++ b/value/src/it/functional/src/main/java/PackagelessValueType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Google Inc.
+ * Copyright 2012 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/it/functional/src/main/java/com/google/auto/value/NestedValueType.java
+++ b/value/src/it/functional/src/main/java/com/google/auto/value/NestedValueType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Google Inc.
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/it/functional/src/main/java/com/google/auto/value/SimpleValueType.java
+++ b/value/src/it/functional/src/main/java/com/google/auto/value/SimpleValueType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Google Inc.
+ * Copyright 2012 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/it/functional/src/test/java/PackagelessValueTypeTest.java
+++ b/value/src/it/functional/src/test/java/PackagelessValueTypeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Google Inc.
+ * Copyright 2012 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/it/functional/src/test/java/com/google/auto/value/AutoAnnotationDefaultsTest.java
+++ b/value/src/it/functional/src/test/java/com/google/auto/value/AutoAnnotationDefaultsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Google Inc.
+ * Copyright 2014 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/it/functional/src/test/java/com/google/auto/value/AutoAnnotationTest.java
+++ b/value/src/it/functional/src/test/java/com/google/auto/value/AutoAnnotationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Google Inc.
+ * Copyright 2014 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/it/functional/src/test/java/com/google/auto/value/AutoOneOfJava8Test.java
+++ b/value/src/it/functional/src/test/java/com/google/auto/value/AutoOneOfJava8Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Google, Inc.
+ * Copyright 2018 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/it/functional/src/test/java/com/google/auto/value/AutoOneOfTest.java
+++ b/value/src/it/functional/src/test/java/com/google/auto/value/AutoOneOfTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Google, Inc.
+ * Copyright 2018 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/it/functional/src/test/java/com/google/auto/value/AutoValueJava8Test.java
+++ b/value/src/it/functional/src/test/java/com/google/auto/value/AutoValueJava8Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Google, Inc.
+ * Copyright 2012 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/it/functional/src/test/java/com/google/auto/value/AutoValueJava8Test.java
+++ b/value/src/it/functional/src/test/java/com/google/auto/value/AutoValueJava8Test.java
@@ -16,6 +16,7 @@
 package com.google.auto.value;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
 import static com.google.common.truth.Truth8.assertThat;
 import static com.google.testing.compile.CompilationSubject.assertThat;
 import static org.junit.Assert.fail;
@@ -698,8 +699,8 @@ public class AutoValueJava8Test {
     Class<?> c = x.getClass();
     assertThat(c.getTypeParameters()).hasLength(1);
     TypeVariable<?> typeParameter = c.getTypeParameters()[0];
-    assertThat(typeParameter.getAnnotations())
-        .named(typeParameter.toString())
+    assertWithMessage(typeParameter.toString())
+        .that(typeParameter.getAnnotations())
         .asList()
         .contains(nullable());
   }
@@ -731,8 +732,8 @@ public class AutoValueJava8Test {
     Class<?> c = builder.getClass();
     assertThat(c.getTypeParameters()).hasLength(1);
     TypeVariable<?> typeParameter = c.getTypeParameters()[0];
-    assertThat(typeParameter.getAnnotations())
-        .named(typeParameter.toString())
+    assertWithMessage(typeParameter.toString())
+        .that(typeParameter.getAnnotations())
         .asList()
         .contains(nullable());
   }

--- a/value/src/it/functional/src/test/java/com/google/auto/value/AutoValueTest.java
+++ b/value/src/it/functional/src/test/java/com/google/auto/value/AutoValueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Google Inc.
+ * Copyright 2012 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/it/functional/src/test/java/com/google/auto/value/SimpleValueTypeTest.java
+++ b/value/src/it/functional/src/test/java/com/google/auto/value/SimpleValueTypeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Google Inc.
+ * Copyright 2012 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/it/functional/src/test/java/com/google/auto/value/annotations/Empty.java
+++ b/value/src/it/functional/src/test/java/com/google/auto/value/annotations/Empty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Google Inc.
+ * Copyright 2014 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/it/functional/src/test/java/com/google/auto/value/annotations/GwtArrays.java
+++ b/value/src/it/functional/src/test/java/com/google/auto/value/annotations/GwtArrays.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Google Inc.
+ * Copyright 2015 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/it/functional/src/test/java/com/google/auto/value/annotations/StringValues.java
+++ b/value/src/it/functional/src/test/java/com/google/auto/value/annotations/StringValues.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Google Inc.
+ * Copyright 2014 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/it/functional/src/test/java/com/google/auto/value/enums/MyEnum.java
+++ b/value/src/it/functional/src/test/java/com/google/auto/value/enums/MyEnum.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Google Inc.
+ * Copyright 2014 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/it/functional/src/test/java/com/google/auto/value/gwt/CustomFieldSerializerTest.java
+++ b/value/src/it/functional/src/test/java/com/google/auto/value/gwt/CustomFieldSerializerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Google Inc.
+ * Copyright 2014 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/it/functional/src/test/java/com/google/auto/value/gwt/EmptyExtension.java
+++ b/value/src/it/functional/src/test/java/com/google/auto/value/gwt/EmptyExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Google, Inc.
+ * Copyright 2018 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/it/functional/src/test/java/com/google/auto/value/gwt/GwtCompilationTest.java
+++ b/value/src/it/functional/src/test/java/com/google/auto/value/gwt/GwtCompilationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Google Inc.
+ * Copyright 2014 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/it/functional/src/test/java/com/google/auto/value/gwt/GwtValueType.java
+++ b/value/src/it/functional/src/test/java/com/google/auto/value/gwt/GwtValueType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Google Inc.
+ * Copyright 2014 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/it/functional/src/test/java/com/google/auto/value/gwt/GwtValueTypeWithBuilder.java
+++ b/value/src/it/functional/src/test/java/com/google/auto/value/gwt/GwtValueTypeWithBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Google Inc.
+ * Copyright 2015 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/it/functional/src/test/java/com/google/auto/value/gwt/NonSerializableGwtValueType.java
+++ b/value/src/it/functional/src/test/java/com/google/auto/value/gwt/NonSerializableGwtValueType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Google Inc.
+ * Copyright 2014 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/it/functional/src/test/java/com/google/auto/value/gwt/SerialSignatureTest.java
+++ b/value/src/it/functional/src/test/java/com/google/auto/value/gwt/SerialSignatureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Google Inc.
+ * Copyright 2014 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/it/gwtserializer/pom.xml
+++ b/value/src/it/gwtserializer/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (C) 2015 Google, Inc.
+  Copyright 2015 Google LLC
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/value/src/it/gwtserializer/src/test/java/com/google/auto/value/GwtSerializerSuite.gwt.xml
+++ b/value/src/it/gwtserializer/src/test/java/com/google/auto/value/GwtSerializerSuite.gwt.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (C) 2015 Google, Inc.
+  Copyright 2015 Google LLC
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/value/src/it/gwtserializer/src/test/java/com/google/auto/value/GwtSerializerSuite.java
+++ b/value/src/it/gwtserializer/src/test/java/com/google/auto/value/GwtSerializerSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Google Inc.
+ * Copyright 2015 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/it/gwtserializer/src/test/java/com/google/auto/value/client/GwtSerializerTest.java
+++ b/value/src/it/gwtserializer/src/test/java/com/google/auto/value/client/GwtSerializerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Google Inc.
+ * Copyright 2015 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/main/java/com/google/auto/value/AutoAnnotation.java
+++ b/value/src/main/java/com/google/auto/value/AutoAnnotation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Google, Inc.
+ * Copyright 2014 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/value/src/main/java/com/google/auto/value/AutoOneOf.java
+++ b/value/src/main/java/com/google/auto/value/AutoOneOf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Google, Inc.
+ * Copyright 2018 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/main/java/com/google/auto/value/AutoValue.java
+++ b/value/src/main/java/com/google/auto/value/AutoValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Google, Inc.
+ * Copyright 2012 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/value/src/main/java/com/google/auto/value/extension/AutoValueExtension.java
+++ b/value/src/main/java/com/google/auto/value/extension/AutoValueExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Google Inc.
+ * Copyright 2015 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/main/java/com/google/auto/value/extension/memoized/Memoized.java
+++ b/value/src/main/java/com/google/auto/value/extension/memoized/Memoized.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Google, Inc.
+ * Copyright 2016 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/main/java/com/google/auto/value/extension/memoized/processor/ClassNames.java
+++ b/value/src/main/java/com/google/auto/value/extension/memoized/processor/ClassNames.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Google, Inc.
+ * Copyright 2017 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/main/java/com/google/auto/value/extension/memoized/processor/MemoizeExtension.java
+++ b/value/src/main/java/com/google/auto/value/extension/memoized/processor/MemoizeExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Google, Inc.
+ * Copyright 2016 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/main/java/com/google/auto/value/extension/memoized/processor/MemoizedValidator.java
+++ b/value/src/main/java/com/google/auto/value/extension/memoized/processor/MemoizedValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Google, Inc.
+ * Copyright 2017 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/main/java/com/google/auto/value/processor/AbortProcessingException.java
+++ b/value/src/main/java/com/google/auto/value/processor/AbortProcessingException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Google, Inc.
+ * Copyright 2014 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/main/java/com/google/auto/value/processor/AnnotationOutput.java
+++ b/value/src/main/java/com/google/auto/value/processor/AnnotationOutput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Google, Inc.
+ * Copyright 2014 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/main/java/com/google/auto/value/processor/AutoAnnotationProcessor.java
+++ b/value/src/main/java/com/google/auto/value/processor/AutoAnnotationProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Google, Inc.
+ * Copyright 2014 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/main/java/com/google/auto/value/processor/AutoAnnotationTemplateVars.java
+++ b/value/src/main/java/com/google/auto/value/processor/AutoAnnotationTemplateVars.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Google, Inc.
+ * Copyright 2014 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/main/java/com/google/auto/value/processor/AutoOneOfProcessor.java
+++ b/value/src/main/java/com/google/auto/value/processor/AutoOneOfProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Google, Inc.
+ * Copyright 2018 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/main/java/com/google/auto/value/processor/AutoOneOfTemplateVars.java
+++ b/value/src/main/java/com/google/auto/value/processor/AutoOneOfTemplateVars.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Google, Inc.
+ * Copyright 2018 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/main/java/com/google/auto/value/processor/AutoValueBuilderProcessor.java
+++ b/value/src/main/java/com/google/auto/value/processor/AutoValueBuilderProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Google, Inc.
+ * Copyright 2014 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/main/java/com/google/auto/value/processor/AutoValueOrOneOfProcessor.java
+++ b/value/src/main/java/com/google/auto/value/processor/AutoValueOrOneOfProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Google, Inc.
+ * Copyright 2018 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/main/java/com/google/auto/value/processor/AutoValueOrOneOfTemplateVars.java
+++ b/value/src/main/java/com/google/auto/value/processor/AutoValueOrOneOfTemplateVars.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Google, Inc.
+ * Copyright 2018 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/main/java/com/google/auto/value/processor/AutoValueProcessor.java
+++ b/value/src/main/java/com/google/auto/value/processor/AutoValueProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Google, Inc.
+ * Copyright 2012 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/main/java/com/google/auto/value/processor/AutoValueTemplateVars.java
+++ b/value/src/main/java/com/google/auto/value/processor/AutoValueTemplateVars.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Google, Inc.
+ * Copyright 2012 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/main/java/com/google/auto/value/processor/BuilderMethodClassifier.java
+++ b/value/src/main/java/com/google/auto/value/processor/BuilderMethodClassifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Google, Inc.
+ * Copyright 2015 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/main/java/com/google/auto/value/processor/BuilderSpec.java
+++ b/value/src/main/java/com/google/auto/value/processor/BuilderSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Google, Inc.
+ * Copyright 2014 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/main/java/com/google/auto/value/processor/ClassNames.java
+++ b/value/src/main/java/com/google/auto/value/processor/ClassNames.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Google, Inc.
+ * Copyright 2018 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/main/java/com/google/auto/value/processor/EclipseHack.java
+++ b/value/src/main/java/com/google/auto/value/processor/EclipseHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Google, Inc.
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/main/java/com/google/auto/value/processor/ErrorReporter.java
+++ b/value/src/main/java/com/google/auto/value/processor/ErrorReporter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Google, Inc.
+ * Copyright 2014 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/main/java/com/google/auto/value/processor/ExtensionContext.java
+++ b/value/src/main/java/com/google/auto/value/processor/ExtensionContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Google Inc.
+ * Copyright 2015 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/main/java/com/google/auto/value/processor/GwtCompatibility.java
+++ b/value/src/main/java/com/google/auto/value/processor/GwtCompatibility.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Google, Inc.
+ * Copyright 2014 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/main/java/com/google/auto/value/processor/GwtSerialization.java
+++ b/value/src/main/java/com/google/auto/value/processor/GwtSerialization.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Google, Inc.
+ * Copyright 2014 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/main/java/com/google/auto/value/processor/JavaScanner.java
+++ b/value/src/main/java/com/google/auto/value/processor/JavaScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Google, Inc.
+ * Copyright 2015 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/main/java/com/google/auto/value/processor/MissingTypeException.java
+++ b/value/src/main/java/com/google/auto/value/processor/MissingTypeException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Google, Inc.
+ * Copyright 2014 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/main/java/com/google/auto/value/processor/Optionalish.java
+++ b/value/src/main/java/com/google/auto/value/processor/Optionalish.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Google Inc.
+ * Copyright 2016 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/main/java/com/google/auto/value/processor/PropertyBuilderClassifier.java
+++ b/value/src/main/java/com/google/auto/value/processor/PropertyBuilderClassifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Google, Inc.
+ * Copyright 2016 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/main/java/com/google/auto/value/processor/PropertyNames.java
+++ b/value/src/main/java/com/google/auto/value/processor/PropertyNames.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Google, Inc.
+ * Copyright 2018 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/main/java/com/google/auto/value/processor/Reformatter.java
+++ b/value/src/main/java/com/google/auto/value/processor/Reformatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Google Inc.
+ * Copyright 2014 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/main/java/com/google/auto/value/processor/SimpleMethod.java
+++ b/value/src/main/java/com/google/auto/value/processor/SimpleMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Google, Inc.
+ * Copyright 2018 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/main/java/com/google/auto/value/processor/SimpleServiceLoader.java
+++ b/value/src/main/java/com/google/auto/value/processor/SimpleServiceLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Google, Inc.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/main/java/com/google/auto/value/processor/TemplateVars.java
+++ b/value/src/main/java/com/google/auto/value/processor/TemplateVars.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Google, Inc.
+ * Copyright 2014 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/main/java/com/google/auto/value/processor/TypeEncoder.java
+++ b/value/src/main/java/com/google/auto/value/processor/TypeEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Google, Inc.
+ * Copyright 2017 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/main/java/com/google/auto/value/processor/TypeMirrorSet.java
+++ b/value/src/main/java/com/google/auto/value/processor/TypeMirrorSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Google, Inc.
+ * Copyright 2014 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/main/java/com/google/auto/value/processor/TypeSimplifier.java
+++ b/value/src/main/java/com/google/auto/value/processor/TypeSimplifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Google, Inc.
+ * Copyright 2012 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/main/java/com/google/auto/value/processor/TypeVariables.java
+++ b/value/src/main/java/com/google/auto/value/processor/TypeVariables.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Google, Inc.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/main/java/com/google/auto/value/processor/autoannotation.vm
+++ b/value/src/main/java/com/google/auto/value/processor/autoannotation.vm
@@ -1,4 +1,4 @@
-## Copyright (C) 2014 Google, Inc.
+## Copyright 2014 Google LLC
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/value/src/main/java/com/google/auto/value/processor/autoannotation.vm
+++ b/value/src/main/java/com/google/auto/value/processor/autoannotation.vm
@@ -275,7 +275,9 @@ final class $className implements $annotationName {
     return
     ## If the invariable part is 0, we avoid outputting `return 0 + ...` just because it generates
     ## unnecessary byte code. But if there are no members then we must say `return 0;` here.
-    #if ($invariableHashSum != 0 || $members.empty)
+    ## We must write $members.isEmpty() because $members is a Map and Velocity interprets
+    ## $members.empty as meaning $members["empty"] in that case.
+    #if ($invariableHashSum != 0 || $members.isEmpty())
 
         $invariableHashSum
         // $invariableHashSum is the contribution from default members $invariableHashes

--- a/value/src/main/java/com/google/auto/value/processor/autooneof.vm
+++ b/value/src/main/java/com/google/auto/value/processor/autooneof.vm
@@ -1,4 +1,4 @@
-## Copyright (C) 2018 Google, Inc.
+## Copyright 2018 Google LLC
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/value/src/main/java/com/google/auto/value/processor/autovalue.vm
+++ b/value/src/main/java/com/google/auto/value/processor/autovalue.vm
@@ -1,4 +1,4 @@
-## Copyright (C) 2014 Google, Inc.
+## Copyright 2014 Google LLC
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/value/src/main/java/com/google/auto/value/processor/equalshashcode.vm
+++ b/value/src/main/java/com/google/auto/value/processor/equalshashcode.vm
@@ -1,4 +1,4 @@
-## Copyright (C) 2018 Google, Inc.
+## Copyright 2018 Google LLC
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/value/src/main/java/com/google/auto/value/processor/gwtserializer.vm
+++ b/value/src/main/java/com/google/auto/value/processor/gwtserializer.vm
@@ -1,4 +1,4 @@
-## Copyright (C) 2014 Google, Inc.
+## Copyright 2014 Google LLC
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/value/src/main/java/com/google/auto/value/processor/package-info.java
+++ b/value/src/main/java/com/google/auto/value/processor/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Google, Inc.
+ * Copyright 2013 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/value/src/test/java/com/google/auto/value/extension/memoized/MemoizedMethodSubject.java
+++ b/value/src/test/java/com/google/auto/value/extension/memoized/MemoizedMethodSubject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Google, Inc.
+ * Copyright 2016 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/test/java/com/google/auto/value/extension/memoized/MemoizedMethodSubjectFactory.java
+++ b/value/src/test/java/com/google/auto/value/extension/memoized/MemoizedMethodSubjectFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Google, Inc.
+ * Copyright 2016 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/test/java/com/google/auto/value/extension/memoized/MemoizedTest.java
+++ b/value/src/test/java/com/google/auto/value/extension/memoized/MemoizedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Google, Inc.
+ * Copyright 2016 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/test/java/com/google/auto/value/extension/memoized/MemoizedValidationTest.java
+++ b/value/src/test/java/com/google/auto/value/extension/memoized/MemoizedValidationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Google, Inc.
+ * Copyright 2016 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/test/java/com/google/auto/value/processor/AutoAnnotationCompilationTest.java
+++ b/value/src/test/java/com/google/auto/value/processor/AutoAnnotationCompilationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Google Inc.
+ * Copyright 2014 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/test/java/com/google/auto/value/processor/AutoAnnotationCompilationTest.java
+++ b/value/src/test/java/com/google/auto/value/processor/AutoAnnotationCompilationTest.java
@@ -15,24 +15,15 @@
  */
 package com.google.auto.value.processor;
 
-import static com.google.common.truth.Truth.assertAbout;
-import static com.google.common.truth.Truth.assertThat;
-import static com.google.common.truth.Truth.assert_;
-import static com.google.testing.compile.JavaSourcesSubjectFactory.javaSources;
+import static com.google.common.truth.Truth8.assertThat;
+import static com.google.testing.compile.CompilationSubject.assertThat;
 import static org.junit.Assert.assertTrue;
 
-import com.google.common.collect.ImmutableList;
+import com.google.testing.compile.Compilation;
+import com.google.testing.compile.Compiler;
 import com.google.testing.compile.JavaFileObjects;
 import java.io.File;
-import java.io.IOException;
-import java.io.Writer;
-import java.util.List;
-import javax.tools.Diagnostic;
-import javax.tools.DiagnosticCollector;
-import javax.tools.JavaCompiler;
-import javax.tools.JavaFileManager;
 import javax.tools.JavaFileObject;
-import javax.tools.ToolProvider;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -88,7 +79,8 @@ public class AutoAnnotationCompilationTest {
             GeneratedImport.importGeneratedAnnotationType(),
             "",
             "@Generated(\"" + AutoAnnotationProcessor.class.getName() + "\")",
-            "final class AutoAnnotation_AnnotationFactory_newMyAnnotation implements MyAnnotation {",
+            "final class AutoAnnotation_AnnotationFactory_newMyAnnotation",
+            "     implements MyAnnotation {",
             "  private final MyEnum value;",
             "  private static final int defaultedValue = 23;",
             "",
@@ -136,13 +128,15 @@ public class AutoAnnotationCompilationTest {
             "    ;",
             "  }",
             "}");
-    assert_()
-        .about(javaSources())
-        .that(ImmutableList.of(annotationFactoryJavaFile, myAnnotationJavaFile, myEnumJavaFile))
-        .processedWith(new AutoAnnotationProcessor())
-        .compilesWithoutError()
-        .and()
-        .generatesSources(expectedOutput);
+    Compilation compilation =
+        Compiler.javac()
+            .withProcessors(new AutoAnnotationProcessor())
+            .compile(annotationFactoryJavaFile, myAnnotationJavaFile, myEnumJavaFile);
+    assertThat(compilation).succeededWithoutWarnings();
+    assertThat(compilation)
+        .generatedSourceFile(
+            "com.example.factories.AutoAnnotation_AnnotationFactory_newMyAnnotation")
+        .hasSourceEquivalentTo(expectedOutput);
   }
 
   @Test
@@ -168,7 +162,8 @@ public class AutoAnnotationCompilationTest {
             GeneratedImport.importGeneratedAnnotationType(),
             "",
             "@Generated(\"" + AutoAnnotationProcessor.class.getName() + "\")",
-            "final class AutoAnnotation_AnnotationFactory_newMyAnnotation implements MyAnnotation {",
+            "final class AutoAnnotation_AnnotationFactory_newMyAnnotation",
+            "    implements MyAnnotation {",
             "  AutoAnnotation_AnnotationFactory_newMyAnnotation() {",
             "  }",
             "",
@@ -195,12 +190,14 @@ public class AutoAnnotationCompilationTest {
             "    return 0;",
             "  }",
             "}");
-    assertAbout(javaSources())
-        .that(ImmutableList.of(annotationFactoryJavaFile, myAnnotationJavaFile))
-        .processedWith(new AutoAnnotationProcessor())
-        .compilesWithoutError()
-        .and()
-        .generatesSources(expectedOutput);
+    Compilation compilation =
+        Compiler.javac()
+            .withProcessors(new AutoAnnotationProcessor())
+            .compile(annotationFactoryJavaFile, myAnnotationJavaFile);
+    assertThat(compilation).succeededWithoutWarnings();
+    assertThat(compilation)
+        .generatedSourceFile("AutoAnnotation_AnnotationFactory_newMyAnnotation")
+        .hasSourceEquivalentTo(expectedOutput);
   }
 
   @Test
@@ -246,7 +243,8 @@ public class AutoAnnotationCompilationTest {
             GeneratedImport.importGeneratedAnnotationType(),
             "",
             "@Generated(\"" + AutoAnnotationProcessor.class.getName() + "\")",
-            "final class AutoAnnotation_AnnotationFactory_newMyAnnotation implements MyAnnotation {",
+            "final class AutoAnnotation_AnnotationFactory_newMyAnnotation implements MyAnnotation"
+                + " {",
             "  private final int[] value;",
             "",
             "  AutoAnnotation_AnnotationFactory_newMyAnnotation(int[] value) {",
@@ -289,15 +287,15 @@ public class AutoAnnotationCompilationTest {
             "        + (" + 127 * "value".hashCode() + " ^ (Arrays.hashCode(value)));",
             "  }",
             "}");
-    assert_()
-        .about(javaSources())
-        .that(
-            ImmutableList.of(
-                annotationFactoryJavaFile, myAnnotationJavaFile, gwtCompatibleJavaFile))
-        .processedWith(new AutoAnnotationProcessor())
-        .compilesWithoutError()
-        .and()
-        .generatesSources(expectedOutput);
+    Compilation compilation =
+        Compiler.javac()
+            .withProcessors(new AutoAnnotationProcessor())
+            .compile(annotationFactoryJavaFile, myAnnotationJavaFile, gwtCompatibleJavaFile);
+    assertThat(compilation).succeededWithoutWarnings();
+    assertThat(compilation)
+        .generatedSourceFile(
+            "com.example.factories.AutoAnnotation_AnnotationFactory_newMyAnnotation")
+        .hasSourceEquivalentTo(expectedOutput);
   }
 
   @Test
@@ -354,7 +352,8 @@ public class AutoAnnotationCompilationTest {
             GeneratedImport.importGeneratedAnnotationType(),
             "",
             "@Generated(\"" + AutoAnnotationProcessor.class.getName() + "\")",
-            "final class AutoAnnotation_AnnotationFactory_newMyAnnotation implements MyAnnotation {",
+            "final class AutoAnnotation_AnnotationFactory_newMyAnnotation implements MyAnnotation"
+                + " {",
             "  private final int[] value;",
             "  private final MyEnum[] enums;",
             "",
@@ -426,28 +425,19 @@ public class AutoAnnotationCompilationTest {
             "    return a;",
             "  }",
             "}");
-    assert_()
-        .about(javaSources())
-        .that(ImmutableList.of(annotationFactoryJavaFile, myEnumJavaFile, myAnnotationJavaFile))
-        .processedWith(new AutoAnnotationProcessor())
-        .compilesWithoutError()
-        .and()
-        .generatesSources(expectedOutput);
+    Compilation compilation =
+        Compiler.javac()
+            .withProcessors(new AutoAnnotationProcessor())
+            .compile(annotationFactoryJavaFile, myEnumJavaFile, myAnnotationJavaFile);
+    assertThat(compilation).succeededWithoutWarnings();
+    assertThat(compilation)
+        .generatedSourceFile(
+            "com.example.factories.AutoAnnotation_AnnotationFactory_newMyAnnotation")
+        .hasSourceEquivalentTo(expectedOutput);
   }
 
   @Test
-  public void testMissingClass() throws IOException {
-    File tempDir = File.createTempFile("AutoAnnotationCompilationTest", "");
-    assertTrue(tempDir.delete());
-    assertTrue(tempDir.mkdir());
-    try {
-      doTestMissingClass(tempDir);
-    } finally {
-      removeDirectory(tempDir);
-    }
-  }
-
-  private void doTestMissingClass(File tempDir) {
+  public void testMissingClass() {
     // Test that referring to an undefined annotation does not trigger @AutoAnnotation processing.
     // The class Erroneous references an undefined annotation @NotAutoAnnotation. If we didn't have
     // any special treatment of undefined types then we could run into a compiler bug where
@@ -468,24 +458,16 @@ public class AutoAnnotationCompilationTest {
             "  @AutoAnnotation static Empty newEmpty() {}",
             "  @NotAutoAnnotation Empty notNewEmpty() {}",
             "}");
-    JavaCompiler javaCompiler = ToolProvider.getSystemJavaCompiler();
-    DiagnosticCollector<JavaFileObject> diagnosticCollector =
-        new DiagnosticCollector<JavaFileObject>();
-    JavaCompiler.CompilationTask compilationTask =
-        javaCompiler.getTask(
-            (Writer) null,
-            (JavaFileManager) null,
-            diagnosticCollector,
-            ImmutableList.of("-d", tempDir.toString()),
-            (Iterable<String>) null,
-            ImmutableList.of(erroneousJavaFileObject));
-    compilationTask.setProcessors(ImmutableList.of(new AutoAnnotationProcessor()));
-    boolean result = compilationTask.call();
-    assertThat(result).isFalse();
-    List<Diagnostic<? extends JavaFileObject>> diagnostics = diagnosticCollector.getDiagnostics();
-    assertThat(diagnostics).isNotEmpty();
-    assertThat(diagnostics.get(0).getMessage(null)).contains("NotAutoAnnotation");
-    assertThat(diagnostics.get(0).getMessage(null)).doesNotContain("static");
+    Compilation compilation =
+        Compiler.javac()
+            .withProcessors(new AutoAnnotationProcessor())
+            .compile(erroneousJavaFileObject);
+    assertThat(compilation).hadErrorContaining("NotAutoAnnotation");
+    assertThat(
+            compilation.errors().stream()
+                .map(diag -> diag.getMessage(null))
+                .filter(m -> m.contains("static")))
+        .isEmpty();
   }
 
   private static void removeDirectory(File dir) {

--- a/value/src/test/java/com/google/auto/value/processor/AutoAnnotationErrorsTest.java
+++ b/value/src/test/java/com/google/auto/value/processor/AutoAnnotationErrorsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Google Inc.
+ * Copyright 2014 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/test/java/com/google/auto/value/processor/AutoOneOfCompilationTest.java
+++ b/value/src/test/java/com/google/auto/value/processor/AutoOneOfCompilationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Google, Inc.
+ * Copyright 2018 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/test/java/com/google/auto/value/processor/AutoValueCompilationTest.java
+++ b/value/src/test/java/com/google/auto/value/processor/AutoValueCompilationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Google, Inc.
+ * Copyright 2018 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/test/java/com/google/auto/value/processor/ExtensionTest.java
+++ b/value/src/test/java/com/google/auto/value/processor/ExtensionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Google Inc.
+ * Copyright 2015 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/test/java/com/google/auto/value/processor/GeneratedDoesNotExistTest.java
+++ b/value/src/test/java/com/google/auto/value/processor/GeneratedDoesNotExistTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Google Inc.
+ * Copyright 2015 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/test/java/com/google/auto/value/processor/GeneratedImport.java
+++ b/value/src/test/java/com/google/auto/value/processor/GeneratedImport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Google, Inc.
+ * Copyright 2017 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/test/java/com/google/auto/value/processor/GuavaCollectionBuildersTest.java
+++ b/value/src/test/java/com/google/auto/value/processor/GuavaCollectionBuildersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Google Inc.
+ * Copyright 2015 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/test/java/com/google/auto/value/processor/JavaScannerTest.java
+++ b/value/src/test/java/com/google/auto/value/processor/JavaScannerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Google Inc.
+ * Copyright 2015 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/test/java/com/google/auto/value/processor/PropertyAnnotationsTest.java
+++ b/value/src/test/java/com/google/auto/value/processor/PropertyAnnotationsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Google Inc.
+ * Copyright 2014 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/test/java/com/google/auto/value/processor/PropertyNamesTest.java
+++ b/value/src/test/java/com/google/auto/value/processor/PropertyNamesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Google, Inc.
+ * Copyright 2018 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/test/java/com/google/auto/value/processor/ReformatterTest.java
+++ b/value/src/test/java/com/google/auto/value/processor/ReformatterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Google Inc.
+ * Copyright 2014 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/test/java/com/google/auto/value/processor/SimpleServiceLoaderTest.java
+++ b/value/src/test/java/com/google/auto/value/processor/SimpleServiceLoaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Google, Inc.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/test/java/com/google/auto/value/processor/SimplifyWithAnnotationsTest.java
+++ b/value/src/test/java/com/google/auto/value/processor/SimplifyWithAnnotationsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Google, Inc.
+ * Copyright 2017 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/test/java/com/google/auto/value/processor/TemplateVarsTest.java
+++ b/value/src/test/java/com/google/auto/value/processor/TemplateVarsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Google Inc.
+ * Copyright 2014 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/test/java/com/google/auto/value/processor/TypeEncoderTest.java
+++ b/value/src/test/java/com/google/auto/value/processor/TypeEncoderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Google, Inc.
+ * Copyright 2017 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/test/java/com/google/auto/value/processor/TypeSimplifierTest.java
+++ b/value/src/test/java/com/google/auto/value/processor/TypeSimplifierTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Google Inc.
+ * Copyright 2012 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/test/java/com/google/auto/value/processor/TypeSimplifierTest.java
+++ b/value/src/test/java/com/google/auto/value/processor/TypeSimplifierTest.java
@@ -16,6 +16,7 @@
 package com.google.auto.value.processor;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
 
 import com.google.testing.compile.CompilationRule;
 import java.util.List;
@@ -226,8 +227,8 @@ public class TypeSimplifierTest {
       }
       TypeMirror fieldType = field.asType();
       boolean actualUnchecked = TypeSimplifier.isCastingUnchecked(fieldType);
-      assertThat(actualUnchecked)
-          .named("Unchecked-cast status for " + fieldType)
+      assertWithMessage("Unchecked-cast status for " + fieldType)
+          .that(actualUnchecked)
           .isEqualTo(expectUnchecked);
     }
   }

--- a/value/src/test/java/com/google/auto/value/processor/TypeVariablesTest.java
+++ b/value/src/test/java/com/google/auto/value/processor/TypeVariablesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Google, Inc.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value/src/test/java/com/google/auto/value/processor/testclasses/RuntimePermission.java
+++ b/value/src/test/java/com/google/auto/value/processor/testclasses/RuntimePermission.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Google, Inc.
+ * Copyright 2016 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Update copyrights to say Google LLC instead of Google Inc.

0079a8d327c8e500260c32014743a73c176e78e2

-------

<p> If $foo is a Map then Velocity interprets $foo.bar the same as $foo["bar"]. Previously EscapeVelocity interpreted it the same as for other objects, by looking for a getBar() method (or boolean isBar()).

It turns out that autoannotation.vm was depending on the old behaviour, so fix that.

6a8497e0bcdbd36074949c7337730140c57ebc94

-------

<p> Use the newer compile-testing API in AutoAnnotationCompilationTest.

9df8881727207ba867683ade13cdf302d65e0a1a

-------

<p> Update to Truth 0.44.

de820d34ceb7f97fbe4de345a9919cb6af58bcca

-------

<p> Migrate from assertThat(foo).named("foo") to assertWithMessage("foo").that(foo).

(The exact change is slightly different in some cases, like when using custom subjects or check(), but it's always a migration from named(...) to [assert]WithMessage(...).)

named(...) is being removed.

This CL may slightly modify the failure messages produced, but all the old information will still be present.

6bf345ddffef9f916797ebff6323f321fedb1b82