### PR TITLE
MOE Sync 2019-11-14

### DIFF
--- a/common/src/main/java/com/google/auto/common/MoreElements.java
+++ b/common/src/main/java/com/google/auto/common/MoreElements.java
@@ -106,19 +106,6 @@ public final class MoreElements {
     }
   }
 
-  private static final class IsTypeVisitor extends SimpleElementVisitor8<Boolean, Void> {
-    private static final IsTypeVisitor INSTANCE = new IsTypeVisitor();
-
-    IsTypeVisitor() {
-      super(false);
-    }
-
-    @Override
-    public Boolean visitType(TypeElement e, Void unused) {
-      return true;
-    }
-  }
-
   /**
    * Returns true if the given {@link Element} instance is a {@link TypeElement}.
    *
@@ -128,9 +115,7 @@ public final class MoreElements {
    * @throws NullPointerException if {@code element} is {@code null}
    */
   public static boolean isType(Element element) {
-    // Use a visitor rather than Element#getKind(). Element#getKind() contains more information
-    // than is needed here. It also requires symbol completion, which can be slow.
-    return element.accept(IsTypeVisitor.INSTANCE, null);
+    return element.getKind().isClass() || element.getKind().isInterface();
   }
 
   /**


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Automated g4 rollback of changelist 279369564.

*** Reason for rollback ***

:-( rolling this back again because it breaks some targets.

java.lang.IllegalArgumentException: <nulltype> cannot be represented as a Class<?>.

My guess is that isType() is returning true when it should be returning false for null types, but I'll need to do more investigation.

*** Original change description ***

Use ElementVisitor rather than Element#getKind() in MoreElements#isType()

d6849d770518abb4869699bdbc64caa2bf6e89e9