### PR TITLE
Moe Sync

### DIFF
--- a/service/annotations/pom.xml
+++ b/service/annotations/pom.xml
@@ -43,11 +43,16 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>com.google.auto.service</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
       </plugin>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
           <!-- disable processing because the definition in META-INF/services breaks javac -->


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Set an Automatic-Module-Name.

This makes it practical to use from code that uses modules.

Compare to Guava:
https://github.com/google/guava/blob/5496c37d4d904869297c2ced1f0d20e6f1507eaa/guava/pom.xml#L60
https://github.com/google/guava/issues/2920

RELNOTES=AutoService: Set an Automatic-Module-Name.

55153f2c0e6b839afe684d5cbf0132f764274a3b