### PR TITLE
Moe Sync

### DIFF
--- a/factory/src/main/java/com/google/auto/factory/processor/FactoryDescriptor.java
+++ b/factory/src/main/java/com/google/auto/factory/processor/FactoryDescriptor.java
@@ -15,7 +15,6 @@
  */
 package com.google.auto.factory.processor;
 
-import com.google.auto.common.MoreTypes;
 import com.google.auto.value.AutoValue;
 import com.google.common.base.CharMatcher;
 import com.google.common.base.Optional;
@@ -222,8 +221,8 @@ abstract class FactoryDescriptor {
     }
 
     // Descriptors are identical if they have the same passed types in the same order.
-    return MoreTypes.equivalence().pairwise().equivalent(
-        Iterables.transform(factory.passedParameters(), Parameter.TYPE),
-        Iterables.transform(implementation.passedParameters(), Parameter.TYPE));
+    return Iterables.elementsEqual(
+        Iterables.transform(factory.passedParameters(), Parameter::type),
+        Iterables.transform(implementation.passedParameters(), Parameter::type));
   }
 }

--- a/factory/src/main/java/com/google/auto/factory/processor/FactoryWriter.java
+++ b/factory/src/main/java/com/google/auto/factory/processor/FactoryWriter.java
@@ -16,7 +16,6 @@
 package com.google.auto.factory.processor;
 
 import static com.google.auto.common.GeneratedAnnotationSpecs.generatedAnnotationSpec;
-import static com.google.auto.factory.processor.Mirrors.isProvider;
 import static com.squareup.javapoet.MethodSpec.constructorBuilder;
 import static com.squareup.javapoet.MethodSpec.methodBuilder;
 import static com.squareup.javapoet.TypeSpec.classBuilder;
