### PR TITLE
Moe Sync

### DIFF
--- a/value/processor/pom.xml
+++ b/value/processor/pom.xml
@@ -53,6 +53,12 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>com.google.errorprone</groupId>
+      <artifactId>error_prone_annotations</artifactId>
+      <version>2.3.3</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>com.google.escapevelocity</groupId>
       <artifactId>escapevelocity</artifactId>
       <version>0.9</version>

--- a/value/src/main/java/com/google/auto/value/processor/AutoAnnotationProcessor.java
+++ b/value/src/main/java/com/google/auto/value/processor/AutoAnnotationProcessor.java
@@ -26,6 +26,7 @@ import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.primitives.Primitives;
+import com.google.errorprone.annotations.FormatMethod;
 import java.io.IOException;
 import java.io.Writer;
 import java.util.Collection;
@@ -82,6 +83,7 @@ public class AutoAnnotationProcessor extends AbstractProcessor {
    * Issue a compilation error. This method does not throw an exception, since we want to continue
    * processing and perhaps report other errors.
    */
+  @FormatMethod
   private void reportError(Element e, String msg, Object... msgParams) {
     String formattedMessage = String.format(msg, msgParams);
     processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, formattedMessage, e);
@@ -91,8 +93,9 @@ public class AutoAnnotationProcessor extends AbstractProcessor {
    * Issue a compilation error and return an exception that, when thrown, will cause the processing
    * of this class to be abandoned. This does not prevent the processing of other classes.
    */
-  private AbortProcessingException abortWithError(String msg, Element e) {
-    reportError(e, msg);
+  @FormatMethod
+  private AbortProcessingException abortWithError(Element e, String msg, Object... msgParams) {
+    reportError(e, msg, msgParams);
     return new AbortProcessingException();
   }
 
@@ -141,7 +144,7 @@ public class AutoAnnotationProcessor extends AbstractProcessor {
 
   private void processMethod(ExecutableElement method) {
     if (!method.getModifiers().contains(Modifier.STATIC)) {
-      throw abortWithError("@AutoAnnotation method must be static", method);
+      throw abortWithError(method, "@AutoAnnotation method must be static");
     }
 
     TypeElement annotationElement = getAnnotationReturnType(method);
@@ -276,8 +279,9 @@ public class AutoAnnotationProcessor extends AbstractProcessor {
       }
     }
     throw abortWithError(
-        "Return type of @AutoAnnotation method must be an annotation type, not " + returnTypeMirror,
-        method);
+        method,
+        "Return type of @AutoAnnotation method must be an annotation type, not %s",
+        returnTypeMirror);
   }
 
   private ImmutableMap<String, ExecutableElement> getMemberMethods(TypeElement annotationElement) {

--- a/value/src/main/java/com/google/auto/value/processor/AutoAnnotationProcessor.java
+++ b/value/src/main/java/com/google/auto/value/processor/AutoAnnotationProcessor.java
@@ -499,6 +499,12 @@ public class AutoAnnotationProcessor extends AbstractProcessor {
       return getTypeMirror().getKind();
     }
 
+    // Used as part of the hashCode() computation.
+    // See https://docs.oracle.com/javase/8/docs/api/java/lang/annotation/Annotation.html#hashCode--
+    public int getNameHash() {
+      return 127 * toString().hashCode();
+    }
+
     public boolean isArrayOfClassWithBounds() {
       if (getTypeMirror().getKind() != TypeKind.ARRAY) {
         return false;

--- a/value/src/main/java/com/google/auto/value/processor/PropertyBuilderClassifier.java
+++ b/value/src/main/java/com/google/auto/value/processor/PropertyBuilderClassifier.java
@@ -356,11 +356,21 @@ class PropertyBuilderClassifier {
     // with the same name.
     Map<String, ExecutableElement> methods = new LinkedHashMap<String, ExecutableElement>();
     for (ExecutableElement method : ElementFilter.methodsIn(elementUtils.getAllMembers(type))) {
-      if (method.getParameters().isEmpty()) {
+      if (method.getParameters().isEmpty() && !isStaticInterfaceMethodNotIn(method, type)) {
         methods.put(method.getSimpleName().toString(), method);
       }
     }
     return methods;
+  }
+
+  // Work around an Eclipse compiler bug: https://bugs.eclipse.org/bugs/show_bug.cgi?id=547185
+  // The result of Elements.getAllMembers includes static methods declared in superinterfaces.
+  // That's wrong because those aren't inherited. So this method checks whether the given method is
+  // a static interface method not in the given type.
+  private static boolean isStaticInterfaceMethodNotIn(ExecutableElement method, TypeElement type) {
+    return method.getModifiers().contains(Modifier.STATIC)
+        && !method.getEnclosingElement().equals(type)
+        && method.getEnclosingElement().getKind().equals(ElementKind.INTERFACE);
   }
 
   private Optional<ExecutableElement> addAllPutAll(TypeElement barBuilderTypeElement) {

--- a/value/src/main/java/com/google/auto/value/processor/autoannotation.vm
+++ b/value/src/main/java/com/google/auto/value/processor/autoannotation.vm
@@ -257,13 +257,6 @@ final class $className implements $annotationName {
   #end
 #end
 
-## Compute the member name's contribution to the hashcode directly in the
-## template engine, to avoid triggering a compiler error for integer overflow.
-#macro (memberNameHash $m)
-  #set ($hc = 127 * $m.toString().hashCode())
-  ${hc} ##
-#end
-
 ## The hashCode is the sum of two parts, an invariable part and a variable part. The invariable part
 ## comes from defaulted members (ones that don't appear in the @AutoAnnotation method parameters)
 ## whose values have hash codes that never change. (That doesn't include Class constants, for
@@ -285,8 +278,8 @@ final class $className implements $annotationName {
     #foreach ($m in $members)
       #if (!$invariableHashes.contains($m.toString()))
 
-        + (#memberNameHash($m) ^ (#memberHashCodeExpression($m)))
-            // #memberNameHash($m) is 127 * "${m}".hashCode()
+        + ($m.nameHash ^ (#memberHashCodeExpression($m)))
+            // $m.nameHash is 127 * "${m}".hashCode()
       #end
     #end
 


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> In autoannotation.vm, avoid an incompatibility between EscapeVelocity and Apache Velocity. In Velocity, if an Integer multiplication overflows, the result is a Long with the correct value. In EscapeVelocity, the result is an Integer containing the bottom 32 bits of the multiplication. We should fix this incompatibility, but for now we can avoid it by doing the computation in Java rather than in the template.

27244baf29edaa94d22e3750a7b5aa71cae22187

-------

<p> Use @FormatMethod in AutoAnnotationProcessor. This addresses an ErrorProne warning in []

5724c0db1331698389b2da12d650151d1e605b4a

-------

<p> Work around an ecj bug in Elements.getAllMembers(). It incorrectly returns static methods from superinterfaces, even though those aren't inherited. This causes AutoValueTest not to compile with ecj on Java 9+, because the MyMap and MyStringMap classes are wrongly shown to contain the static "of()" method that was added to Map in Java 9. AutoValue then tries to use MyMap.of() to construct a default instance of MyMap.

RELNOTES=Worked around an Eclipse compiler bug where static interface methods are incorrectly shown as being inherited.

3854a6508a8cc72eda1ae15b08ab3949d1cc778d