### PR TITLE
Mark autovalue-annotations optional (Maven) or compileOnly (gradle)

### DIFF
--- a/value/userguide/index.md
+++ b/value/userguide/index.md
@@ -83,6 +83,7 @@ Maven users should add the following to the project's `pom.xml` file:
   <groupId>com.google.auto.value</groupId>
   <artifactId>auto-value-annotations</artifactId>
   <version>1.6.6</version>
+  <optional>true</optional>
 </dependency>
 <dependency>
   <groupId>com.google.auto.value</groupId>
@@ -101,8 +102,8 @@ Gradle users can declare the dependencies in their `build.gradle` script:
 
 ```groovy
 dependencies {
-  // Use 'api' rather than 'compile' for Android or java-library projects.
-  compile             "com.google.auto.value:auto-value-annotations:1.6.6"
+  // Use 'api' rather than 'compileOnly' for Android or java-library projects.
+  compileOnly         "com.google.auto.value:auto-value-annotations:1.6.6"
   annotationProcessor "com.google.auto.value:auto-value:1.6.6"
 }
 ```


### PR DESCRIPTION
@eamonnmcmanus @saturnism