@@ -143,13 +142,13 @@ final class FactoryWriter {
         CodeBlock argument;
         if (methodDescriptor.passedParameters().contains(parameter)) {
           argument = CodeBlock.of(parameter.name());
-          if (parameter.type().getKind().isPrimitive()) {
+          if (parameter.isPrimitive()) {
             checkNotNull = false;
           }
         } else {
           ProviderField provider = descriptor.providers().get(parameter.key());
           argument = CodeBlock.of(provider.name());
-          if (isProvider(parameter.type())) {
+          if (parameter.isProvider()) {
             // Providers are checked for nullness in the Factory's constructor.
             checkNotNull = false;
           } else {
@@ -204,7 +203,7 @@ final class FactoryWriter {
     ImmutableList.Builder<ParameterSpec> builder = ImmutableList.builder();
     for (Parameter parameter : parameters) {
       ParameterSpec.Builder parameterBuilder =
-          ParameterSpec.builder(TypeName.get(parameter.type()), parameter.name());
+          ParameterSpec.builder(TypeName.get(parameter.type().get()), parameter.name());
       for (AnnotationMirror annotation :
           Iterables.concat(parameter.nullable().asSet(), parameter.key().qualifier().asSet())) {
         parameterBuilder.addAnnotation(AnnotationSpec.get(annotation));
@@ -243,7 +242,7 @@ final class FactoryWriter {
     }
     for (FactoryMethodDescriptor method : descriptor.methodDescriptors()) {
       for (Parameter parameter : method.creationParameters()) {
-        if (!parameter.nullable().isPresent() && !parameter.type().getKind().isPrimitive()) {
+        if (!parameter.nullable().isPresent() && !parameter.type().get().getKind().isPrimitive()) {
           return true;
         }
       }

--- a/factory/src/main/java/com/google/auto/factory/processor/Parameter.java
+++ b/factory/src/main/java/com/google/auto/factory/processor/Parameter.java
@@ -21,9 +21,9 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import com.google.auto.common.AnnotationMirrors;
 import com.google.auto.common.MoreElements;
+import com.google.auto.common.MoreTypes;
 import com.google.auto.value.AutoValue;
 import com.google.common.base.Equivalence;
-import com.google.common.base.Function;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
@@ -45,18 +45,19 @@ import javax.lang.model.util.Types;
 @AutoValue
 abstract class Parameter {
 
-  static final Function<Parameter, TypeMirror> TYPE = new Function<Parameter, TypeMirror>() {
-      @Override
-      public TypeMirror apply(Parameter parameter) {
-        return parameter.type();
-      }
-    };
-
   /**
    * The original type of the parameter, while {@code key().type()} erases the wrapped {@link
    * Provider}, if any.
    */
-  abstract TypeMirror type();
+  abstract Equivalence.Wrapper<TypeMirror> type();
+
+  boolean isProvider() {
+    return Mirrors.isProvider(type().get());
+  }
+
+  boolean isPrimitive() {
+    return type().get().getKind().isPrimitive();
+  }
 
   /** The name of the parameter. */
   abstract String name();
@@ -82,7 +83,7 @@ abstract class Parameter {
 
     Key key = Key.create(type, annotations, types);
     return new AutoValue_Parameter(
-        type,
+        MoreTypes.equivalence().wrap(type),
         variable.getSimpleName().toString(),
         key,
         wrapOptionalInEquivalence(AnnotationMirrors.equivalence(), nullable));

--- a/value/pom.xml
+++ b/value/pom.xml
@@ -38,7 +38,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.version>1.8</java.version>
     <guava.version>27.0.1-jre</guava.version>
-    <truth.version>0.44</truth.version>
+    <truth.version>0.45</truth.version>
   </properties>
 
   <scm>
@@ -107,7 +107,7 @@
       <dependency>
         <groupId>com.google.testing.compile</groupId>
         <artifactId>compile-testing</artifactId>
-        <version>0.16</version>
+        <version>0.18</version>
       </dependency>
       <dependency>
         <groupId>com.google.truth</groupId>

--- a/value/src/test/java/com/google/auto/value/extension/memoized/MemoizedMethodSubject.java
+++ b/value/src/test/java/com/google/auto/value/extension/memoized/MemoizedMethodSubject.java
@@ -27,7 +27,7 @@ import com.google.common.truth.Subject;
 import com.google.testing.compile.JavaFileObjects;
 import javax.tools.JavaFileObject;
 
-final class MemoizedMethodSubject extends Subject<MemoizedMethodSubject, String> {
+final class MemoizedMethodSubject extends Subject {
   private final String actual;
 
   MemoizedMethodSubject(FailureMetadata failureMetadata, String actual) {


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Update to Truth 0.45, and address deprecations.

Renames may include:
- containsAllOf => containsAtLeast
- containsAllIn => containsAtLeastElementsIn
- isSameAs => isSameInstanceAs
- isOrdered => isInOrder
- isStrictlyOrdered => isInStrictOrder

The other major change is to change custom subjects to extend raw Subject instead of supplying type parameters. The type parameters are being removed from Subject. This CL will temporarily produce rawtypes warnings, which will go away when I remove the type parameters (as soon as this batch of CLs is submitted).

Some CLs in this batch also migrate calls away from actualAsString(). Its literal replacement is `"<" + actual + ">"` (unless an object overrides actualCustomStringRepresentation()), but usually I've made a larger change, such as switching from an old-style "Not true that..." failure message to one generated with the Fact API. In that case, the new code usually contains a direct reference to this.actual (a field that I occasionally had to create). Another larger change I sometimes made is to switch from a manual check-and-fail approach to instead use check(...). And sometimes I just remove a withMessage() call that's no longer necessary now that the code uses check(...), or I introduce a check(...) call. (An assertion made with check(...) automatically includes the actual value from the original subject, so there's no need to set it again with withMessage().)

Finally, there's one CL in this batch in which I migrate a Correspondence subclass to instead use Correspondence.from.

8f73446e9b3dbee19f72fdacbb6ca62247ab5e10

-------

<p> Don't compare TypeMirrors using Object#equals

29d59269b35d05cda20c79165aee9b31dd3ef004