### PR TITLE
MOE Sync 2019-12-02

### DIFF
--- a/service/annotations/src/main/java/com/google/auto/service/AutoService.java
+++ b/service/annotations/src/main/java/com/google/auto/service/AutoService.java
@@ -16,7 +16,7 @@
 package com.google.auto.service;
 
 import static java.lang.annotation.ElementType.TYPE;
-import static java.lang.annotation.RetentionPolicy.SOURCE;
+import static java.lang.annotation.RetentionPolicy.CLASS;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
@@ -36,7 +36,7 @@ import java.lang.annotation.Target;
  * </ul>
  */
 @Documented
-@Retention(SOURCE)
+@Retention(CLASS)
 @Target(TYPE)
 public @interface AutoService {
   /** Returns the interfaces implemented by this service provider. */

--- a/value/src/main/java/com/google/auto/value/processor/TemplateVars.java
+++ b/value/src/main/java/com/google/auto/value/processor/TemplateVars.java
@@ -155,6 +155,10 @@ abstract class TemplateVars {
   // through the getResourceAsStream should be a lot more efficient than reopening the jar.
   private static Reader readerFromUrl(String resourceName) throws IOException {
     URL resourceUrl = TemplateVars.class.getResource(resourceName);
+    if (resourceUrl == null) {
+      // This is unlikely, since getResourceAsStream has already succeeded for the same resource.
+      throw new IllegalArgumentException("Could not find resource: " + resourceName);
+    }
     InputStream in;
     try {
       if (resourceUrl.getProtocol().equalsIgnoreCase("file")) {


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> In TemplateVars, check that getResource returns non-null. This check is redundant because if we reach this point then we've already checked that getResourceAsStream returns non-null for the same resource. But it's a little tricky to trace through the logic to prove that.

Fixes https://github.com/google/auto/issues/796.

1a2243d69cf27e4871a9260b7b75b33b3c6a612c

-------

<p> Use CLASS retention for @AutoService.

This reapplies 28a2c791575a7e4545293169bea0921b81363a3 after fixing an
internal, fragile test.

377b9d964deeeb0619523c44186cab727af1bc6a