### PR TITLE
MOE Sync 2020-07-08

### DIFF
--- a/value/src/main/java/com/google/auto/value/extension/memoized/processor/MemoizeExtension.java
+++ b/value/src/main/java/com/google/auto/value/extension/memoized/processor/MemoizeExtension.java
@@ -100,8 +100,11 @@ public final class MemoizeExtension extends AutoValueExtension {
   private static final String AUTO_VALUE_NAME = AUTO_VALUE_PACKAGE_NAME + "AutoValue";
   private static final String COPY_ANNOTATIONS_NAME = AUTO_VALUE_NAME + ".CopyAnnotations";
 
+  // Maven is configured to shade (rewrite) com.google packages to prevent dependency conflicts.
+  // Split up the package here with a call to concat to prevent Maven from finding and rewriting it,
+  // so that this will be able to find the LazyInit annotation if it's on the classpath.
   private static final ClassName LAZY_INIT =
-      ClassName.get("com.google.errorprone.annotations.concurrent", "LazyInit");
+      ClassName.get("com".concat(".google.errorprone.annotations.concurrent"), "LazyInit");
 
   private static final AnnotationSpec SUPPRESS_WARNINGS =
       AnnotationSpec.builder(SuppressWarnings.class).addMember("value", "$S", "Immutable").build();


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Stop the LazyInit annotation from getting shaded by Maven, so that AutoValue can find it on the classpath.

The @LazyInit annotation is added if it's found on the classpath (https://github.com/google/auto/blob/da84ef1fae38f2d72901c2b95674271e89600f28/value/src/main/java/com/google/auto/value/extension/memoized/processor/MemoizeExtension.java#L577) but shading rewrites the package at https://github.com/google/auto/blob/da84ef1fae38f2d72901c2b95674271e89600f28/value/src/main/java/com/google/auto/value/extension/memoized/processor/MemoizeExtension.java#L104 from "com.google.errorprone.annotations.concurrent" to "autovalue.shaded.com.google$.errorprone.annotations.$concurrent" (you can verify this by disassembling the bytecode for MemoizeExtension.class in the release JAR). This means that even with the Error Prone annotations on the classpath, it won't be able to find the LazyInit annotation.

Splitting up the package with a call to String#concat means Maven will no longer rewrite it, so AutoValue will be able to find the LazyInit annotation on the classpath if it's there.

Fixes https://github.com/google/auto/issues/427

RELNOTES=Stop the LazyInit annotation from getting shaded by Maven, so that AutoValue can find it on the classpath.

74a18fd500075429c07b95daec79fa88e27a1296