### PR TITLE
MOE Sync 2020-04-27

### DIFF
--- a/value/src/it/functional/src/test/java/com/google/auto/value/AutoValueTest.java
+++ b/value/src/it/functional/src/test/java/com/google/auto/value/AutoValueTest.java
@@ -2793,6 +2793,8 @@ public class AutoValueTest {
   abstract static class BuildMyMap<K, V> {
     abstract MyMap<K, V> map();
 
+    abstract Builder<K, V> toBuilder();
+
     static <K, V> Builder<K, V> builder() {
       return new AutoValue_AutoValueTest_BuildMyMap.Builder<K, V>();
     }
@@ -2812,6 +2814,12 @@ public class AutoValueTest {
     mapBuilder.put("23", 23);
     BuildMyMap<String, Integer> built = builder.build();
     assertThat(built.map()).containsExactly("23", 23);
+
+    BuildMyMap.Builder<String, Integer> builder2 = built.toBuilder();
+    MyMapBuilder<String, Integer> mapBuilder2 = builder2.mapBuilder();
+    mapBuilder2.put("17", 17);
+    BuildMyMap<String, Integer> built2 = builder2.build();
+    assertThat(built2.map()).containsExactly("23", 23, "17", 17);
   }
 
   public static class MyStringMap<V> extends MyMap<String, V> {
@@ -2843,6 +2851,8 @@ public class AutoValueTest {
   abstract static class BuildMyStringMap<V> {
     abstract MyStringMap<V> map();
 
+    abstract Builder<V> toBuilder();
+
     static <V> Builder<V> builder() {
       return new AutoValue_AutoValueTest_BuildMyStringMap.Builder<V>();
     }
@@ -2862,6 +2872,12 @@ public class AutoValueTest {
     mapBuilder.put("23", 23);
     BuildMyStringMap<Integer> built = builder.build();
     assertThat(built.map()).containsExactly("23", 23);
+
+    BuildMyStringMap.Builder<Integer> builder2 = built.toBuilder();
+    MyStringMapBuilder<Integer> mapBuilder2 = builder2.mapBuilder();
+    mapBuilder2.put("17", 17);
+    BuildMyStringMap<Integer> built2 = builder2.build();
+    assertThat(built2.map()).containsExactly("17", 17, "23", 23);
   }
 
   @AutoValue

--- a/value/src/main/java/com/google/auto/value/processor/BuilderMethodClassifier.java
+++ b/value/src/main/java/com/google/auto/value/processor/BuilderMethodClassifier.java
@@ -210,8 +210,8 @@ class BuilderMethodClassifier {
             // If property bar of type Bar has a barBuilder() that returns BarBuilder, then it must
             // be possible to make a BarBuilder from a Bar if either (1) the @AutoValue class has a
             // toBuilder() or (2) there is also a setBar(Bar). Making BarBuilder from Bar is
-            // possible if Bar either has a toBuilder() method or is a Guava immutable collection
-            // (in which case we can use addAll or putAll).
+            // possible if Bar either has a toBuilder() method or BarBuilder has an addAll or putAll
+            // method that accepts a Bar argument.
             boolean canMakeBarBuilder =
                 (propertyBuilder.getBuiltToBuilder() != null
                     || propertyBuilder.getCopyAll() != null);
@@ -221,7 +221,8 @@ class BuilderMethodClassifier {
                   String.format(
                       "Property builder method returns %1$s but there is no way to make that type"
                           + " from %2$s: %2$s does not have a non-static toBuilder() method that"
-                          + " returns %1$s",
+                          + " returns %1$s, and %1$s does not have a method addAll or"
+                          + " putAll that accepts an argument of type %2$s",
                       propertyBuilder.getBuilderTypeMirror(), propertyType);
               errorReporter.reportError(error, propertyBuilder.getPropertyBuilderMethod());
             }

--- a/value/userguide/builders-howto.md
+++ b/value/userguide/builders-howto.md
@@ -450,8 +450,8 @@ One solution for this problem is just below.
 
 ### <a name="add"></a>... accumulate values for a collection-valued property, without "breaking the chain"?
 
-Another option is to keep `countriesBuilder()` itself non-public, only use it to
-implement a public `addCountry` method:
+Another option is to keep `countriesBuilder()` itself non-public, and only use
+it to implement a public `addCountry` method:
 
 ```java
 @AutoValue
@@ -577,6 +577,19 @@ requirements are:
   method then `Species` must also have a `toBuilder()` method. That also applies
   if there is an abstract `setSpecies` method in addition to the
   `speciesBuilder` method.
+
+  As an alternative to having a method `Species.Builder toBuilder()` in
+  `Species`, `Species.Builder` can have a method called `addAll` or `putAll`
+  that accepts an argument of type `Species`. This is how AutoValue handles
+  `ImmutableSet` for example. `ImmutableSet` does not have a `toBuilder()`
+  method, but `ImmutableSet.Builder` does have an `addAll` method that accepts
+  an `ImmutableSet`. So given `ImmutableSet<String> strings`, we can achieve the
+  effect of `strings.toBuilder()` by doing:
+
+  ```
+  ImmutableSet.Builder<String> builder = ImmutableSet.builder();
+  builder.addAll(strings);
+  ```
 
 There are no requirements on the name of the builder class. Instead of
 `Species.Builder`, it could be `Species.Factory` or `SpeciesBuilder`.

--- a/value/userguide/howto.md
+++ b/value/userguide/howto.md
@@ -569,12 +569,12 @@ public abstract class Transform {
   public static Transform ofNone() {
     return AutoOneOf_Transform.none();
   }
-  
+
   public static Transform ofCircleCrop() {
     return AutoOneOf_Transform.circleCrop();
   }
 
-  public static Transform ofBlur(BlurTransformParmeters params) {}
+  public static Transform ofBlur(BlurTransformParmeters params) {
     return AutoOneOf_Transform.blur(params);
   }
 }


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Generalize the logic for determining if we can make a BarBuilder out of a Bar.

If you have an `@AutoValue` class `Foo` with a property `Bar bar()` and `Foo.Builder` has a method `BarBuilder barBuilder()`, then we previously allowed that, provided we knew how to make a `BarBuilder` (for example by calling `Bar.builder()`). But if, in addition, `Foo` has its own `toBuilder()` method, then we also need to be able to make a `BarBuilder` out of an existing `Bar`, because if you call `Foo.Builder builder = foo1.toBuilder()` then the builder returned by `builder.barBuilder()` must start off with the contents of `foo1.bar()`. Previously we allowed that when `Bar` had a method `BarBuilder toBuilder()`. We also had a special case for Guava classes like `ImmutableList`. `ImmutableList` doesn't have a `toBuilder()` method, but you can make an `ImmutableList.Builder` out of an `ImmutableList` by starting with an empty `ImmutableList.Builder` and calling `addAll(theImmutableList)`. The change here generalizes that special case: it will work if the `BarBuilder` class has a method `addAll` or `putAll` that can accept an argument of type `Bar`. `ImmutableList.Builder<E>` has a method `addAll(Iterable<? extends E>)` and you can pass an `ImmutableList<E>` to that method, so we still accept `ImmutableList.Builder<T> barBuilder()`. But we now also accept any other class that qualifies.

Fixes https://github.com/google/auto/issues/794.

RELNOTES=Generalized the logic for determining if we can make a BarBuilder out of a Bar. For example, if your `@AutoValue` class `Foo` has a property `IntList ints()`, then your builder can have `IntListBuilder intsBuilder()`, where `IntListBuilder` is your own type, and this will work even if there is a `Foo.toBuilder()` method, provided it's possible to call `IntListBuilder.addAll(IntList)`. Previously it worked, but not if there was a `Foo.toBuilder()` because we didn't know how to make `IntListBuilder` out of `IntList`.

860905865e66f3985d7e7d5dc0f44a9f2a7906cc