### PR TITLE
MOE Sync 2020-01-02

### DIFF
--- a/value/src/it/functional/src/test/java/com/google/auto/value/AutoValueTest.java
+++ b/value/src/it/functional/src/test/java/com/google/auto/value/AutoValueTest.java
@@ -2160,6 +2160,31 @@ public class AutoValueTest {
     }
   }
 
+  interface ImmutableListOf<T> {
+    ImmutableList<T> list();
+  }
+
+  @AutoValue
+  abstract static class PropertyBuilderInheritsType implements ImmutableListOf<String> {
+    static Builder builder() {
+      return new AutoValue_AutoValueTest_PropertyBuilderInheritsType.Builder();
+    }
+
+    @AutoValue.Builder
+    abstract static class Builder {
+      abstract ImmutableList.Builder<String> listBuilder();
+      abstract PropertyBuilderInheritsType build();
+    }
+  }
+
+  @Test
+  public void propertyBuilderInheritsType() {
+    PropertyBuilderInheritsType.Builder builder = PropertyBuilderInheritsType.builder();
+    builder.listBuilder().add("foo", "bar");
+    PropertyBuilderInheritsType x = builder.build();
+    assertThat(x.list()).containsExactly("foo", "bar").inOrder();
+  }
+
   @AutoValue
   public abstract static class BuilderWithExoticPropertyBuilders<
       K extends Number, V extends Comparable<K>> {

--- a/value/src/main/java/com/google/auto/value/processor/BuilderMethodClassifier.java
+++ b/value/src/main/java/com/google/auto/value/processor/BuilderMethodClassifier.java
@@ -434,7 +434,7 @@ class BuilderMethodClassifier {
     // Parameter type is not equal to property type, but might be convertible with copyOf.
     ImmutableList<ExecutableElement> copyOfMethods = copyOfMethods(targetType, setter);
     if (!copyOfMethods.isEmpty()) {
-      return getConvertingSetterFunction(copyOfMethods, valueGetter, setter);
+      return getConvertingSetterFunction(copyOfMethods, valueGetter, setter, parameterType);
     }
     String error =
         String.format(
@@ -452,9 +452,9 @@ class BuilderMethodClassifier {
   private Optional<Function<String, String>> getConvertingSetterFunction(
       ImmutableList<ExecutableElement> copyOfMethods,
       ExecutableElement valueGetter,
-      ExecutableElement setter) {
+      ExecutableElement setter,
+      TypeMirror parameterType) {
     DeclaredType targetType = MoreTypes.asDeclared(getterToPropertyType.get(valueGetter));
-    TypeMirror parameterType = setter.getParameters().get(0).asType();
     for (ExecutableElement copyOfMethod : copyOfMethods) {
       Optional<Function<String, String>> function =
           getConvertingSetterFunction(copyOfMethod, targetType, parameterType);
@@ -465,8 +465,9 @@ class BuilderMethodClassifier {
     String targetTypeSimpleName = targetType.asElement().getSimpleName().toString();
     String error =
         String.format(
-            "Parameter type of setter method should be %s to match getter %s.%s, or it should be a "
-                + "type that can be passed to %s.%s to produce %s",
+            "Parameter type %s of setter method should be %s to match getter %s.%s,"
+                + " or it should be a type that can be passed to %s.%s to produce %s",
+            parameterType,
             targetType,
             autoValueClass,
             valueGetter.getSimpleName(),

--- a/value/src/main/java/com/google/auto/value/processor/autovalue.vm
+++ b/value/src/main/java/com/google/auto/value/processor/autovalue.vm
@@ -116,7 +116,7 @@ ${modifiers}class $subclass$formalTypes extends $origClass$actualTypes {
 
   #foreach ($p in $props)
 
-        #if ($identifiers) + "$p.name=" ##
+        #if ($identifiers)+ "$p.name=" ##
         #end+ #if ($p.kind == "ARRAY") `java.util.Arrays`.toString($p) #else $p #end
         #if ($foreach.hasNext) + ", " #end
 

--- a/value/src/test/java/com/google/auto/value/processor/AutoValueCompilationTest.java
+++ b/value/src/test/java/com/google/auto/value/processor/AutoValueCompilationTest.java
@@ -1599,7 +1599,7 @@ public class AutoValueCompilationTest {
             .compile(javaFileObject);
     assertThat(compilation)
         .hadErrorContaining(
-            "Parameter type of setter method should be "
+            "Parameter type java.lang.String of setter method should be "
                 + "com.google.common.collect.ImmutableList<java.lang.String> to match getter "
                 + "foo.bar.Baz.blam, or it should be a type that can be passed to "
                 + "ImmutableList.copyOf")
@@ -1636,7 +1636,7 @@ public class AutoValueCompilationTest {
             .compile(javaFileObject);
     assertThat(compilation)
         .hadErrorContaining(
-            "Parameter type of setter method should be "
+            "Parameter type java.util.Collection<java.lang.Integer> of setter method should be "
                 + "com.google.common.collect.ImmutableList<java.lang.String> to match getter "
                 + "foo.bar.Baz.blam, or it should be a type that can be passed to "
                 + "ImmutableList.copyOf to produce "


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> When checking builder setter parameters, use the final type. The final type is the type after type-variable substitution. Report this type in error messages, since it may not be obvious.

(See AutoValueNotEclipseTest for an example of the problem this is fixing.)

Fix CompileWithEclipseTest so that it actually does exclude AutoValueNotEclipseTest.java from the compilation, as intended. Move the existing test within that file into AutoValueTest.java, since apparently the Eclipse bug it was provoking has been fixed. Add the test for the bug being fixed here into AutoValueNotEclipseTest.java, because it hits another Eclipse bug.

Fixes https://github.com/google/auto/issues/802.

RELNOTES=Fixed an issue with type checking of setter parameters in the presence of inheritance and generics.

a09d30bfbc859f9eaa49ab6f808da0a39936ec92

-------

<p> Improve toString alignment in AutoValue's toString.

285631153f0ee822d4ceb34ea874583f899dc6f3