### PR TITLE
MOE Sync 2019-11-13

### DIFF
--- a/common/src/test/java/com/google/auto/common/MoreTypesTest.java
+++ b/common/src/test/java/com/google/auto/common/MoreTypesTest.java
@@ -281,6 +281,7 @@ public class MoreTypesTest {
   private static class ChildA extends Parent<Number> {}
   private static class ChildB extends Parent<String> {}
   private static class GenericChild<T> extends Parent<T> {}
+  private interface InterfaceType {}
 
   @Test
   public void asElement_throws() {
@@ -317,7 +318,15 @@ public class MoreTypesTest {
     TypeElement genericChild = elements.getTypeElement(GenericChild.class.getCanonicalName());
     TypeMirror genericChildOfNumber = types.getDeclaredType(genericChild, numberType);
     TypeMirror genericChildOfInteger = types.getDeclaredType(genericChild, integerType);
+    TypeMirror objectType =
+        elements.getTypeElement(Object.class.getCanonicalName()).asType();
+    TypeMirror interfaceType =
+        elements.getTypeElement(InterfaceType.class.getCanonicalName()).asType();
 
+    assertThat(MoreTypes.nonObjectSuperclass(types, elements, (DeclaredType) objectType))
+        .isAbsent();
+    assertThat(MoreTypes.nonObjectSuperclass(types, elements, (DeclaredType) interfaceType))
+        .isAbsent();
     assertThat(MoreTypes.nonObjectSuperclass(types, elements, (DeclaredType) parent.asType()))
         .isAbsent();
 


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Optimize MoreTypes.nonObjectSuperclass

This CL tries to avoid using expensive method calls like Elements#getTypeElement, TypeElement#getKind(), and Types#directSupertypes. Of all of these, TypeElement#getKind() had the largest cost because it requires symbol completion. In addition, getKind() was being called on unnecessarily on all supertypes, even though only the first type can possibly be an ElementKind.CLASS.

RELNOTES=N/A

e5a8638a73feaab4e5e656f27dd1484260740226