### PR TITLE
MOE Sync 2020-07-08

### DIFF
--- a/value/src/it/functional/src/test/java/com/google/auto/value/AutoValueJava8Test.java
+++ b/value/src/it/functional/src/test/java/com/google/auto/value/AutoValueJava8Test.java
@@ -19,7 +19,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
 import static com.google.common.truth.Truth8.assertThat;
 import static com.google.testing.compile.CompilationSubject.assertThat;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assume.assumeTrue;
 
 import com.google.common.collect.ImmutableList;
@@ -375,12 +375,9 @@ public class AutoValueJava8Test {
 
   @Test
   public void testNotNullablePrimitiveArrays() {
-    try {
-      PrimitiveArrays.create(null, new int[0]);
-      fail("Construction with null value for non-@Nullable array should have failed");
-    } catch (NullPointerException e) {
-      assertThat(e.getMessage()).contains("booleans");
-    }
+    NullPointerException e =
+        assertThrows(NullPointerException.class, () -> PrimitiveArrays.create(null, new int[0]));
+    assertThat(e).hasMessageThat().contains("booleans");
   }
 
   @AutoValue
@@ -421,12 +418,10 @@ public class AutoValueJava8Test {
     assertThat(instance3.notNullable()).isEqualTo("hello");
     assertThat(instance3.nullable()).isEqualTo("world");
 
-    try {
-      NullablePropertyWithBuilder.builder().build();
-      fail("Expected IllegalStateException for unset non-@Nullable property");
-    } catch (IllegalStateException e) {
-      assertThat(e.getMessage()).contains("notNullable");
-    }
+    IllegalStateException e =
+        assertThrows(
+            IllegalStateException.class, () -> NullablePropertyWithBuilder.builder().build());
+    assertThat(e).hasMessageThat().contains("notNullable");
   }
 
   @AutoValue
@@ -470,11 +465,39 @@ public class AutoValueJava8Test {
     assertThat(instance3.notOptional()).isEqualTo("hello");
     assertThat(instance3.optional()).hasValue("world");
 
-    try {
-      OptionalPropertyWithNullableBuilder.builder().build();
-      fail("Expected IllegalStateException for unset non-Optional property");
-    } catch (IllegalStateException expected) {
+    assertThrows(
+        IllegalStateException.class, () -> OptionalPropertyWithNullableBuilder.builder().build());
+  }
+
+  @AutoValue
+  public abstract static class NullableOptionalPropertyWithNullableBuilder {
+    public abstract @Nullable Optional<String> optional();
+
+    public static Builder builder() {
+      return new AutoValue_AutoValueJava8Test_NullableOptionalPropertyWithNullableBuilder.Builder();
     }
+
+    @AutoValue.Builder
+    public interface Builder {
+      Builder optional(@Nullable String s);
+
+      NullableOptionalPropertyWithNullableBuilder build();
+    }
+  }
+
+  @Test
+  public void testNullableOptional() {
+    NullableOptionalPropertyWithNullableBuilder instance1 =
+        NullableOptionalPropertyWithNullableBuilder.builder().build();
+    assertThat(instance1.optional()).isNull();
+
+    NullableOptionalPropertyWithNullableBuilder instance2 =
+        NullableOptionalPropertyWithNullableBuilder.builder().optional(null).build();
+    assertThat(instance2.optional()).isEmpty();
+
+    NullableOptionalPropertyWithNullableBuilder instance3 =
+        NullableOptionalPropertyWithNullableBuilder.builder().optional("haruspex").build();
+    assertThat(instance3.optional()).hasValue("haruspex");
   }
 
   @AutoValue
@@ -522,18 +545,10 @@ public class AutoValueJava8Test {
 
     BuilderWithUnprefixedGetters.Builder<String> builder = BuilderWithUnprefixedGetters.builder();
     assertThat(builder.t()).isNull();
-    try {
-      builder.list();
-      fail("Attempt to retrieve unset list property should have failed");
-    } catch (IllegalStateException e) {
-      assertThat(e).hasMessageThat().isEqualTo("Property \"list\" has not been set");
-    }
-    try {
-      builder.ints();
-      fail("Attempt to retrieve unset ints property should have failed");
-    } catch (IllegalStateException e) {
-      assertThat(e).hasMessageThat().isEqualTo("Property \"ints\" has not been set");
-    }
+    IllegalStateException e1 = assertThrows(IllegalStateException.class, () -> builder.list());
+    assertThat(e1).hasMessageThat().isEqualTo("Property \"list\" has not been set");
+    IllegalStateException e2 = assertThrows(IllegalStateException.class, () -> builder.ints());
+    assertThat(e2).hasMessageThat().isEqualTo("Property \"ints\" has not been set");
 
     builder.setList(names);
     assertThat(builder.list()).isSameInstanceAs(names);
@@ -596,12 +611,8 @@ public class AutoValueJava8Test {
 
     BuilderWithPrefixedGetters.Builder<String> builder = BuilderWithPrefixedGetters.builder();
     assertThat(builder.getInts()).isNull();
-    try {
-      builder.getList();
-      fail("Attempt to retrieve unset list property should have failed");
-    } catch (IllegalStateException e) {
-      assertThat(e).hasMessageThat().isEqualTo("Property \"list\" has not been set");
-    }
+    IllegalStateException e = assertThrows(IllegalStateException.class, () -> builder.getList());
+    assertThat(e).hasMessageThat().isEqualTo("Property \"list\" has not been set");
 
     builder.setList(names);
     assertThat(builder.getList()).isSameInstanceAs(names);


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Fix handling of `@Nullable Optional<T> foo()` properties being set by `setFoo(@Nullable T)` setters.

Previously calling `setFoo(null)` resulted in the property being set to `null`, even though for `Optional<T> foo()` (without `@Nullable`) it would set the property to `Optional.empty()`. With this change, it is set to `Optional.empty()` whether or not it is `@Nullable`.

RELNOTES=Fixed handling of `@Nullable Optional<T> foo()` properties being set by `setFoo(@Nullable T)` setters. Now `setFoo(null)` results in `Optional.empty()`, not `null`.

541505d5053adfb3501043d76abee232b855a561