### PR TITLE
MOE Sync 2019-12-06

### DIFF
--- a/value/src/main/java/com/google/auto/value/processor/autooneof.vm
+++ b/value/src/main/java/com/google/auto/value/processor/autooneof.vm
@@ -177,12 +177,9 @@ final class $generatedClass {
 
     @Override
     public String toString() {
-      return "${simpleClassName}{$p.name=" +
-        #if ($p.kind == "ARRAY")
-          `java.util.Arrays`.toString(this.$p)
-        #else
-          this.$p
-        #end + "}";
+      return "${simpleClassName}{$p.name=" ##
+          + #if ($p.kind == "ARRAY") `java.util.Arrays`.toString(this.$p) #else this.$p #end
+          + "}";
     }
 
     #end


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Fix spacing in generated toString() for @AutoOneOf.

Before the change:

    public String toString() {
      return "OneOfOne{dog=" +
                  this.dog
         + "}";
    }

After the change:

    public String toString() {
      return "OneOfOne{dog=" + this.dog + "}";
    }

(Having to fiddle with spaces like this is perhaps the biggest disadvantage of the current template approach. It would go away if we postprocessed with google-java-format, though the performance overhead of that is probably too great.)

9174db2282dd41627c5e5f4f947fc4baeee70fc5

-------

<p> Simplify CastingUncheckedVisitor by passing the default value to the superclass constructor and ignoring the parameter. Also make it a constant.

91581b92d0742e7f801bbf2727da8616b08a50e9