### PR TITLE
Moe Sync

### DIFF
--- a/service/README.md
+++ b/service/README.md
@@ -1,19 +1,19 @@
-AutoService
-======
+# AutoService
 
-A configuration/metadata generator for java.util.ServiceLoader-style service providers 
+A configuration/metadata generator for java.util.ServiceLoader-style service
+providers
 
-AutoWhat‽
----------
+## AutoWhat‽
 
-[Java][java] annotation processors and other systems use [java.util.ServiceLoader][sl] to
-register implementations of well-known types using META-INF metadata. However, it is easy
-for a developer to forget to update or correctly specify the service descriptors.  
-AutoService generates this metadata for the developer, for any class annotated with
-`@AutoService`, avoiding typos, providing resistance to errors from refactoring, etc.
+[Java][java] annotation processors and other systems use
+[java.util.ServiceLoader][sl] to register implementations of well-known types
+using META-INF metadata. However, it is easy for a developer to forget to update
+or correctly specify the service descriptors. \
+AutoService generates this metadata for the developer, for any class annotated
+with `@AutoService`, avoiding typos, providing resistance to errors from
+refactoring, etc.
 
-Example
--------
+## Example
 
 Say you have:
 
@@ -28,26 +28,58 @@ final class MyProcessor implements Processor {
 }
 ```
 
-AutoService will generate the file `META-INF/services/javax.annotation.processing.Processor`
-in the output classes folder. The file will contain:
+AutoService will generate the file
+`META-INF/services/javax.annotation.processing.Processor` in the output classes
+folder. The file will contain:
 
 ```
 foo.bar.MyProcessor
 ```
 
-In the case of javax.annotation.processing.Processor, if this metadata file is included in a jar,
-and that jar is on javac's classpath, then `javac` will automatically load it, and include it in
-its normal annotation processing environment.  Other users of java.util.ServiceLoader may use 
-the infrastructure to different ends, but this metadata will provide auto-loading appropriately.
+In the case of javax.annotation.processing.Processor, if this metadata file is
+included in a jar, and that jar is on javac's classpath, then `javac` will
+automatically load it, and include it in its normal annotation processing
+environment. Other users of java.util.ServiceLoader may use the infrastructure
+to different ends, but this metadata will provide auto-loading appropriately.
 
-Download
---------
+## Getting Started
 
-In order to activate metadata generation you will need to include 
-`auto-service-${version}.jar` in your build at compile time.
+You will need `auto-service-annotations-${version}.jar` in your compile-time
+classpath, and you will need `auto-service-${version}.jar` in your
+annotation-processor classpath.
 
-In a Maven project, one would include the `auto-service` 
-artifact as an "optional" dependency:
+In Maven, you can write:
+
+```xml
+<dependencies>
+  <dependency>
+    <groupId>com.google.auto.service</groupId>
+    <artifactId>auto-service-annotations</artifactId>
+    <version>${auto-service.version}</version>
+    <optional>true</optional>
+  </dependency>
+</dependencies>
+
+...
+
+<plugins>
+  <plugin>
+    <artifactId>maven-compiler-plugin</artifactId>
+    <configuration>
+      <annotationProcessorPaths>
+        <path>
+          <groupId>com.google.auto.service</groupId>
+          <artifactId>auto-service</artifactId>
+          <version>${auto-service.version}</version>
+        </path>
+      </annotationProcessorPaths>
+    </configuration>
+  </plugin>
+</plugins>
+```
+
+Alternatively, you can include the processor itself (which transitively depends
+on the annotation) in your compile-time classpath:
 
 ```xml
 <dependencies>
@@ -60,8 +92,7 @@ artifact as an "optional" dependency:
 </dependencies>
 ```
 
-License
--------
+## License
 
     Copyright 2013 Google LLC
 

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -38,7 +38,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.version>1.8</java.version>
     <guava.version>27.0.1-jre</guava.version>
-    <truth.version>0.44</truth.version>
+    <truth.version>1.0</truth.version>
   </properties>
 
   <scm>
@@ -90,7 +90,7 @@
       <dependency>
         <groupId>com.google.testing.compile</groupId>
         <artifactId>compile-testing</artifactId>
-        <version>0.16</version>
+        <version>0.18</version>
       </dependency>
       <dependency>
         <groupId>com.google.truth</groupId>


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Document the annotationProcessorPaths approach to using AutoService.

We've already documented this for AutoValue:
https://github.com/google/auto/blob/master/value/userguide/index.md#in-pomxml

Here, I've chosen to recommend annotationProcessorPaths as the first option:
- I assume that this reduces the chance of classpath conflicts.
- It also keeps AutoService working when I switch to the new way of running Error Prone (though maybe there are alternatives). See CL 272720556.

Also, run the whole file through mdformat.

9b9148606ff2ebc046939aca955a4bdb059f6eec

-------

<p> Update to Truth 1.0.

Fixes #764

8eda25c96cac9d1857497d6410ec5edae82e9095