### PR TITLE
MOE Sync 2020-02-11

### DIFF
--- a/value/src/main/java/com/google/auto/value/processor/AutoValueProcessor.java
+++ b/value/src/main/java/com/google/auto/value/processor/AutoValueProcessor.java
@@ -247,6 +247,11 @@ public class AutoValueProcessor extends AutoValueOrOneOfProcessor {
     defineSharedVarsForType(type, methods, vars);
     defineVarsForType(type, vars, toBuilderMethods, propertyMethodsAndTypes, builder);
 
+    // If we've encountered problems then we might end up invoking extensions with inconsistent
+    // state. Anyway we probably don't want to generate code which is likely to provoke further
+    // compile errors to add to the ones we've already seen.
+    errorReporter().abortIfAnyError();
+
     GwtCompatibility gwtCompatibility = new GwtCompatibility(type);
     vars.gwtCompatibleAnnotation = gwtCompatibility.gwtCompatibleAnnotationString();
 


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> If AutoValue detects an error, don't invoke extensions or generate code.
For example if there's a type mismatch between a property getter and the
corresponding setter in a Builder, we may otherwise end up invoking an extension
with an inconsistent state. Also the generated code is likely to have compile
errors of its own, which distract from the real source of the problem.

Fixes https://github.com/google/auto/issues/809.

RELNOTES=Don't generate code or invoke extensions if AutoValue detects a problem, for example a mismatch between getters and setters.

3b0e558348812803d719241ffa577d5125ae933e