### PR TITLE
MOE Sync 2019-11-08

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Save time.  Save code.  Save sanity.
 
     [![Maven Central](https://img.shields.io/maven-central/v/com.google.auto.service/auto-service.svg)](https://mvnrepository.com/artifact/com.google.auto.service/auto-service)
 
-  * [AutoValue] - Immutable [value-type] code generation for Java 1.6+.
+  * [AutoValue] - Immutable [value-type] code generation for Java 7+.
 
     [![Maven Central](https://img.shields.io/maven-central/v/com.google.auto.value/auto-value.svg)](https://mvnrepository.com/artifact/com.google.auto.value/auto-value)
 

--- a/value/README.md
+++ b/value/README.md
@@ -1,6 +1,6 @@
 # AutoValue
 
-*Generated immutable value classes for Java 1.6+* <br />
+*Generated immutable value classes for Java 7+* <br />
 ***Kevin Bourrillion, Éamonn McManus*** <br />
 **Google, Inc.**
 

--- a/value/pom.xml
+++ b/value/pom.xml
@@ -29,7 +29,7 @@
   <version>HEAD-SNAPSHOT</version>
   <name>AutoValue Parent</name>
   <description>
-    Immutable value-type code generation for Java 1.6+.
+    Immutable value-type code generation for Java 7+.
   </description>
   <packaging>pom</packaging>
   <url>https://github.com/google/auto/tree/master/value</url>

--- a/value/src/it/gwtserializer/pom.xml
+++ b/value/src/it/gwtserializer/pom.xml
@@ -103,8 +103,8 @@
           </dependency>
         </dependencies>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>1.7</source>
+          <target>1.7</target>
           <compilerArgument>-Xlint:all</compilerArgument>
           <showWarnings>true</showWarnings>
           <showDeprecation>true</showDeprecation>

--- a/value/src/main/java/com/google/auto/value/extension/memoized/Memoized.java
+++ b/value/src/main/java/com/google/auto/value/extension/memoized/Memoized.java
@@ -16,7 +16,7 @@
 package com.google.auto.value.extension.memoized;
 
 import static java.lang.annotation.ElementType.METHOD;
-import static java.lang.annotation.RetentionPolicy.SOURCE;
+import static java.lang.annotation.RetentionPolicy.CLASS;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
@@ -80,6 +80,6 @@ import java.lang.annotation.Target;
  *   }</pre>
  */
 @Documented
-@Retention(SOURCE)
+@Retention(CLASS)
 @Target(METHOD)
 public @interface Memoized {}

--- a/value/userguide/index.md
+++ b/value/userguide/index.md
@@ -1,7 +1,7 @@
 # AutoValue
 
 
-*Generated immutable value classes for Java 1.6+* <br />
+*Generated immutable value classes for Java 7+* <br />
 ***Éamonn McManus, Kevin Bourrillion*** <br />
 **Google, Inc.**
 
@@ -209,6 +209,12 @@ unordered collections like `HashSet`.
 ## <a name="why"></a>Why should I use AutoValue?
 
 See [Why AutoValue?](why.md).
+
+## <a name="versions"></a>What Java versions does it work with?
+
+AutoValue requires that your compiler be at least Java 8. However, the code that
+it generates is compatible with Java 7. That means that you can use it with
+`-source 7 -target 7` or (for Java 9+) `--release 7`.
 
 ## <a name="more_howto"></a>How do I...
 


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Be more explicit about which Java versions AutoValue supports. The compiler must be at least Java 8, but it can generate code for Java 7.

Also update gwtserializer/pom.xml to specify Java 7 rather than Java 6. Compiling with -source 6 is no longer supported in recent Java versions.

Fixes https://github.com/google/auto/issues/771.
Closes https://github.com/google/auto/pull/524.

2952f392d8f8a8fda82f7cce3b8fadd32a1b321d

-------

<p> Make @Memoized have class-level retention

RELNOTES=Make @Memoized have class-level retention

f8ae2320e94d7b1b6e538a3d42ba1c9da0fa8fbc