### PR TITLE
MOE Sync 2019-12-01

### DIFF
--- a/value/userguide/index.md
+++ b/value/userguide/index.md
@@ -76,11 +76,11 @@ examples short and simple.
 
 ### With Maven
 
-You will need `auto-value-annotations-${version}.jar` in your compile-time
-classpath, and you will need `auto-value-${version}.jar` in your
-annotation-processor classpath.
+You will need `auto-value-annotations-${auto-value.version}.jar` in your
+compile-time classpath, and you will need `auto-value-${auto-value.version}.jar`
+in your annotation-processor classpath.
 
-In `pom.xml`, you can write:
+For `auto-value-annotations`, you can write this in `pom.xml`:
 
 ```xml
 <dependencies>
@@ -90,35 +90,38 @@ In `pom.xml`, you can write:
     <version>${auto-value.version}</version>
   </dependency>
 </dependencies>
-
-...
-
-<plugins>
-  <plugin>
-    <artifactId>maven-compiler-plugin</artifactId>
-    <configuration>
-      <annotationProcessorPaths>
-        <path>
-          <groupId>com.google.auto.value</groupId>
-          <artifactId>auto-value</artifactId>
-          <version>${auto-value.version}</version>
-        </path>
-      </annotationProcessorPaths>
-    </configuration>
-  </plugin>
-</plugins>
 ```
 
-Alternatively, you can include the processor itself (which transitively depends
-on the annotation) in your compile-time classpath. (However, note that doing so
-may pull unnecessary classes into your runtime classpath.)
+For `auto-value` (the annotation processor), you can write this:
+
+```xml
+<build>
+  <plugins>
+    <plugin>
+      <artifactId>maven-compiler-plugin</artifactId>
+      <configuration>
+        <annotationProcessorPaths>
+          <path>
+            <groupId>com.google.auto.value</groupId>
+            <artifactId>auto-value</artifactId>
+            <version>${auto-value.version}</version>
+          </path>
+        </annotationProcessorPaths>
+      </configuration>
+    </plugin>
+  </plugins>
+</build>
+```
+
+Alternatively, you can include the processor itself in your compile-time
+classpath. Doing so may pull unnecessary classes into your runtime classpath.
 
 ```xml
 <dependencies>
   <dependency>
     <groupId>com.google.auto.value</groupId>
     <artifactId>auto-value</artifactId>
-    <version>${version}</version>
+    <version>${auto-value.version}</version>
     <optional>true</optional>
   </dependency>
 </dependencies>


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Improve Maven instructions for AutoValue.

It is not true that a dependency on the auto-value artifact transitively implies a dependency on auto-value-annotations, so it is not correct to suggest that users can include only the former.

Make it clearer that <plugins> is inside the <build> section.

Use ${auto-value.version} consistently, rather than sometimes that and sometimes ${version}.

bde81014a89eccd3125db0e4933b89fd60725099