### PR TITLE
Moe Sync

### DIFF
--- a/common/src/test/java/com/google/auto/common/BasicAnnotationProcessorTest.java
+++ b/common/src/test/java/com/google/auto/common/BasicAnnotationProcessorTest.java
@@ -307,18 +307,10 @@ public class BasicAnnotationProcessorTest {
 
   private static <K, V>
       Correspondence<SetMultimap<K, V>, SetMultimap<K, String>> setMultimapValuesByString() {
-    return new Correspondence<SetMultimap<K, V>, SetMultimap<K, String>>() {
-      @Override
-      public boolean compare(SetMultimap<K, V> actual, SetMultimap<K, String> expected) {
-        return ImmutableSetMultimap.copyOf(transformValues(actual, Object::toString))
-            .equals(expected);
-      }
-
-      @Override
-      public String toString() {
-        return "is equivalent comparing multimap values by `toString()` to";
-      }
-    };
+    return Correspondence.from(
+        (actual, expected) ->
+            ImmutableSetMultimap.copyOf(transformValues(actual, Object::toString)).equals(expected),
+        "is equivalent comparing multimap values by `toString()` to");
   }
 
   @Test public void reportsMissingType() {

--- a/factory/pom.xml
+++ b/factory/pom.xml
@@ -83,6 +83,12 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>net.ltgt.gradle.incap</groupId>
+      <artifactId>incap</artifactId>
+      <version>0.2</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>com.google.googlejavaformat</groupId>
       <artifactId>google-java-format</artifactId>
       <version>1.5</version>

--- a/factory/src/main/java/com/google/auto/factory/processor/AutoFactoryProcessor.java
+++ b/factory/src/main/java/com/google/auto/factory/processor/AutoFactoryProcessor.java
@@ -51,12 +51,15 @@ import javax.lang.model.util.ElementFilter;
 import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
 import javax.tools.Diagnostic.Kind;
+import net.ltgt.gradle.incap.IncrementalAnnotationProcessor;
+import net.ltgt.gradle.incap.IncrementalAnnotationProcessorType;
 
 /**
  * The annotation processor that generates factories for {@link AutoFactory} annotations.
  *
  * @author Gregory Kick
  */
+@IncrementalAnnotationProcessor(IncrementalAnnotationProcessorType.ISOLATING)
 @AutoService(Processor.class)
 public final class AutoFactoryProcessor extends AbstractProcessor {
   private FactoryDescriptorGenerator factoryDescriptorGenerator;

--- a/factory/src/main/java/com/google/auto/factory/processor/FactoryDescriptor.java
+++ b/factory/src/main/java/com/google/auto/factory/processor/FactoryDescriptor.java
@@ -56,6 +56,10 @@ abstract class FactoryDescriptor {
   abstract boolean allowSubclasses();
   abstract ImmutableMap<Key, ProviderField> providers();
 
+  final AutoFactoryDeclaration declaration() {
+    return Iterables.getFirst(methodDescriptors(), null).declaration();
+  }
+
   private static class UniqueNameSet {
     private final Set<String> uniqueNames = new HashSet<String>();
 

--- a/factory/src/main/java/com/google/auto/factory/processor/FactoryWriter.java
+++ b/factory/src/main/java/com/google/auto/factory/processor/FactoryWriter.java
@@ -106,7 +106,7 @@ final class FactoryWriter {
     Iterator<ProviderField> providerFields = descriptor.providers().values().iterator();
     for (int argumentIndex = 1; providerFields.hasNext(); argumentIndex++) {
       ProviderField provider = providerFields.next();
-      TypeName typeName = TypeName.get(provider.key().type()).box();
+      TypeName typeName = TypeName.get(provider.key().type().get()).box();
       TypeName providerType = ParameterizedTypeName.get(ClassName.get(Provider.class), typeName);
       factory.addField(providerType, provider.name(), PRIVATE, FINAL);
       if (provider.key().qualifier().isPresent()) {

--- a/factory/src/main/java/com/google/auto/factory/processor/FactoryWriter.java
+++ b/factory/src/main/java/com/google/auto/factory/processor/FactoryWriter.java
@@ -67,7 +67,9 @@ final class FactoryWriter {
   void writeFactory(final FactoryDescriptor descriptor)
       throws IOException {
     String factoryName = getSimpleName(descriptor.name()).toString();
-    TypeSpec.Builder factory = classBuilder(factoryName);
+    TypeSpec.Builder factory =
+        classBuilder(factoryName)
+            .addOriginatingElement(descriptor.declaration().targetType());
     generatedAnnotationSpec(
             elements,
             sourceVersion,

--- a/factory/src/main/java/com/google/auto/factory/processor/Key.java
+++ b/factory/src/main/java/com/google/auto/factory/processor/Key.java
@@ -38,9 +38,11 @@ import javax.lang.model.util.Types;
  * @author Gregory Kick
  */
 @AutoValue
+// TODO(ronshapiro): reuse dagger.model.Key?
 abstract class Key {
 
-  abstract TypeMirror type();
+  abstract Equivalence.Wrapper<TypeMirror> type();
+
   abstract Optional<Equivalence.Wrapper<AnnotationMirror>> qualifierWrapper();
 
   Optional<AnnotationMirror> qualifier() {
@@ -80,7 +82,8 @@ abstract class Key {
             ? MoreTypes.asDeclared(type).getTypeArguments().get(0)
             : boxedType(type, types);
     return new AutoValue_Key(
-        keyType, wrapOptionalInEquivalence(AnnotationMirrors.equivalence(), qualifier));
+        MoreTypes.equivalence().wrap(keyType),
+        wrapOptionalInEquivalence(AnnotationMirrors.equivalence(), qualifier));
   }
 
   /**
@@ -95,7 +98,7 @@ abstract class Key {
 
   @Override
   public String toString() {
-    String typeQualifiedName = MoreTypes.asTypeElement(type()).toString();
+    String typeQualifiedName = MoreTypes.asTypeElement(type().get()).toString();
     return qualifier().isPresent()
         ? qualifier().get() + "/" + typeQualifiedName
         : typeQualifiedName;

--- a/factory/src/test/resources/expected/CheckerFrameworkNullableFactory.java
+++ b/factory/src/test/resources/expected/CheckerFrameworkNullableFactory.java
@@ -27,24 +27,21 @@ import org.checkerframework.checker.nullness.compatqual.NullableType;
 )
 final class CheckerFrameworkNullableFactory {
 
-  private final Provider<String> providedNullableDeclProvider;
-  private final Provider<String> providedNullableTypeProvider;
+  private final Provider<String> java_lang_StringProvider;
 
   @Inject
   CheckerFrameworkNullableFactory(
-      Provider<String> providedNullableDeclProvider,
-      Provider<String> providedNullableTypeProvider) {
-    this.providedNullableDeclProvider = checkNotNull(providedNullableDeclProvider, 1);
-    this.providedNullableTypeProvider = checkNotNull(providedNullableTypeProvider, 2);
+      Provider<String> java_lang_StringProvider) {
+    this.java_lang_StringProvider = checkNotNull(java_lang_StringProvider, 1);
   }
 
   CheckerFrameworkNullable create(
       @NullableDecl String nullableDecl, @NullableType String nullableType) {
     return new CheckerFrameworkNullable(
         nullableDecl,
-        providedNullableDeclProvider.get(),
+        java_lang_StringProvider.get(),
         nullableType,
-        providedNullableTypeProvider.get());
+        java_lang_StringProvider.get());
   }
 
   private static <T> T checkNotNull(T reference, int argumentIndex) {

--- a/value/src/main/java/com/google/auto/value/processor/AutoOneOfProcessor.java
+++ b/value/src/main/java/com/google/auto/value/processor/AutoOneOfProcessor.java
@@ -64,6 +64,11 @@ public class AutoOneOfProcessor extends AutoValueOrOneOfProcessor {
   }
 
   @Override
+  boolean propertiesCanBeVoid() {
+    return true;
+  }
+
+  @Override
   void processType(TypeElement autoOneOfType) {
     if (autoOneOfType.getKind() != ElementKind.CLASS) {
       errorReporter()
@@ -255,6 +260,10 @@ public class AutoOneOfProcessor extends AutoValueOrOneOfProcessor {
         propertySet(type, propertyMethods, ImmutableListMultimap.of(), ImmutableListMultimap.of());
     vars.kindGetter = kindGetter.getSimpleName().toString();
     vars.kindType = TypeEncoder.encode(kindGetter.getReturnType());
+    TypeElement javaIoSerializable = elementUtils().getTypeElement("java.io.Serializable");
+    vars.serializable =
+        javaIoSerializable != null  // just in case
+        && typeUtils().isAssignable(type.asType(), javaIoSerializable.asType());
   }
 
   @Override

--- a/value/src/main/java/com/google/auto/value/processor/AutoOneOfTemplateVars.java
+++ b/value/src/main/java/com/google/auto/value/processor/AutoOneOfTemplateVars.java
@@ -44,6 +44,9 @@ class AutoOneOfTemplateVars extends AutoValueOrOneOfTemplateVars {
   /** Maps property names like {@code dog} to enum constants like {@code DOG}. */
   Map<String, String> propertyToKind;
 
+  /** True if this {@code @AutoOneOf} class is Serializable. */
+  Boolean serializable;
+
   private static final Template TEMPLATE = parsedTemplateForResource("autooneof.vm");
 
   @Override

--- a/value/src/main/java/com/google/auto/value/processor/AutoValueOrOneOfProcessor.java
+++ b/value/src/main/java/com/google/auto/value/processor/AutoValueOrOneOfProcessor.java
@@ -719,16 +719,21 @@ abstract class AutoValueOrOneOfProcessor extends AbstractProcessor {
    * Returns the subset of property methods in the given set of abstract methods. A property method
    * has no arguments, is not void, and is not {@code hashCode()} or {@code toString()}.
    */
-  static ImmutableSet<ExecutableElement> propertyMethodsIn(Set<ExecutableElement> abstractMethods) {
+  ImmutableSet<ExecutableElement> propertyMethodsIn(Set<ExecutableElement> abstractMethods) {
     ImmutableSet.Builder<ExecutableElement> properties = ImmutableSet.builder();
     for (ExecutableElement method : abstractMethods) {
       if (method.getParameters().isEmpty()
-          && method.getReturnType().getKind() != TypeKind.VOID
+          && (method.getReturnType().getKind() != TypeKind.VOID || propertiesCanBeVoid())
           && objectMethodToOverride(method) == ObjectMethod.NONE) {
         properties.add(method);
       }
     }
     return properties.build();
+  }
+
+  /** True if void properties are allowed. */
+  boolean propertiesCanBeVoid() {
+    return false;
   }
 
   /**

--- a/value/src/main/java/com/google/auto/value/processor/BuilderMethodClassifier.java
+++ b/value/src/main/java/com/google/auto/value/processor/BuilderMethodClassifier.java
@@ -526,26 +526,28 @@ class BuilderMethodClassifier {
     if (!targetType.getKind().equals(TypeKind.DECLARED)) {
       return ImmutableList.of();
     }
-    String copyOf;
+    ImmutableSet<String> copyOfNames;
     Optionalish optionalish = Optionalish.createIfOptional(targetType);
     if (optionalish == null) {
-      copyOf = "copyOf";
+      copyOfNames = ImmutableSet.of("copyOfSorted", "copyOf");
     } else {
       VariableElement parameterElement = Iterables.getOnlyElement(setter.getParameters());
       boolean nullable =
           AutoValueOrOneOfProcessor.nullableAnnotationFor(
                   parameterElement, parameterElement.asType())
               .isPresent();
-      copyOf = nullable ? optionalish.ofNullable() : "of";
+      copyOfNames = ImmutableSet.of(nullable ? optionalish.ofNullable() : "of");
     }
     TypeElement targetTypeElement = MoreElements.asType(typeUtils.asElement(targetType));
     ImmutableList.Builder<ExecutableElement> copyOfMethods = ImmutableList.builder();
-    for (ExecutableElement method :
-        ElementFilter.methodsIn(targetTypeElement.getEnclosedElements())) {
-      if (method.getSimpleName().contentEquals(copyOf)
-          && method.getParameters().size() == 1
-          && method.getModifiers().contains(Modifier.STATIC)) {
-        copyOfMethods.add(method);
+    for (String copyOfName : copyOfNames) {
+      for (ExecutableElement method :
+          ElementFilter.methodsIn(targetTypeElement.getEnclosedElements())) {
+        if (method.getSimpleName().contentEquals(copyOfName)
+            && method.getParameters().size() == 1
+            && method.getModifiers().contains(Modifier.STATIC)) {
+          copyOfMethods.add(method);
+        }
       }
     }
     return copyOfMethods.build();

--- a/value/src/main/java/com/google/auto/value/processor/PropertyBuilderClassifier.java
+++ b/value/src/main/java/com/google/auto/value/processor/PropertyBuilderClassifier.java
@@ -186,7 +186,8 @@ class PropertyBuilderClassifier {
   // (1) It must have an instance method called `build()` that returns `Bar`. If the type of
   //     `bar()` is `Bar<String>` then the type of `build()` must be `Bar<String>`.
   // (2) `BarBuilder` must have a public no-arg constructor, or `Bar` must have a static method
-  //     `builder()` or `newBuilder()` that returns `BarBuilder`.
+  //     `naturalOrder(), `builder()`, or `newBuilder()` that returns `BarBuilder`. The
+  //     `naturalOrder()` case is specifically for ImmutableSortedSet and ImmutableSortedMap.
   // (3) `Bar` must have an instance method `BarBuilder toBuilder()`, or `BarBuilder` must be a
   //      Guava immutable builder like `ImmutableSet.Builder`. (See TODO below for relaxing the
   //      requirement on having a `toBuilder()`.
@@ -324,10 +325,10 @@ class PropertyBuilderClassifier {
   }
 
   private static final ImmutableSet<String> BUILDER_METHOD_NAMES =
-      ImmutableSet.of("builder", "newBuilder");
+      ImmutableSet.of("naturalOrder", "builder", "newBuilder");
 
   // (2) `BarBuilder must have a public no-arg constructor, or `Bar` must have a visible static
-  //      method `builder()` or `newBuilder()` that returns `BarBuilder`.
+  //      method `naturalOrder(), `builder()`, or `newBuilder()` that returns `BarBuilder`.
   private Optional<ExecutableElement> builderMaker(
       Map<String, ExecutableElement> barNoArgMethods, TypeElement barBuilderTypeElement) {
     for (String builderMethodName : BUILDER_METHOD_NAMES) {

--- a/value/src/main/java/com/google/auto/value/processor/autooneof.vm
+++ b/value/src/main/java/com/google/auto/value/processor/autooneof.vm
@@ -46,6 +46,14 @@ final class $generatedClass {
 ## Factory methods.
 #foreach ($p in $props)
 
+  #if ($p.type == "void")
+
+  static $origClass$wildcardTypes $p() {
+    return Impl_${p}.INSTANCE;
+  }
+
+  #else
+
   ## If the @AutoOneOf type is TaskResult<V extends Serializable>, then we might have here:
   ## static <V extends Serializable> TaskResult<V> value(V value) {
   ##   return new Impl_value<V>(value);
@@ -55,16 +63,18 @@ final class $generatedClass {
 
   static $formalTypes $origClass$actualTypes $p($p.type $p) {
 
-  #if (!$p.kind.primitive)
+    #if (!$p.kind.primitive)
 
     if ($p == null) {
       throw new NullPointerException();
     }
 
-  #end
+    #end
 
     return new Impl_$p$actualTypes($p);
   }
+
+  #end
 
 #end
 
@@ -99,6 +109,59 @@ final class $generatedClass {
 
   // Implementation when the contained property is "${p}".
   private static final class Impl_$p$formalTypes extends Parent_$actualTypes {
+
+  #if ($p.type == "void")
+
+    // There is only one instance of this class.
+    static final Impl_$p$wildcardTypes INSTANCE = new ##
+      #if ($wildcardTypes == "") Impl_$p() #else Impl_$p<>() #end;
+
+    private Impl_$p() {}
+
+    @Override
+    public void ${p.getter}() {}
+
+    #if ($serializable)
+
+    private Object readResolve() {
+      return INSTANCE;
+    }
+
+    #end
+
+    #if ($toString)
+
+    @Override
+    public String toString() {
+      return "${simpleClassName}{$p.name}";
+    }
+
+    #end
+
+    ## The implementations of equals and hashCode are equivalent to the ones
+    ## we inherit from Object. We only need to define them if they're redeclared
+    ## as abstract in an ancestor class. But currently we define them always.
+
+    #if ($equals)
+
+    @Override
+    public boolean equals($equalsParameterType x) {
+      return x == this;
+    }
+
+    #end
+
+    #if ($hashCode)
+
+    @Override
+    public int hashCode() {
+      return System.identityHashCode(this);
+    }
+
+    #end
+
+  #else
+
     private final $p.type $p;
 
     Impl_$p($p.type $p) {
@@ -106,25 +169,20 @@ final class $generatedClass {
     }
 
     @Override
-    public $kindType ${kindGetter}() {
-      return ${kindType}.$propertyToKind[$p.name];
-    }
-
-    @Override
     public $p.type ${p.getter}() {
       return $p;
     }
 
-  #if ($toString)
+    #if ($toString)
 
     @Override
     public String toString() {
       return "${simpleClassName}{$p.name=" + this.$p + "}";
     }
 
-  #end
+    #end
 
-  #if ($equals)
+    #if ($equals)
 
     @Override
     public boolean equals($equalsParameterType x) {
@@ -137,16 +195,23 @@ final class $generatedClass {
       }
     }
 
-  #end
+    #end
 
-  #if ($hashCode)
+    #if ($hashCode)
 
     @Override
     public int hashCode() {
       return #hashCodeExpression($p);
     }
 
+    #end
+
   #end
+
+    @Override
+    public $kindType ${kindGetter}() {
+      return ${kindType}.$propertyToKind[$p.name];
+    }
 
   }
 

--- a/value/src/test/java/com/google/auto/value/processor/AutoOneOfCompilationTest.java
+++ b/value/src/test/java/com/google/auto/value/processor/AutoOneOfCompilationTest.java
@@ -44,11 +44,12 @@ public class AutoOneOfCompilationTest {
             "",
             "@AutoOneOf(TaskResult.Kind.class)",
             "public abstract class TaskResult<V, T extends Throwable> {",
-            "  public enum Kind {VALUE, EXCEPTION}",
+            "  public enum Kind {VALUE, EXCEPTION, EMPTY}",
             "  public abstract Kind getKind();",
             "",
             "  public abstract V value();",
             "  public abstract Throwable exception();",
+            "  public abstract void empty();",
             "",
             "  public static <V> TaskResult<V, ?> value(V value) {",
             "    return AutoOneOf_TaskResult.value(value);",
@@ -83,6 +84,10 @@ public class AutoOneOfCompilationTest {
             "    return new Impl_exception<V, T>(exception);",
             "  }",
             "",
+            "  static TaskResult<?, ?> empty() {",
+            "    return Impl_empty.INSTANCE;",
+            "  }",
+            "",
             "  // Parent class that each implementation will inherit from.",
             "  private abstract static class Parent_<V, T extends Throwable> "
                 + "extends TaskResult<V, T> {",
@@ -95,6 +100,11 @@ public class AutoOneOfCompilationTest {
             "    public Throwable exception() {",
             "      throw new UnsupportedOperationException(getKind().toString());",
             "    }",
+            "",
+            "    @Override",
+            "    public void empty() {",
+            "      throw new UnsupportedOperationException(getKind().toString());",
+            "    }",
             "  }",
             "",
             "  // Implementation when the contained property is \"value\".",
@@ -104,11 +114,6 @@ public class AutoOneOfCompilationTest {
             "",
             "    Impl_value(V value) {",
             "      this.value = value;",
-            "    }",
-            "",
-            "    @Override",
-            "    public TaskResult.Kind getKind() {",
-            "      return TaskResult.Kind.VALUE;",
             "    }",
             "",
             "    @Override",
@@ -136,6 +141,11 @@ public class AutoOneOfCompilationTest {
             "    public int hashCode() {",
             "      return value.hashCode();",
             "    }",
+            "",
+            "    @Override",
+            "    public TaskResult.Kind getKind() {",
+            "      return TaskResult.Kind.VALUE;",
+            "    }",
             "  }",
             "",
             "  // Implementation when the contained property is \"exception\".",
@@ -145,11 +155,6 @@ public class AutoOneOfCompilationTest {
             "",
             "    Impl_exception(Throwable exception) {",
             "      this.exception = exception;",
-            "    }",
-            "",
-            "    @Override",
-            "    public TaskResult.Kind getKind() {",
-            "      return TaskResult.Kind.EXCEPTION;",
             "    }",
             "",
             "    @Override",
@@ -176,6 +181,42 @@ public class AutoOneOfCompilationTest {
             "    @Override",
             "    public int hashCode() {",
             "      return exception.hashCode();",
+            "    }",
+            "",
+            "    @Override",
+            "    public TaskResult.Kind getKind() {",
+            "      return TaskResult.Kind.EXCEPTION;",
+            "    }",
+            "  }",
+            "",
+            "  // Implementation when the contained property is \"empty\".",
+            "  private static final class Impl_empty<V, T extends Throwable> "
+                + "extends Parent_<V, T> {",
+            "    static final Impl_empty<?, ?> INSTANCE = new Impl_empty<>();",
+            "",
+            "    private Impl_empty() {}",
+            "",
+            "    @Override",
+            "    public void empty() {}",
+            "",
+            "    @Override",
+            "    public String toString() {",
+            "      return \"TaskResult{empty}\";",
+            "    }",
+            "",
+            "    @Override",
+            "    public boolean equals(Object x) {",
+            "      return x == this;",
+            "    }",
+            "",
+            "    @Override",
+            "    public int hashCode() {",
+            "      return System.identityHashCode(this);",
+            "    }",
+            "",
+            "    @Override",
+            "    public TaskResult.Kind getKind() {",
+            "      return TaskResult.Kind.EMPTY;",
             "    }",
             "  }");
     Compilation compilation =
@@ -318,35 +359,6 @@ public class AutoOneOfCompilationTest {
             "Name of enum constant 'GERBIL' does not correspond to any property name")
         .inFile(javaFileObject)
         .onLineContaining("GERBIL");
-  }
-
-  @Test
-  public void abstractVoidMethod() {
-    JavaFileObject javaFileObject =
-        JavaFileObjects.forSourceLines(
-            "foo.bar.Pet",
-            "package foo.bar;",
-            "",
-            "import com.google.auto.value.AutoOneOf;",
-            "",
-            "@AutoOneOf(Pet.Kind.class)",
-            "public abstract class Pet {",
-            "  public enum Kind {",
-            "    DOG,",
-            "    CAT,",
-            "  }",
-            "  public abstract Kind getKind();",
-            "  public abstract String dog();",
-            "  public abstract String cat();",
-            "  public abstract void frob();",
-            "}");
-    Compilation compilation =
-        javac().withProcessors(new AutoOneOfProcessor()).compile(javaFileObject);
-    assertThat(compilation)
-        .hadWarningContaining(
-            "Abstract methods in @AutoOneOf classes must be non-void with no parameters")
-        .inFile(javaFileObject)
-        .onLineContaining("frob");
   }
 
   @Test

--- a/value/src/test/java/com/google/auto/value/processor/AutoValueCompilationTest.java
+++ b/value/src/test/java/com/google/auto/value/processor/AutoValueCompilationTest.java
@@ -2154,8 +2154,9 @@ public class AutoValueCompilationTest {
             .compile(javaFileObject);
     assertThat(compilation)
         .hadErrorContaining(
-            "Method without arguments should be a build method returning foo.bar.Baz"
-                + " or a getter method with the same name and type as a getter method of foo.bar.Baz")
+            "Method without arguments should be a build method returning foo.bar.Baz, or a getter"
+                + " method with the same name and type as a getter method of foo.bar.Baz, or"
+                + " fooBuilder() where foo() or getFoo() is a getter method of foo.bar.Baz")
         .inFile(javaFileObject)
         .onLine(12);
   }

--- a/value/userguide/howto.md
+++ b/value/userguide/howto.md
@@ -536,9 +536,52 @@ factory method for each property, with the same name. In the example, the
 `STRING` value in the enum corresponds to the `string()` property and to the
 `AutoOneOf_StringOrInteger.string` factory method.
 
+Properties in an `@AutoOneOf` class can be `void` to indicate that the
+corresponding variant has no data. In that case, the factory method for that
+variant has no parameters:
+
+```java
+@AutoOneOf(Transform.Kind.class)
+public abstract class Transform {
+  public enum Kind {NONE, CIRCLE_CROP, BLUR}
+  public abstract Kind getKind();
+
+  abstract void none();
+
+  abstract void circleCrop();
+
+  public abstract BlurTransformParameters blur();
+
+  public static Transform ofNone() {
+    return AutoOneOf_Transform.none();
+  }
+  
+  public static Transform ofCircleCrop() {
+    return AutoOneOf_Transform.circleCrop();
+  }
+
+  public static Transform ofBlur(BlurTransformParmeters params) {}
+    return AutoOneOf_Transform.blur(params);
+  }
+}
+```
+
+Here, the `NONE` and `CIRCLE_CROP` variants have no associated data but are
+distinct from each other. The `BLUR` variant does have data. The `none()`
+and `circleCrop()` methods are package-private; they must exist to configure
+`@AutoOneOf`, but calling them is not very useful. (It does nothing if the
+instance is of the correct variant, or throws an exception otherwise.)
+
+The `AutoOneOf_Transform.none()` and `AutoOneOf_Transform.circleCrop()` methods
+return the same instance every time they are called.
+
+If one of the `void` variants means "none", consider using an `Optional<Transform>` or
+a `@Nullable Transform` instead of that variant.
+
 Properties in an `@AutoOneOf` class cannot be null. Instead of a
 `StringOrInteger` with a `@Nullable String`, you probably want a
-`@Nullable StringOrInteger` or an `Optional<StringOrInteger>`.
+`@Nullable StringOrInteger` or an `Optional<StringOrInteger>`, or an empty
+variant as just described.
 
 ## <a name="copy_annotations"></a>... copy annotations from a class/method to the implemented class/method/field?
 


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Don't compare TypeMirrors using Object#equals

They don't override Object#equals and are not interned, so reference
equality is not useful. This was causing unnecessary duplication of
Provider fields in AutoFactories.

d9c0593d3359b2aecf04f9b9fef51c091009d73e

-------

<p> Add an originating element for AutoFactory types

c148ee4c6cc332e1115a1fc488fae85d9eb13162

-------

<p> Make AutoFactory an isolating annotation processor in Gradle

RELNOTES=Gradle: `@AutoFactory` is now an isolating annotation processor

0b58d0428800f186e8430a9f51673c2fa5383744

-------

<p> Allow @AutoOneOf properties to be void.

An abstract void method means that the associated kind has no value. The factory method has no parameter and calling the implementation of the void method does nothing unless the instance is of another kind.

RELNOTES=Allow @AutoOneOf properties to be void.

d5e4f555ec8cd715b1c4a920aaed435d2118b5f0

-------

<p> Improve the logic for setter type conversion. Setter type conversion is when for example we have a property `Optional<String> foo()` or `ImmutableList<String> bar()` and a setter like `setFoo(String x)` or `setBar(String[] x)`. The generated setter will need to do `Optional.of(x)` or `ImmutableList.copyOf(x)`.

Previously the logic to do this was split into two places: (a) where we determined whether a conversion was possible, and (b) where we generated the code. In (b) we had to guess the name of the copy method (`of` or `copyOf` for example) even though we knew it in (a). Now we arrange for the information about the method name to be copied from (a) to (b).

This change will allow us to add logic to support ImmutableSortedSet.copyOfSorted and ImmutableSortedMap.copyOfSorted.

e0c631a59355c4fc86f0d052acd2d63604215fa8

-------

<p> Better support for ImmutableSortedSet and ImmutableSortedMap. Use .copyOfSorted when setting from a SortedSet or SortedMap. Use .naturalOrder when constructing a builder.

Fixes https://github.com/google/auto/issues/666.

RELNOTES=Use ImmutableSortedSet.copyOfSorted and .naturalOrder where appropriate.

7564c4c6a5c5a6dee14fb2b3771d21fc9de2b151

-------

<p> Migrate Correspondence subclasses to instead call Correspondence.from.

6c9bd9fdbc46a4c7ac01b4d2accd7571dd144338