### PR TITLE
Moe Sync

### DIFF
--- a/value/pom.xml
+++ b/value/pom.xml
@@ -37,8 +37,8 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.version>1.8</java.version>
-    <guava.version>27.0.1-jre</guava.version>
-    <truth.version>0.45</truth.version>
+    <guava.version>28.1-jre</guava.version>
+    <truth.version>1.0</truth.version>
   </properties>
 
   <scm>
@@ -89,7 +89,7 @@
       <dependency>
         <groupId>com.squareup</groupId>
         <artifactId>javapoet</artifactId>
-        <version>1.9.0</version>
+        <version>1.11.1</version>
       </dependency>
 
       <!-- test dependencies -->

--- a/value/processor/pom.xml
+++ b/value/processor/pom.xml
@@ -49,7 +49,7 @@
     <dependency>
       <groupId>com.google.auto.service</groupId>
       <artifactId>auto-service</artifactId>
-      <version>1.0-rc4</version>
+      <version>1.0-rc6</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/value/src/it/functional/pom.xml
+++ b/value/src/it/functional/pom.xml
@@ -48,7 +48,7 @@
     <dependency>
       <groupId>com.google.auto.service</groupId>
       <artifactId>auto-service</artifactId>
-      <version>1.0-rc4</version>
+      <version>1.0-rc6</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
@@ -92,7 +92,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>2.28.2</version>
+      <version>3.1.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Update dependencies:

- mvn versions:use-latest-releases
- mvn versions:update-properties

The immediate motivation is that we just broke Caliper's build by updating Dagger, which requires a newer version of JavaPoet than the one currently used by AutoValue (which, sadly, is the version selected by Maven).

f3fe6e8e42b81600c30e83454de7c8d39bb86799