### PR TITLE
MOE Sync 2019-11-11

### DIFF
--- a/common/src/main/java/com/google/auto/common/MoreElements.java
+++ b/common/src/main/java/com/google/auto/common/MoreElements.java
@@ -106,6 +106,19 @@ public final class MoreElements {
     }
   }
 
+  private static final class IsTypeVisitor extends SimpleElementVisitor8<Boolean, Void> {
+    private static final IsTypeVisitor INSTANCE = new IsTypeVisitor();
+
+    IsTypeVisitor() {
+      super(false);
+    }
+
+    @Override
+    public Boolean visitType(TypeElement e, Void unused) {
+      return true;
+    }
+  }
+
   /**
    * Returns true if the given {@link Element} instance is a {@link TypeElement}.
    *
@@ -115,7 +128,9 @@ public final class MoreElements {
    * @throws NullPointerException if {@code element} is {@code null}
    */
   public static boolean isType(Element element) {
-    return element.getKind().isClass() || element.getKind().isInterface();
+    // Use a visitor rather than Element#getKind(). Element#getKind() contains more information
+    // than is needed here. It also requires symbol completion, which can be slow.
+    return element.accept(IsTypeVisitor.INSTANCE, null);
   }
 
   /**

--- a/value/src/main/java/com/google/auto/value/processor/BuilderMethodClassifier.java
+++ b/value/src/main/java/com/google/auto/value/processor/BuilderMethodClassifier.java
@@ -321,7 +321,7 @@ class BuilderMethodClassifier {
       // boxedOriginalType is Integer, and containedType is also Integer.
       // We don't need any special code for OptionalInt because containedType will be int then.
       TypeMirror boxedOriginalType =
-          (originalGetterType.getKind().isPrimitive())
+          originalGetterType.getKind().isPrimitive()
               ? typeUtils.boxedClass(MoreTypes.asPrimitiveType(originalGetterType)).asType()
               : null;
       if (TYPE_EQUIVALENCE.equivalent(containedType, originalGetterType)


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Roll forward of CL 264613939: Use ElementVisitor rather than Element#getKind() in MoreElements#isType()

*** Original change description ***

Use ElementVisitor rather than Element#getKind() in MoreElements#isType()

Element#getKind() contains more information than is needed here (we just need to know if the element is an instance of TypeElement, not its kind). Element#getKind() forces symbol completion, which requires parsing the class, so we shouldn't use it unless we have...

***

449920a39c6516aad44cd88c1ac942d90358d12c

-------

<p> Fix 1 ErrorProneStyle finding:
* These grouping parentheses are unnecessary; it is unlikely the code will be misinterpreted without them

35991c1464896afd5f08fd032b0b90284869ec40