### PR TITLE
Update AutovalueProcessor to be "ISOLATING" as the other processors

### DIFF
--- a/value/src/main/java/com/google/auto/value/processor/AutoValueProcessor.java
+++ b/value/src/main/java/com/google/auto/value/processor/AutoValueProcessor.java
@@ -63,7 +63,7 @@ import net.ltgt.gradle.incap.IncrementalAnnotationProcessorType;
  */
 @AutoService(Processor.class)
 @SupportedAnnotationTypes(AUTO_VALUE_NAME)
-@IncrementalAnnotationProcessor(IncrementalAnnotationProcessorType.DYNAMIC)
+@IncrementalAnnotationProcessor(IncrementalAnnotationProcessorType.ISOLATING)
 public class AutoValueProcessor extends AutoValueOrOneOfProcessor {
   private static final String OMIT_IDENTIFIERS_OPTION = "com.google.auto.value.OmitIdentifiers";
 


### PR DESCRIPTION
Issue detected during building with KAPT for kotlon android project.
[WARN] Incremental annotation processing requested, but support is disabled because the following processors are not incremental: 
com.google.auto.value.processor.AutoValueProcessor (DYNAMIC)

Thanks for this commit from @tbroyer
https://github.com/google/auto/commit/a5673d06f687e1354f1f069cce36136538cf532c#diff-3c05eef48fd8e04c525c96b18fab9281R66

But not sure why the AutoValueProcessor was annoated with @IncrementalAnnotationProcessor(IncrementalAnnotationProcessorType.DYNAMIC)
instead of @IncrementalAnnotationProcessor(IncrementalAnnotationProcessorType.ISOLATING)as the others.

Having tested it by setting it as "ISOLATING", the kapt doesn't compain it blocks incremental build anymore.
