### PR TITLE
MOE Sync 2020-05-01

### DIFF
--- a/value/src/it/functional/src/test/java/com/google/auto/value/AutoValueTest.java
+++ b/value/src/it/functional/src/test/java/com/google/auto/value/AutoValueTest.java
@@ -1571,6 +1571,51 @@ public class AutoValueTest {
   }
 
   @AutoValue
+  public abstract static class PrimitiveAndBoxed {
+    public abstract int anInt();
+
+    @Nullable
+    public abstract Integer aNullableInteger();
+
+    public abstract Integer aNonNullableInteger();
+
+    public abstract Builder toBuilder();
+
+    public static Builder builder() {
+      return new AutoValue_AutoValueTest_PrimitiveAndBoxed.Builder();
+    }
+
+    @AutoValue.Builder
+    public interface Builder {
+      Builder setAnInt(Integer x);
+
+      Builder setANullableInteger(int x);
+
+      Builder setANonNullableInteger(int x);
+
+      PrimitiveAndBoxed build();
+    }
+  }
+
+  @Test
+  public void testPrimitiveAndBoxed() {
+    PrimitiveAndBoxed instance1 =
+        PrimitiveAndBoxed.builder().setAnInt(17).setANonNullableInteger(23).build();
+    assertThat(instance1.anInt()).isEqualTo(17);
+    assertThat(instance1.aNullableInteger()).isNull();
+    assertThat(instance1.aNonNullableInteger()).isEqualTo(23);
+
+    PrimitiveAndBoxed instance2 = instance1.toBuilder().setANullableInteger(5).build();
+    assertThat(instance2.aNullableInteger()).isEqualTo(5);
+
+    try {
+      instance1.toBuilder().setAnInt(null);
+      fail();
+    } catch (NullPointerException expected) {
+    }
+  }
+
+  @AutoValue
   public abstract static class OptionalPropertiesWithBuilder {
     public abstract com.google.common.base.Optional<String> optionalString();
 

--- a/value/src/main/java/com/google/auto/value/processor/BuilderMethodClassifier.java
+++ b/value/src/main/java/com/google/auto/value/processor/BuilderMethodClassifier.java
@@ -432,7 +432,11 @@ class BuilderMethodClassifier {
         MoreTypes.asExecutable(
             typeUtils.asMemberOf(MoreTypes.asDeclared(builderType.asType()), setter));
     TypeMirror parameterType = finalSetter.getParameterTypes().get(0);
-    if (typeUtils.isSameType(parameterType, targetType)) {
+    // Two types are assignable to each other if they are the same type, or if one is primitive and
+    // the other is the corresponding boxed type. There might be other cases where this is true, but
+    // we're likely to want to accept those too.
+    if (typeUtils.isAssignable(parameterType, targetType)
+        && typeUtils.isAssignable(targetType, parameterType)) {
       if (nullableParameter) {
         boolean nullableProperty =
             nullableAnnotationFor(valueGetter, valueGetter.getReturnType()).isPresent();


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Allow boxed @AutoValue properties to be set from the corresponding primitive type.

We also allow the converse, though that's less likely to be useful.

RELNOTES=Allow boxed @AutoValue properties to be set from the corresponding primitive type.

d1597efaed9d8f6d139d310c8cf7d9774ac7a0e6