### PR TITLE
Bump auto to latest version.

### DIFF
--- a/factory/pom.xml
+++ b/factory/pom.xml
@@ -74,7 +74,7 @@
     <dependency>
       <groupId>com.google.auto.value</groupId>
       <artifactId>auto-value</artifactId>
-      <version>1.5.3</version>
+      <version>1.7</version>
     </dependency>
     <dependency>
       <groupId>com.google.auto.service</groupId>


### PR DESCRIPTION
This was blocking incremental annotation processing in certain
situations.

```
Gradle may disable incremental compilation as the following annotation processors are not incremental: jetified-auto-value-1.5.3.jar (com.google.auto.value:auto-value:1.5.3).
```

Thanks to @rciovati for noticing this in our repo.