### PR TITLE
MOE Sync 2020-02-10

### DIFF
--- a/value/src/main/java/com/google/auto/value/processor/autooneof.vm
+++ b/value/src/main/java/com/google/auto/value/processor/autooneof.vm
@@ -47,10 +47,20 @@ final class $generatedClass {
 #foreach ($p in $props)
 
   #if ($p.type == "void")
+    #if ($wildcardTypes == "")
 
-  static $origClass$wildcardTypes $p() {
+  static $origClass $p() {
     return Impl_${p}.INSTANCE;
   }
+
+    #else
+
+  @SuppressWarnings("unchecked") // type parameters are unused in void instances
+  static $formalTypes $origClass$actualTypes $p() {
+    return ($origClass$actualTypes) Impl_${p}.INSTANCE;
+  }
+
+    #end
 
   #else
 


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Add type parameters to void AutoOneOf values.

This allows users of AutoOneOf to not have to manually cast the value.

Before:

@SuppressWarnings("unchecked")
public static <T> MyOneOf<T> empty() {
  return (MyOneOf<T>) AutoOneOf_MyOneOf.empty();
}

After:

public static <T> MyOneOf<T> empty() {
  return AutoOneOf_MyOneOf.empty();
}

RELNOTES=Add type parameters to factory methods for void AutoOneOf values

866fbfef20c3997f5b960684be1250cca8de3ba7