### PR TITLE
Moe Sync

### DIFF
--- a/value/src/it/functional/src/test/java/com/google/auto/value/AutoValueTest.java
+++ b/value/src/it/functional/src/test/java/com/google/auto/value/AutoValueTest.java
@@ -178,6 +178,30 @@ public class AutoValueTest {
   }
 
   @AutoValue
+  abstract static class StrangeGetters {
+    abstract int get1st();
+    abstract int get_1st(); // by default we'll use _1st where identifiers are needed, so foil that.
+
+    @AutoValue.Builder
+    abstract static class Builder {
+      abstract Builder set1st(int x);
+      abstract Builder set_1st(int x);
+      abstract StrangeGetters build();
+    }
+
+    static Builder builder() {
+      return new AutoValue_AutoValueTest_StrangeGetters.Builder();
+    }
+  }
+
+  @Test
+  public void testStrangeGetters() {
+    StrangeGetters instance = StrangeGetters.builder().set1st(17).set_1st(23).build();
+    String expectedString = omitIdentifiers ? "{17, 23}" : "StrangeGetters{1st=17, _1st=23}";
+    assertThat(instance.toString()).isEqualTo(expectedString);
+  }
+
+  @AutoValue
   abstract static class GettersAndConcreteNonGetters {
     abstract int getFoo();
 

--- a/value/src/main/java/com/google/auto/value/processor/AutoValueOrOneOfProcessor.java
+++ b/value/src/main/java/com/google/auto/value/processor/AutoValueOrOneOfProcessor.java
@@ -633,13 +633,21 @@ abstract class AutoValueOrOneOfProcessor extends AbstractProcessor {
    */
   static void fixReservedIdentifiers(Map<?, String> methodToIdentifier) {
     for (Map.Entry<?, String> entry : methodToIdentifier.entrySet()) {
-      if (SourceVersion.isKeyword(entry.getValue())) {
-        entry.setValue(disambiguate(entry.getValue(), methodToIdentifier.values()));
+      String name = entry.getValue();
+      if (SourceVersion.isKeyword(name) || !Character.isJavaIdentifierStart(name.codePointAt(0))) {
+        entry.setValue(disambiguate(name, methodToIdentifier.values()));
       }
     }
   }
 
   private static String disambiguate(String name, Collection<String> existingNames) {
+    if (!Character.isJavaIdentifierStart(name.codePointAt(0))) {
+      // You've defined a getter called get1st(). What were you thinking?
+      name = "_" + name;
+      if (!existingNames.contains(name)) {
+        return name;
+      }
+    }
     for (int i = 0; ; i++) {
       String candidate = name + i;
       if (!existingNames.contains(candidate)) {


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Allow @AutoValue getters to define properties that are not valid Java identifiers.

For example, get1st() defines a property called 1st. This is consistent with JavaBeans, freaky as it is.

RELNOTES=Allow @AutoValue getters to define properties that are not valid Java identifiers, for example get1st().

d6f8279bfc873dbaac16ac879cc10eb64b274c8b