### PR TITLE
MOE Sync 2019-10-30

### DIFF
--- a/factory/src/main/java/com/google/auto/factory/processor/AutoFactoryProcessor.java
+++ b/factory/src/main/java/com/google/auto/factory/processor/AutoFactoryProcessor.java
@@ -175,7 +175,7 @@ public final class AutoFactoryProcessor extends AbstractProcessor {
                   implementationMethodDescriptors.get(entry.getKey()),
                   allowSubclasses));
         } catch (IOException e) {
-          messager.printMessage(Kind.ERROR, "failed");
+          messager.printMessage(Kind.ERROR, "failed: " + e);
         }
       }
     }


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Improved AutoFactory error message

RELNOTES=Better error message for failed factory write.

One known cause of this error is using an impl class name that is the same
as the declared interface (in which case this new message will tell you
that you are attempting to recreate an existing file name).

f12cb93d409a330dc5474c65395e2fdb5da9b68c