### PR TITLE
MOE Sync 2020-06-08

### DIFF
--- a/value/src/main/java/com/google/auto/value/processor/AutoOneOfProcessor.java
+++ b/value/src/main/java/com/google/auto/value/processor/AutoOneOfProcessor.java
@@ -72,7 +72,7 @@ public class AutoOneOfProcessor extends AutoValueOrOneOfProcessor {
   void processType(TypeElement autoOneOfType) {
     if (autoOneOfType.getKind() != ElementKind.CLASS) {
       errorReporter()
-          .abortWithError("@" + AUTO_ONE_OF_NAME + " only applies to classes", autoOneOfType);
+          .abortWithError(autoOneOfType, "@" + AUTO_ONE_OF_NAME + " only applies to classes");
     }
     checkModifiersIfNested(autoOneOfType);
     DeclaredType kindMirror = mirrorForKindType(autoOneOfType);
@@ -128,9 +128,9 @@ public class AutoOneOfProcessor extends AutoValueOrOneOfProcessor {
       // but it has happened in the past and can crash the compiler.
       errorReporter()
           .abortWithError(
+              autoOneOfType,
               "annotation processor for @AutoOneOf was invoked with a type"
-                  + " that does not have that annotation; this is probably a compiler bug",
-              autoOneOfType);
+                  + " that does not have that annotation; this is probably a compiler bug");
     }
     AnnotationValue kindValue =
         AnnotationMirrors.getAnnotationValue(oneOfAnnotation.get(), "value");
@@ -183,8 +183,9 @@ public class AutoOneOfProcessor extends AutoValueOrOneOfProcessor {
           if (!transformedEnumConstants.containsKey(transformed)) {
             errorReporter()
                 .reportError(
-                    "Enum has no constant with name corresponding to property '" + property + "'",
-                    kindElement);
+                    kindElement,
+                    "Enum has no constant with name corresponding to property '%s'",
+                    property);
           }
         });
     // Enum constants that have no property
@@ -193,10 +194,9 @@ public class AutoOneOfProcessor extends AutoValueOrOneOfProcessor {
           if (!transformedPropertyNames.containsKey(transformed)) {
             errorReporter()
                 .reportError(
-                    "Name of enum constant '"
-                        + constant.getSimpleName()
-                        + "' does not correspond to any property name",
-                    constant);
+                    constant,
+                    "Name of enum constant '%s' does not correspond to any property name",
+                    constant.getSimpleName());
           }
         });
     throw new AbortProcessingException();
@@ -220,15 +220,17 @@ public class AutoOneOfProcessor extends AutoValueOrOneOfProcessor {
       case 0:
         errorReporter()
             .reportError(
-                autoOneOfType + " must have a no-arg abstract method returning " + kindMirror,
-                autoOneOfType);
+                autoOneOfType,
+                "%s must have a no-arg abstract method returning %s",
+                autoOneOfType,
+                kindMirror);
         break;
       case 1:
         return Iterables.getOnlyElement(kindGetters);
       default:
         for (ExecutableElement getter : kindGetters) {
           errorReporter()
-              .reportError("More than one abstract method returns " + kindMirror, getter);
+              .reportError(getter, "More than one abstract method returns %s", kindMirror);
         }
     }
     throw new AbortProcessingException();
@@ -252,8 +254,7 @@ public class AutoOneOfProcessor extends AutoValueOrOneOfProcessor {
         // implement this alien method.
         errorReporter()
             .reportWarning(
-                "Abstract methods in @AutoOneOf classes must have no parameters",
-                method);
+                method, "Abstract methods in @AutoOneOf classes must have no parameters");
       }
     }
     errorReporter().abortIfAnyError();
