### PR TITLE
Moe Sync

### DIFF
--- a/common/src/main/java/com/google/auto/common/GeneratedAnnotationSpecs.java
+++ b/common/src/main/java/com/google/auto/common/GeneratedAnnotationSpecs.java
@@ -54,15 +54,6 @@ public final class GeneratedAnnotationSpecs {
         .map(annotation -> annotation.addMember("comments", "$S", comments).build());
   }
 
-  private static Optional<AnnotationSpec.Builder> generatedAnnotationSpecBuilder(
-      Elements elements, Class<?> processorClass) {
-    return GeneratedAnnotations.generatedAnnotation(elements)
-        .map(
-            generated ->
-                AnnotationSpec.builder(ClassName.get(generated))
-                    .addMember("value", "$S", processorClass.getCanonicalName()));
-  }
-
   /**
    * Returns {@code @Generated("processorClass"} for the target {@code SourceVersion}.
    *
@@ -88,6 +79,15 @@ public final class GeneratedAnnotationSpecs {
       Elements elements, SourceVersion sourceVersion, Class<?> processorClass, String comments) {
     return generatedAnnotationSpecBuilder(elements, sourceVersion, processorClass)
         .map(annotation -> annotation.addMember("comments", "$S", comments).build());
+  }
+
+  private static Optional<AnnotationSpec.Builder> generatedAnnotationSpecBuilder(
+      Elements elements, Class<?> processorClass) {
+    return GeneratedAnnotations.generatedAnnotation(elements)
+        .map(
+            generated ->
+                AnnotationSpec.builder(ClassName.get(generated))
+                    .addMember("value", "$S", processorClass.getCanonicalName()));
   }
 
   private static Optional<AnnotationSpec.Builder> generatedAnnotationSpecBuilder(

--- a/common/src/main/java/com/google/auto/common/MoreTypes.java
+++ b/common/src/main/java/com/google/auto/common/MoreTypes.java
@@ -866,12 +866,7 @@ public final class MoreTypes {
 
     @Override
     public Boolean visitDeclared(DeclaredType type, Void ignored) {
-      TypeElement typeElement;
-      try {
-        typeElement = MoreElements.asType(type.asElement());
-      } catch (IllegalArgumentException iae) {
-        throw new IllegalArgumentException(type + " does not represent a class or interface.");
-      }
+      TypeElement typeElement = MoreElements.asType(type.asElement());
       return typeElement.getQualifiedName().contentEquals(clazz.getCanonicalName());
     }
   }
@@ -898,7 +893,7 @@ public final class MoreTypes {
                       @Override
                       public boolean apply(TypeMirror input) {
                         return input.getKind().equals(TypeKind.DECLARED)
-                            && (MoreElements.asType(MoreTypes.asDeclared(input).asElement()))
+                            && MoreElements.asType(MoreTypes.asDeclared(input).asElement())
                                 .getKind()
                                 .equals(ElementKind.CLASS)
                             && !types.isSameType(objectType, input);


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Fix 4 ErrorProneStyle findings:
* Constructors and methods with the same name should appear sequentially with no other code in between. Please re-order or re-name methods.
* These grouping parentheses are unnecessary; it is unlikely the code will be misinterpreted without them

8452560f480290ead80eba029a4523b2af11d3d5