### PR TITLE
Exclude unused transitive dependencies

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -69,6 +69,12 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <version>${guava.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>listenablefuture</artifactId>          
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <!-- Used only by GeneratedAnnotationSpecs.
@@ -103,6 +109,12 @@
       <artifactId>truth</artifactId>
       <version>${truth.version}</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.auto.value</groupId>
+          <artifactId>auto-value-annotations</artifactId>          
+        </exclusion>
+      </exclusions>      
     </dependency>
     <dependency>
       <groupId>org.eclipse.jdt.core.compiler</groupId>


### PR DESCRIPTION
Hello, I noticed that dependencies `com.google.guava:listenablefuture` and `com.google.auto.value:auto-value-annotations` are included in the dependency tree of module `auto-common`. However, these transitive dependencies are not used and therefore can be excluded in the `pom`. This makes the library slimmer for its users and the Maven dependency clearer and less complex. 