### PR TITLE
Moe Sync

### DIFF
--- a/common/src/main/java/com/google/auto/common/BasicAnnotationProcessor.java
+++ b/common/src/main/java/com/google/auto/common/BasicAnnotationProcessor.java
@@ -171,10 +171,14 @@ public abstract class BasicAnnotationProcessor extends AbstractProcessor {
 
     deferredElementNames.clear();
 
-    // If this is the last round, report all of the missing elements
+    // If this is the last round, report all of the missing elements if there
+    // were no errors raised in the round; otherwise reporting the missing
+    // elements just adds noise the output.
     if (roundEnv.processingOver()) {
       postRound(roundEnv);
-      reportMissingElements(deferredElements, elementsDeferredBySteps.values());
+      if (!roundEnv.errorRaised()) {
+        reportMissingElements(deferredElements, elementsDeferredBySteps.values());
+      }
       return false;
     }
 


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Suppress emitting errors about unprocessed elements when there are already errors in the processing round. The extra errors don't add any information and end up hiding the real errors.

I found this substantially reduced the issue highlighted in b/141176717.

RELNOTES=Suppress error noise in `com.google.auto.common.BasicAnnotationProcessor`

8d0693cdb8b7331dcf2aa2cf45cfb6eb507101f1