### PR TITLE
Ensure to process all providers in when generating config files

### DIFF
--- a/service/processor/src/main/java/com/google/auto/service/processor/AutoServiceProcessor.java
+++ b/service/processor/src/main/java/com/google/auto/service/processor/AutoServiceProcessor.java
@@ -190,7 +190,7 @@ public class AutoServiceProcessor extends AbstractProcessor {
         Set<String> newServices = new HashSet<String>(providers.get(providerInterface));
         if (allServices.containsAll(newServices)) {
           log("No new service entries being added.");
-          return;
+          continue;
         }
 
         allServices.addAll(newServices);


### PR DESCRIPTION
In `AutoServiceProcessor#generateConfigFiles` the loop over providers can
be left prematurely if for a provider type there is no new services. The
remaining provider types can still have new services though.