@@ -277,7 +278,7 @@ public class AutoOneOfProcessor extends AutoValueOrOneOfProcessor {
   @Override
   Optional<String> nullableAnnotationForMethod(ExecutableElement propertyMethod) {
     if (nullableAnnotationFor(propertyMethod, propertyMethod.getReturnType()).isPresent()) {
-      errorReporter().reportError("@AutoOneOf properties cannot be @Nullable", propertyMethod);
+      errorReporter().reportError(propertyMethod, "@AutoOneOf properties cannot be @Nullable");
     }
     return Optional.empty();
   }

--- a/value/src/main/java/com/google/auto/value/processor/AutoValueOrOneOfProcessor.java
+++ b/value/src/main/java/com/google/auto/value/processor/AutoValueOrOneOfProcessor.java
@@ -873,7 +873,7 @@ abstract class AutoValueOrOneOfProcessor extends AbstractProcessor {
     return className.startsWith(AUTO_VALUE_PACKAGE_NAME) && !className.contains("Test");
   }
 
-  private ImmutableList<String> copiedClassAnnotations(TypeElement type) {
+  ImmutableList<String> copiedClassAnnotations(TypeElement type) {
     // Only copy annotations from a class if it has @AutoValue.CopyAnnotations.
     if (hasAnnotationMirror(type, COPY_ANNOTATIONS_NAME)) {
       Set<String> excludedAnnotations =

--- a/value/src/main/java/com/google/auto/value/processor/AutoValueOrOneOfTemplateVars.java
+++ b/value/src/main/java/com/google/auto/value/processor/AutoValueOrOneOfTemplateVars.java
@@ -56,9 +56,10 @@ abstract class AutoValueOrOneOfTemplateVars extends TemplateVars {
   String simpleClassName;
 
   /**
-   * The full spelling of any annotation to add to this class, or an empty list if there are none. A
-   * non-empty value might look something like {@code
-   * "@com.google.common.annotations.GwtCompatible(serializable = true)"}.
+   * The full spelling of any annotations to add to this class, or an empty list if there are none.
+   * A non-empty value might look something like {@code
+   * "@`com.google.common.annotations.GwtCompatible`(serializable = true)"}. The {@code ``} marks
+   * are explained in {@link TypeEncoder}.
    */
   ImmutableList<String> annotations;
 

--- a/value/src/main/java/com/google/auto/value/processor/AutoValueProcessor.java
+++ b/value/src/main/java/com/google/auto/value/processor/AutoValueProcessor.java
@@ -423,7 +423,7 @@ public class AutoValueProcessor extends AutoValueOrOneOfProcessor {
       AutoValueTemplateVars vars,
       ImmutableSet<ExecutableElement> toBuilderMethods,
       ImmutableMap<ExecutableElement, TypeMirror> propertyMethodsAndTypes,
-      Optional<BuilderSpec.Builder> builder) {
+      Optional<BuilderSpec.Builder> maybeBuilder) {
     ImmutableSet<ExecutableElement> propertyMethods = propertyMethodsAndTypes.keySet();
     // We can't use ImmutableList.toImmutableList() for obscure Google-internal reasons.
     vars.toBuilderMethods =
@@ -436,11 +436,13 @@ public class AutoValueProcessor extends AutoValueOrOneOfProcessor {
         propertySet(propertyMethodsAndTypes, annotatedPropertyFields, annotatedPropertyMethods);
     vars.serialVersionUID = getSerialVersionUID(type);
     // Check for @AutoValue.Builder and add appropriate variables if it is present.
-    if (builder.isPresent()) {
-      ImmutableBiMap<ExecutableElement, String> methodToPropertyName =
-          propertyNameToMethodMap(propertyMethods).inverse();
-      builder.get().defineVars(vars, methodToPropertyName);
-    }
+    maybeBuilder.ifPresent(
+        builder -> {
+          ImmutableBiMap<ExecutableElement, String> methodToPropertyName =
+              propertyNameToMethodMap(propertyMethods).inverse();
+          builder.defineVars(vars, methodToPropertyName);
+          vars.builderAnnotations = copiedClassAnnotations(builder.builderType());
+        });
   }
 
   @Override

--- a/value/src/main/java/com/google/auto/value/processor/AutoValueTemplateVars.java
+++ b/value/src/main/java/com/google/auto/value/processor/AutoValueTemplateVars.java
@@ -36,7 +36,7 @@ class AutoValueTemplateVars extends AutoValueOrOneOfTemplateVars {
    * The properties defined by the parent class's abstract methods. The elements of this set are in
    * the same order as the original abstract method declarations in the AutoValue class.
    */
-  ImmutableSet<AutoValueProcessor.Property> props;
+  ImmutableSet<AutoValueOrOneOfProcessor.Property> props;
 
   /**
    * Whether to include identifiers in strings in the generated code. If false, exception messages
@@ -99,6 +99,14 @@ class AutoValueTemplateVars extends AutoValueOrOneOfTemplateVars {
 
   /** True if the builder being implemented is an interface, false if it is an abstract class. */
   Boolean builderIsInterface = false;
+
+  /**
+   * The full spelling of any annotations to add to the generated builder subclass, or an empty list
+   * if there are none. A non-empty value might look something like {@code
+   * @`java.lang.SuppressWarnings`("Immutable")}. The {@code ``} marks are explained in
+   * {@link TypeEncoder}.
+   */
+  ImmutableList<String> builderAnnotations = ImmutableList.of();
 
   /** The builder's build method, often {@code "build"}. */
   Optional<SimpleMethod> buildMethod = Optional.empty();

--- a/value/src/main/java/com/google/auto/value/processor/BuilderSpec.java
+++ b/value/src/main/java/com/google/auto/value/processor/BuilderSpec.java
@@ -447,11 +447,9 @@ class BuilderSpec {
 
     if (!sameTypeParameters(autoValueClass, builderTypeElement)) {
       errorReporter.reportError(
-          "Type parameters of "
-              + builderTypeElement
-              + " must have same names and bounds as "
-              + "type parameters of "
-              + autoValueClass,
+          String.format(
+              "Type parameters of %s must have same names and bounds as type parameters of %s",
+              builderTypeElement, autoValueClass),
           builderTypeElement);
       return Optional.empty();
     }

--- a/value/src/main/java/com/google/auto/value/processor/BuilderSpec.java
+++ b/value/src/main/java/com/google/auto/value/processor/BuilderSpec.java
@@ -86,14 +86,16 @@ class BuilderSpec {
       if (hasAnnotationMirror(containedClass, AUTO_VALUE_BUILDER_NAME)) {
         if (!CLASS_OR_INTERFACE.contains(containedClass.getKind())) {
           errorReporter.reportError(
-              "@AutoValue.Builder can only apply to a class or an interface", containedClass);
+              containedClass, "@AutoValue.Builder can only apply to a class or an interface");
         } else if (!containedClass.getModifiers().contains(Modifier.STATIC)) {
           errorReporter.reportError(
-              "@AutoValue.Builder cannot be applied to a non-static class", containedClass);
+              containedClass, "@AutoValue.Builder cannot be applied to a non-static class");
         } else if (builderTypeElement.isPresent()) {
           errorReporter.reportError(
-              autoValueClass + " already has a Builder: " + builderTypeElement.get(),
-              containedClass);
+              containedClass,
+              "%s already has a Builder: %s",
+              autoValueClass,
+              builderTypeElement.get());
         } else {
           builderTypeElement = Optional.of(containedClass);
         }
@@ -215,17 +217,17 @@ class BuilderSpec {
                   .collect(toList());
           if (!builderTypeParamNames.equals(typeArguments)) {
             errorReporter.reportError(
-                "Builder converter method should return "
-                    + builderTypeElement
-                    + TypeSimplifier.actualTypeParametersString(builderTypeElement),
-                method);
+                method,
+                "Builder converter method should return %s%s",
+                builderTypeElement,
+                TypeSimplifier.actualTypeParametersString(builderTypeElement));
           }
         }
       }
       ImmutableSet<ExecutableElement> builderMethods = methods.build();
       if (builderMethods.size() > 1) {
         errorReporter.reportError(
-            "There can be at most one builder converter method", builderMethods.iterator().next());
+            builderMethods.iterator().next(), "There can be at most one builder converter method");
       }
       this.toBuilderMethods = builderMethods;
       return builderMethods;
@@ -263,7 +265,7 @@ class BuilderSpec {
           // For now we ignore methods with annotations, because for example we do want to allow
           // Jackson's @JsonCreator.
           errorReporter.reportWarning(
-              "Static builder() method should be in the containing class", method);
+              method, "Static builder() method should be in the containing class");
         }
       }
       this.classifier = optionalClassifier.get();
@@ -273,10 +275,10 @@ class BuilderSpec {
             buildMethods.isEmpty() ? ImmutableSet.of(builderTypeElement) : buildMethods;
         for (Element buildMethod : errorElements) {
           errorReporter.reportError(
-              "Builder must have a single no-argument method returning "
-                  + autoValueClass
-                  + typeParamsString(),
-              buildMethod);
+              buildMethod,
+              "Builder must have a single no-argument method returning %s%s",
+              autoValueClass,
+              typeParamsString());
         }
         return;
       }
@@ -447,10 +449,10 @@ class BuilderSpec {
 
     if (!sameTypeParameters(autoValueClass, builderTypeElement)) {
       errorReporter.reportError(
-          String.format(
-              "Type parameters of %s must have same names and bounds as type parameters of %s",
-              builderTypeElement, autoValueClass),
-          builderTypeElement);
+          builderTypeElement,
+          "Type parameters of %s must have same names and bounds as type parameters of %s",
+          builderTypeElement,
+          autoValueClass);
       return Optional.empty();
     }
     return Optional.of(new Builder(builderTypeElement));

--- a/value/src/main/java/com/google/auto/value/processor/ErrorReporter.java
+++ b/value/src/main/java/com/google/auto/value/processor/ErrorReporter.java
@@ -15,6 +15,7 @@
  */
 package com.google.auto.value.processor;
 
+import com.google.errorprone.annotations.FormatMethod;
 import javax.annotation.processing.Messager;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.Element;
@@ -36,21 +37,25 @@ class ErrorReporter {
   /**
    * Issue a compilation note.
    *
-   * @param msg the text of the note
    * @param e the element to which it pertains
+   * @param format the format string for the text of the note
+   * @param args arguments for the format string
    */
-  void reportNote(String msg, Element e) {
-    messager.printMessage(Diagnostic.Kind.NOTE, msg, e);
+  @FormatMethod
+  void reportNote(Element e, String format, Object... args) {
+    messager.printMessage(Diagnostic.Kind.NOTE, String.format(format, args), e);
   }
 
   /**
    * Issue a compilation warning.
    *
-   * @param msg the text of the warning
    * @param e the element to which it pertains
+   * @param format the format string for the text of the warning
+   * @param args arguments for the format string
    */
-  void reportWarning(String msg, Element e) {
-    messager.printMessage(Diagnostic.Kind.WARNING, msg, e);
+  @FormatMethod
+  void reportWarning(Element e, String format, Object... args) {
+    messager.printMessage(Diagnostic.Kind.WARNING, String.format(format, args), e);
   }
 
   /**
@@ -59,11 +64,13 @@ class ErrorReporter {
    * CompilationTest for any new call to reportError(...) to ensure that we continue correctly after
    * an error.
    *
-   * @param msg the text of the warning
    * @param e the element to which it pertains
+   * @param format the format string for the text of the warning
+   * @param args arguments for the format string
    */
-  void reportError(String msg, Element e) {
-    messager.printMessage(Diagnostic.Kind.ERROR, msg, e);
+  @FormatMethod
+  void reportError(Element e, String format, Object... args) {
+    messager.printMessage(Diagnostic.Kind.ERROR, String.format(format, args), e);
     errorCount++;
   }
 
@@ -71,11 +78,13 @@ class ErrorReporter {
    * Issue a compilation error and abandon the processing of this class. This does not prevent the
    * processing of other classes.
    *
-   * @param msg the text of the error
    * @param e the element to which it pertains
+   * @param format the format string for the text of the error
+   * @param args arguments for the format string
    */
-  void abortWithError(String msg, Element e) {
-    reportError(msg, e);
+  @FormatMethod
+  void abortWithError(Element e, String format, Object... args) {
+    reportError(e, format, args);
     throw new AbortProcessingException();
   }
 

--- a/value/src/main/java/com/google/auto/value/processor/PropertyBuilderClassifier.java
+++ b/value/src/main/java/com/google/auto/value/processor/PropertyBuilderClassifier.java
@@ -197,8 +197,8 @@ class PropertyBuilderClassifier {
     TypeMirror barBuilderTypeMirror = builderMethodClassifier.builderMethodReturnType(method);
     if (barBuilderTypeMirror.getKind() != TypeKind.DECLARED) {
       errorReporter.reportError(
-          "Method looks like a property builder, but its return type is not a class or interface",
-          method);
+          method,
+          "Method looks like a property builder, but its return type is not a class or interface");
       return Optional.empty();
     }
     DeclaredType barBuilderDeclaredType = MoreTypes.asDeclared(barBuilderTypeMirror);
@@ -209,16 +209,17 @@ class PropertyBuilderClassifier {
     TypeMirror barTypeMirror = getterToPropertyType.get(barGetter);
     if (barTypeMirror.getKind() != TypeKind.DECLARED) {
       errorReporter.reportError(
-          "Method looks like a property builder, but the type of property "
-              + property
-              + " is not a class or interface",
-          method);
+          method,
+          "Method looks like a property builder, but the type of property %s is not a class or"
+              + " interface",
+          property);
       return Optional.empty();
     }
     if (isNullable(barGetter)) {
       errorReporter.reportError(
-          "Property " + property + " has a property builder so it cannot be @Nullable",
-          barGetter);
+          barGetter,
+          "Property %s has a property builder so it cannot be @Nullable",
+          property);
     }
     TypeElement barTypeElement = MoreTypes.asTypeElement(barTypeMirror);
     Map<String, ExecutableElement> barNoArgMethods = noArgMethodsOf(barTypeElement);
@@ -227,10 +228,10 @@ class PropertyBuilderClassifier {
     ExecutableElement build = barBuilderNoArgMethods.get("build");
     if (build == null || build.getModifiers().contains(Modifier.STATIC)) {
       errorReporter.reportError(
-          "Method looks like a property builder, but it returns "
-              + barBuilderTypeElement
-              + " which does not have a non-static build() method",
-          method);
+          method,
+          "Method looks like a property builder, but it returns %s which does not have a"
+              + " non-static build() method",
+          barBuilderTypeElement);
       return Optional.empty();
     }
 
@@ -239,15 +240,12 @@ class PropertyBuilderClassifier {
     TypeMirror buildType = eclipseHack.methodReturnType(build, barBuilderDeclaredType);
     if (!MoreTypes.equivalence().equivalent(barTypeMirror, buildType)) {
       errorReporter.reportError(
-          "Property builder for "
-              + property
-              + " has type "
-              + barBuilderTypeElement
-              + " whose build() method returns "
-              + buildType
-              + " instead of "
-              + barTypeMirror,
-          method);
+          method,
+          "Property builder for %s has type %s whose build() method returns %s instead of %s",
+          property,
+          barBuilderTypeElement,
+          buildType,
+          barTypeMirror);
       return Optional.empty();
     }
 
@@ -255,13 +253,13 @@ class PropertyBuilderClassifier {
         builderMaker(barNoArgMethods, barBuilderTypeElement);
     if (!maybeBuilderMaker.isPresent()) {
       errorReporter.reportError(
-          "Method looks like a property builder, but its type "
-              + barBuilderTypeElement
-              + " does not have a public constructor and "
-              + barTypeElement
-              + " does not have a static builder() or newBuilder() method that returns "
-              + barBuilderTypeElement,
-          method);
+          method,
+          "Method looks like a property builder, but its type %s does not have a public"
+              + " constructor and %s does not have a static builder() or newBuilder() method that"
+              + " returns %s",
+          barBuilderTypeElement,
+          barTypeElement,
+          barBuilderTypeElement);
       return Optional.empty();
     }
     ExecutableElement builderMaker = maybeBuilderMaker.get();

--- a/value/src/main/java/com/google/auto/value/processor/autovalue.vm
+++ b/value/src/main/java/com/google/auto/value/processor/autovalue.vm
@@ -192,6 +192,13 @@ ${modifiers}class $subclass$formalTypes extends $origClass$actualTypes {
 
   #end
 
+  ## BUILDER CLASS
+
+  #foreach ($a in $builderAnnotations)
+
+  $a##
+  #end
+
   static #if ($isFinal) final #end class Builder${builderFormalTypes} ##
   #if ($builderIsInterface) implements #else extends #end
       ${builderTypeName}${builderActualTypes} {

--- a/value/userguide/howto.md
+++ b/value/userguide/howto.md
@@ -625,6 +625,10 @@ final class AutoValue_Example extends Example {
 }
 ```
 
+Applying `@AutoValue.CopyAnnotations` to an `@AutoValue.Builder` class like
+`Foo.Builder` similarly causes annotations on that class to be copied to the
+generated subclass `AutoValue_Foo.Builder`.
+
 ### Copying to the generated method
 
 For historical reasons, annotations on methods of an `@AutoValue`-annotated


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Copy annotations from `@AutoValue.Builder` to the generated `Builder` subclass.

This happens only if `@AutoValue.CopyAnnotations` is present on the `@AutoValue.Builder` class, using the same logic as for copying annotations from the main `@AutoValue` class.

RELNOTES=Optionally copy annotations from the `@AutoValue.Builder` class to the generated subclass.

980a6b9e821e5c2f4fd4b906a6b43a1f0af037ff

-------

<p> Change error reporting methods to use format strings.

e55a019dec9a3bb2906a1bf2e344e743948925ed