### PR TITLE
MOE Sync 2020-01-13

### DIFF
--- a/value/src/main/java/com/google/auto/value/processor/BuilderSpec.java
+++ b/value/src/main/java/com/google/auto/value/processor/BuilderSpec.java
@@ -17,6 +17,7 @@ package com.google.auto.value.processor;
 
 import static com.google.auto.common.MoreElements.getLocalAndInheritedMethods;
 import static com.google.auto.value.processor.AutoValueOrOneOfProcessor.hasAnnotationMirror;
+import static com.google.auto.value.processor.AutoValueOrOneOfProcessor.nullableAnnotationFor;
 import static com.google.auto.value.processor.ClassNames.AUTO_VALUE_BUILDER_NAME;
 import static com.google.common.collect.Sets.immutableEnumSet;
 import static java.util.stream.Collectors.toList;
@@ -367,8 +368,7 @@ class BuilderSpec {
       primitiveParameter = parameterType.getKind().isPrimitive();
       this.parameterTypeString = parameterTypeString(setter, parameterType);
       VariableElement parameterElement = Iterables.getOnlyElement(setter.getParameters());
-      Optional<String> maybeNullable =
-          AutoValueOrOneOfProcessor.nullableAnnotationFor(parameterElement, parameterType);
+      Optional<String> maybeNullable = nullableAnnotationFor(parameterElement, parameterType);
       this.nullableAnnotation = maybeNullable.orElse("");
     }
 


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Make it an error if a setter has a @Nullable parameter when the property being set is not @Nullable. We will generate code that rejects a null parameter whether or not @Nullable is present, so allowing it is just misleading users of the API.

The mirror situation, where the property is @Nullable but the setter is not, is arguably also incorrect. In that case the generated code does *not* reject a null parameter, even though we might expect it to in the absence of @Nullable on the parameter. However, changing that would surely break a lot of existing code.

Fixes https://github.com/google/auto/issues/777.

RELNOTES=It is now a compilation error if a setter method in a builder has a parameter marked @Nullable when the corresponding property is not in fact @Nullable. This already generated a NullPointerException at runtime.

b11b028d95cc27cdd0014d2aea21eed8687fb3b3