### PR TITLE
Moe Sync

### DIFF
--- a/value/src/test/java/com/google/auto/value/processor/GuavaCollectionBuildersTest.java
+++ b/value/src/test/java/com/google/auto/value/processor/GuavaCollectionBuildersTest.java
@@ -89,8 +89,8 @@ public class GuavaCollectionBuildersTest {
     Class<?> builderClass = Class.forName(c.getName() + "$Builder");
     expect.that(builderMethod.getReturnType()).isEqualTo(builderClass);
     expect
+        .withMessage(c.getName())
         .that(Arrays.toString(builderMethodParameterizedReturn.getActualTypeArguments()))
-        .named(c.getName())
         .isEqualTo(Arrays.toString(builderClass.getTypeParameters()));
 
     // The Builder has a public build() method that returns ImmutableFoo.
@@ -110,6 +110,6 @@ public class GuavaCollectionBuildersTest {
         }
       }
     }
-    expect.that(found).named(builderClass.getName() + " has addAll or putAll").isTrue();
+    expect.withMessage(builderClass.getName() + " has addAll or putAll").that(found).isTrue();
   }
 }


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Migrate from assertThat(foo).named("foo") to assertWithMessage("foo").that(foo).

(The exact change is slightly different in some cases, like when using custom subjects or check(), but it's always a migration from named(...) to [assert]WithMessage(...).)

named(...) is being removed.

This CL may slightly modify the failure messages produced, but all the old information will still be present.

e39fdad3200647211083d03996de56d7c875d8df