### PR TITLE
Moe Sync

### DIFF
--- a/value/src/test/java/com/google/auto/value/extension/memoized/MemoizedMethodSubject.java
+++ b/value/src/test/java/com/google/auto/value/extension/memoized/MemoizedMethodSubject.java
@@ -28,9 +28,11 @@ import com.google.testing.compile.JavaFileObjects;
 import javax.tools.JavaFileObject;
 
 final class MemoizedMethodSubject extends Subject<MemoizedMethodSubject, String> {
+  private final String actual;
 
-  MemoizedMethodSubject(FailureMetadata failureMetadata, String subject) {
-    super(failureMetadata, subject);
+  MemoizedMethodSubject(FailureMetadata failureMetadata, String actual) {
+    super(failureMetadata, actual);
+    this.actual = actual;
   }
 
   void hasError(String error) {
@@ -42,7 +44,7 @@ final class MemoizedMethodSubject extends Subject<MemoizedMethodSubject, String>
             "",
             "@AutoValue abstract class Value {",
             "  abstract String string();",
-            getSubject(),
+            actual,
             "}");
     assertAbout(javaSource())
         .that(file)


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Instead of calling Subject.actual(), store the actual value in a field, and read that.

actual() is being removed.

0b6ea9775d9f5731664d9fd07083ecdca7721c5d