### PR TITLE
MOE Sync 2020-01-16

### DIFF
--- a/value/userguide/practices.md
+++ b/value/userguide/practices.md
@@ -61,8 +61,4 @@ especially helpful if you are *[underriding](howto.md#custom)* `equals`,
 
 ## <a name="constructor"></a>Maybe add an explicit, inaccessible constructor
 
-There are a few small advantages to adding a package-private, parameterless
-constructor to your abstract class. It prevents unwanted subclasses, and
-prevents an undocumented public constructor showing up in your generated API
-documentation. Whether these benefits are worth the extra noise in the file is a
-matter of your judgment.
+There are a few small advantages to adding a package-private, parameterless constructor to your abstract class. It prevents unwanted subclasses, and prevents an undocumented public constructor showing up in your generated API documentation. Whether these benefits are worth the extra noise in the file is a matter of your judgment.


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> AutoValue best practices: mention that subclassing is now prevented.

I think this obviates most of the reason to add explicit constructors.

0912254a175ea2b7d90bfdb7cee452d13145bdd4