### PR TITLE
MOE Sync 2020-07-27

### DIFF
--- a/value/src/main/java/com/google/auto/value/processor/AutoOneOfProcessor.java
+++ b/value/src/main/java/com/google/auto/value/processor/AutoOneOfProcessor.java
@@ -72,7 +72,9 @@ public class AutoOneOfProcessor extends AutoValueOrOneOfProcessor {
   void processType(TypeElement autoOneOfType) {
     if (autoOneOfType.getKind() != ElementKind.CLASS) {
       errorReporter()
-          .abortWithError(autoOneOfType, "@" + AUTO_ONE_OF_NAME + " only applies to classes");
+          .abortWithError(
+              autoOneOfType,
+              "[AutoOneOfNotClass] @" + AUTO_ONE_OF_NAME + " only applies to classes");
     }
     checkModifiersIfNested(autoOneOfType);
     DeclaredType kindMirror = mirrorForKindType(autoOneOfType);
@@ -129,7 +131,7 @@ public class AutoOneOfProcessor extends AutoValueOrOneOfProcessor {
       errorReporter()
           .abortWithError(
               autoOneOfType,
-              "annotation processor for @AutoOneOf was invoked with a type"
+              "[AutoOneOfCompilerBug] annotation processor for @AutoOneOf was invoked with a type"
                   + " that does not have that annotation; this is probably a compiler bug");
     }
     AnnotationValue kindValue =
@@ -184,7 +186,8 @@ public class AutoOneOfProcessor extends AutoValueOrOneOfProcessor {
             errorReporter()
                 .reportError(
                     kindElement,
-                    "Enum has no constant with name corresponding to property '%s'",
+                    "[AutoOneOfNoEnumConstant] Enum has no constant with name corresponding to"
+                        + " property '%s'",
                     property);
           }
         });
@@ -195,7 +198,8 @@ public class AutoOneOfProcessor extends AutoValueOrOneOfProcessor {
             errorReporter()
                 .reportError(
                     constant,
-                    "Name of enum constant '%s' does not correspond to any property name",
+                    "[AutoOneOfBadEnumConstant] Name of enum constant '%s' does not correspond to"
+                        + " any property name",
                     constant.getSimpleName());
           }
         });
@@ -221,7 +225,7 @@ public class AutoOneOfProcessor extends AutoValueOrOneOfProcessor {
         errorReporter()
             .reportError(
                 autoOneOfType,
-                "%s must have a no-arg abstract method returning %s",
+                "[AutoOneOfNoKindGetter] %s must have a no-arg abstract method returning %s",
                 autoOneOfType,
                 kindMirror);
         break;
@@ -230,7 +234,10 @@ public class AutoOneOfProcessor extends AutoValueOrOneOfProcessor {
       default:
         for (ExecutableElement getter : kindGetters) {
           errorReporter()
-              .reportError(getter, "More than one abstract method returns %s", kindMirror);
+              .reportError(
+                  getter,
+                  "[AutoOneOfTwoKindGetters] More than one abstract method returns %s",
+                  kindMirror);
         }
     }
     throw new AbortProcessingException();
@@ -254,7 +261,8 @@ public class AutoOneOfProcessor extends AutoValueOrOneOfProcessor {
         // implement this alien method.
         errorReporter()
             .reportWarning(
-                method, "Abstract methods in @AutoOneOf classes must have no parameters");
+                method,
+                "[AutoOneOfParams] Abstract methods in @AutoOneOf classes must have no parameters");
       }
     }
     errorReporter().abortIfAnyError();
@@ -278,7 +286,9 @@ public class AutoOneOfProcessor extends AutoValueOrOneOfProcessor {
   @Override
   Optional<String> nullableAnnotationForMethod(ExecutableElement propertyMethod) {
     if (nullableAnnotationFor(propertyMethod, propertyMethod.getReturnType()).isPresent()) {
-      errorReporter().reportError(propertyMethod, "@AutoOneOf properties cannot be @Nullable");
+      errorReporter()
+          .reportError(
+              propertyMethod, "[AutoOneOfNullable] @AutoOneOf properties cannot be @Nullable");
     }
     return Optional.empty();
   }

--- a/value/src/main/java/com/google/auto/value/processor/AutoValueOrOneOfProcessor.java
+++ b/value/src/main/java/com/google/auto/value/processor/AutoValueOrOneOfProcessor.java
@@ -71,7 +71,6 @@ import javax.lang.model.element.QualifiedNameable;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.TypeParameterElement;
 import javax.lang.model.element.VariableElement;
-import javax.lang.model.type.ArrayType;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
@@ -301,7 +300,8 @@ abstract class AutoValueOrOneOfProcessor extends AbstractProcessor {
       for (TypeElement type : deferredTypes) {
         errorReporter.reportError(
             type,
-            "Did not generate @%s class for %s because it references undefined types",
+            "[AutoValueUndefined] Did not generate @%s class for %s because it references"
+                + " undefined types",
             simpleAnnotationName,
             type.getQualifiedName());
       }
@@ -331,7 +331,10 @@ abstract class AutoValueOrOneOfProcessor extends AbstractProcessor {
       } catch (RuntimeException e) {
         String trace = Throwables.getStackTraceAsString(e);
         errorReporter.reportError(
-            type, "@%s processor threw an exception: %s", simpleAnnotationName, trace);
+            type,
+            "[AutoValueException] @%s processor threw an exception: %s",
+            simpleAnnotationName,
+            trace);
         throw e;
       }
     }
@@ -378,8 +381,9 @@ abstract class AutoValueOrOneOfProcessor extends AbstractProcessor {
     ImmutableSet.Builder<Property> props = ImmutableSet.builder();
     propertyMethodsAndTypes.forEach(
         (propertyMethod, returnType) -> {
-          String propertyType = TypeEncoder.encodeWithAnnotations(
-              returnType, getExcludedAnnotationTypes(propertyMethod));
+          String propertyType =
+              TypeEncoder.encodeWithAnnotations(
+                  returnType, getExcludedAnnotationTypes(propertyMethod));
           String propertyName = methodToPropertyName.get(propertyMethod);
           String identifier = methodToIdentifier.get(propertyMethod);
           ImmutableList<String> fieldAnnotations =
@@ -399,7 +403,9 @@ abstract class AutoValueOrOneOfProcessor extends AbstractProcessor {
                   nullableAnnotation);
           props.add(p);
           if (p.isNullable() && returnType.getKind().isPrimitive()) {
-            errorReporter().reportError(propertyMethod, "Primitive types cannot be @Nullable");
+            errorReporter()
+                .reportError(
+                    propertyMethod, "[AutoValueNullPrimitive] Primitive types cannot be @Nullable");
           }
         });
     return props.build();
@@ -517,7 +523,10 @@ abstract class AutoValueOrOneOfProcessor extends AbstractProcessor {
         // reportedDups prevents us from reporting more than one error for the same method.
         for (ExecutableElement context : contexts) {
           errorReporter.reportError(
-              context, "More than one @%s property called %s", simpleAnnotationName, name);
+              context,
+              "[AutoValueDupProperty] More than one @%s property called %s",
+              simpleAnnotationName,
+              name);
         }
       }
     }
@@ -622,16 +631,18 @@ abstract class AutoValueOrOneOfProcessor extends AbstractProcessor {
     if (enclosingKind.isClass() || enclosingKind.isInterface()) {
       if (type.getModifiers().contains(Modifier.PRIVATE)) {
         errorReporter.abortWithError(
-            type, "@%s class must not be private", simpleAnnotationName);
+            type, "[AutoValuePrivate] @%s class must not be private", simpleAnnotationName);
       } else if (Visibility.effectiveVisibilityOfElement(type).equals(Visibility.PRIVATE)) {
         // The previous case, where the class itself is private, is much commoner so it deserves
         // its own error message, even though it would be caught by the test here too.
         errorReporter.abortWithError(
-            type, "@%s class must not be nested in a private class", simpleAnnotationName);
+            type,
+            "[AutoValueInPrivate] @%s class must not be nested in a private class",
+            simpleAnnotationName);
       }
       if (!type.getModifiers().contains(Modifier.STATIC)) {
         errorReporter.abortWithError(
-            type, "Nested @%s class must be static", simpleAnnotationName);
+            type, "[AutoValueInner] Nested @%s class must be static", simpleAnnotationName);
       }
     }
     // In principle type.getEnclosingElement() could be an ExecutableElement (for a class
@@ -766,13 +777,14 @@ abstract class AutoValueOrOneOfProcessor extends AbstractProcessor {
   final void checkReturnType(TypeElement autoValueClass, ExecutableElement getter) {
     TypeMirror type = getter.getReturnType();
     if (type.getKind() == TypeKind.ARRAY) {
-      TypeMirror componentType = ((ArrayType) type).getComponentType();
-      if (componentType.getKind().isPrimitive()) {
+      TypeMirror componentType = MoreTypes.asArray(type).getComponentType();
+     if (componentType.getKind().isPrimitive()) {
         warnAboutPrimitiveArrays(autoValueClass, getter);
       } else {
         errorReporter.reportError(
             getter,
-            "An @%s class cannot define an array-valued property unless it is a primitive array",
+            "[AutoValueArray] An @%s class cannot define an array-valued property unless it is a"
+                + " primitive array",
             simpleAnnotationName);
       }
     }
@@ -799,10 +811,11 @@ abstract class AutoValueOrOneOfProcessor extends AbstractProcessor {
       String context = sameClass ? "" : (" Method: " + getter.getEnclosingElement() + "." + getter);
       errorReporter.reportWarning(
           element,
-          "An @%s property that is a primitive array returns the original array, which can"
-              + " therefore be modified by the caller. If this is OK, you can suppress this warning"
-              + " with @SuppressWarnings(\"mutable\"). Otherwise, you should replace the property"
-              + " with an immutable type, perhaps a simple wrapper around the original array.%s",
+          "[AutoValueMutable] An @%s property that is a primitive array returns the original"
+              + " array, which can therefore be modified by the caller. If this is OK, you can"
+              + " suppress this warning with @SuppressWarnings(\"mutable\"). Otherwise, you should"
+              + " replace the property with an immutable type, perhaps a simple wrapper around the"
+              + " original array.%s",
           simpleAnnotationName,
           context);
     }
@@ -815,8 +828,8 @@ abstract class AutoValueOrOneOfProcessor extends AbstractProcessor {
   private static class ContainsMutableVisitor extends SimpleAnnotationValueVisitor8<Boolean, Void> {
     @Override
     public Boolean visitArray(List<? extends AnnotationValue> list, Void p) {
-      return list.stream().map(av -> av.getValue()).anyMatch("mutable"::equals);
-    }
+      return list.stream().map(AnnotationValue::getValue).anyMatch("mutable"::equals);
+   }
   }
 
   /**
@@ -1102,7 +1115,10 @@ abstract class AutoValueOrOneOfProcessor extends AbstractProcessor {
       // error later because user code will have a reference to the code we were supposed to
       // generate (new AutoValue_Foo() or whatever) and that reference will be undefined.
       errorReporter.reportWarning(
-          originatingType, "Could not write generated class %s: %s", className, e);
+          originatingType,
+          "[AutoValueCouldNotWrite] Could not write generated class %s: %s",
+          className,
+          e);
     }
   }
 }

--- a/value/src/main/java/com/google/auto/value/processor/AutoValueProcessor.java
+++ b/value/src/main/java/com/google/auto/value/processor/AutoValueProcessor.java
@@ -121,8 +121,8 @@ public class AutoValueProcessor extends AutoValueOrOneOfProcessor {
         errorReporter()
             .reportWarning(
                 null,
-                "An exception occurred while looking for AutoValue extensions."
-                    + " No extensions will function.%s\n%s",
+                "[AutoValueExtensionsException] An exception occurred while looking for AutoValue"
+                    + " extensions. No extensions will function.%s\n%s",
                 explain,
                 Throwables.getStackTraceAsString(e));
         extensions = ImmutableList.of();
@@ -170,19 +170,22 @@ public class AutoValueProcessor extends AutoValueOrOneOfProcessor {
       errorReporter()
           .abortWithError(
               type,
-              "annotation processor for @AutoValue was invoked with a type"
+              "[AutoValueCompilerBug] annotation processor for @AutoValue was invoked with a type"
                   + " that does not have that annotation; this is probably a compiler bug");
     }
     if (type.getKind() != ElementKind.CLASS) {
-      errorReporter().abortWithError(type, "@AutoValue only applies to classes");
+      errorReporter()
+          .abortWithError(type, "[AutoValueNotClass] @AutoValue only applies to classes");
     }
     if (ancestorIsAutoValue(type)) {
-      errorReporter().abortWithError(type, "One @AutoValue class may not extend another");
+      errorReporter()
+          .abortWithError(type, "[AutoValueExtend] One @AutoValue class may not extend another");
     }
     if (implementsAnnotation(type)) {
       errorReporter()
           .abortWithError(
-              type, "@AutoValue may not be used to implement an annotation"
+              type,
+              "[AutoValueImplAnnotation] @AutoValue may not be used to implement an annotation"
                   + " interface; try using @AutoAnnotation instead");
     }
     checkModifiersIfNested(type);
@@ -333,7 +336,8 @@ public class AutoValueProcessor extends AutoValueOrOneOfProcessor {
         errorReporter()
             .reportError(
                 type,
-                "More than one extension wants to generate the final class: %s",
+                "[AutoValueMultiFinal] More than one extension wants to generate the final class:"
+                    + " %s",
                 finalExtensions.stream().map(this::extensionName).collect(joining(", ")));
         break;
     }
@@ -355,7 +359,8 @@ public class AutoValueProcessor extends AutoValueOrOneOfProcessor {
           errorReporter()
               .reportError(
                   type,
-                  "Extension %s wants to consume a property that does not exist: %s",
+                  "[AutoValueConsumeNonexist] Extension %s wants to consume a property that does"
+                      + " not exist: %s",
                   extensionName(extension),
                   consumedProperty);
         } else {
@@ -367,8 +372,8 @@ public class AutoValueProcessor extends AutoValueOrOneOfProcessor {
           errorReporter()
               .reportError(
                   type,
-                  "Extension %s wants to consume a method that is not one of the abstract methods"
-                      + " in this class: %s",
+                  "[AutoValueConsumeNotAbstract] Extension %s wants to consume a method that is"
+                      + " not one of the abstract methods in this class: %s",
                   extensionName(extension),
                   consumedMethod);
         } else {
@@ -379,8 +384,8 @@ public class AutoValueProcessor extends AutoValueOrOneOfProcessor {
         errorReporter()
             .reportError(
                 repeat,
-                "Extension %s wants to consume a method that was already consumed by another"
-                    + " extension",
+                "[AutoValueMultiConsume] Extension %s wants to consume a method that was already"
+                    + " consumed by another extension",
                 extensionName(extension));
       }
       consumed.addAll(consumedHere);
@@ -404,10 +409,12 @@ public class AutoValueProcessor extends AutoValueOrOneOfProcessor {
         // another, and therefore leaves us with both an abstract method and the subclass method
         // that overrides it. This shows up in AutoValueTest.LukesBase for example.
         String extensionMessage = extensionsPresent ? ", and no extension consumed it" : "";
-        errorReporter().reportWarning(
-            method,
-            "Abstract method is neither a property getter nor a Builder converter%s",
-            extensionMessage);
+        errorReporter()
+            .reportWarning(
+                method,
+                "[AutoValueBuilderWhat] Abstract method is neither a property getter nor a Builder"
+                    + " converter%s",
+                extensionMessage);
       }
     }
     errorReporter().abortIfAnyError();

--- a/value/src/main/java/com/google/auto/value/processor/BuilderSpec.java
+++ b/value/src/main/java/com/google/auto/value/processor/BuilderSpec.java
@@ -86,14 +86,17 @@ class BuilderSpec {
       if (hasAnnotationMirror(containedClass, AUTO_VALUE_BUILDER_NAME)) {
         if (!CLASS_OR_INTERFACE.contains(containedClass.getKind())) {
           errorReporter.reportError(
-              containedClass, "@AutoValue.Builder can only apply to a class or an interface");
+              containedClass,
+              "[AutoValueBuilderClass] @AutoValue.Builder can only apply to a class or an"
+                  + " interface");
         } else if (!containedClass.getModifiers().contains(Modifier.STATIC)) {
           errorReporter.reportError(
-              containedClass, "@AutoValue.Builder cannot be applied to a non-static class");
+              containedClass,
+              "[AutoValueInnerBuilder] @AutoValue.Builder cannot be applied to a non-static class");
         } else if (builderTypeElement.isPresent()) {
           errorReporter.reportError(
               containedClass,
-              "%s already has a Builder: %s",
+              "[AutoValueTwoBuilders] %s already has a Builder: %s",
               autoValueClass,
               builderTypeElement.get());
         } else {
@@ -218,7 +221,7 @@ class BuilderSpec {
           if (!builderTypeParamNames.equals(typeArguments)) {
             errorReporter.reportError(
                 method,
-                "Builder converter method should return %s%s",
+                "[AutoValueBuilderConverterReturn] Builder converter method should return %s%s",
                 builderTypeElement,
                 TypeSimplifier.actualTypeParametersString(builderTypeElement));
           }
@@ -227,7 +230,8 @@ class BuilderSpec {
       ImmutableSet<ExecutableElement> builderMethods = methods.build();
       if (builderMethods.size() > 1) {
         errorReporter.reportError(
-            builderMethods.iterator().next(), "There can be at most one builder converter method");
+            builderMethods.iterator().next(),
+            "[AutoValueTwoBuilderConverters] There can be at most one builder converter method");
       }
       this.toBuilderMethods = builderMethods;
       return builderMethods;
@@ -265,7 +269,9 @@ class BuilderSpec {
           // For now we ignore methods with annotations, because for example we do want to allow
           // Jackson's @JsonCreator.
           errorReporter.reportWarning(
-              method, "Static builder() method should be in the containing class");
+              method,
+              "[AutoValueBuilderInBuilder] Static builder() method should be in the containing"
+                  + " class");
         }
       }
       this.classifier = optionalClassifier.get();
@@ -276,7 +282,8 @@ class BuilderSpec {
         for (Element buildMethod : errorElements) {
           errorReporter.reportError(
               buildMethod,
-              "Builder must have a single no-argument method returning %s%s",
+              "[AutoValueBuilderBuild] Builder must have a single no-argument method returning"
+                  + " %s%s",
               autoValueClass,
               typeParamsString());
         }
@@ -470,7 +477,8 @@ class BuilderSpec {
     if (!sameTypeParameters(autoValueClass, builderTypeElement)) {
       errorReporter.reportError(
           builderTypeElement,
-          "Type parameters of %s must have same names and bounds as type parameters of %s",
+          "[AutoValueTypeParamMismatch] Type parameters of %s must have same names and bounds as"
+              + " type parameters of %s",
           builderTypeElement,
           autoValueClass);
       return Optional.empty();

--- a/value/src/main/java/com/google/auto/value/processor/PropertyBuilderClassifier.java
+++ b/value/src/main/java/com/google/auto/value/processor/PropertyBuilderClassifier.java
@@ -198,7 +198,8 @@ class PropertyBuilderClassifier {
     if (barBuilderTypeMirror.getKind() != TypeKind.DECLARED) {
       errorReporter.reportError(
           method,
-          "Method looks like a property builder, but its return type is not a class or interface");
+          "[AutoValueOddBuilderMethod] Method looks like a property builder, but its return type"
+              + " is not a class or interface");
       return Optional.empty();
     }
     DeclaredType barBuilderDeclaredType = MoreTypes.asDeclared(barBuilderTypeMirror);
@@ -210,15 +211,15 @@ class PropertyBuilderClassifier {
     if (barTypeMirror.getKind() != TypeKind.DECLARED) {
       errorReporter.reportError(
           method,
-          "Method looks like a property builder, but the type of property %s is not a class or"
-              + " interface",
+          "[AutoValueBadBuilderMethod] Method looks like a property builder, but the type of"
+              + " property %s is not a class or interface",
           property);
       return Optional.empty();
     }
     if (isNullable(barGetter)) {
       errorReporter.reportError(
           barGetter,
-          "Property %s has a property builder so it cannot be @Nullable",
+          "[AutoValueNullBuilder] Property %s has a property builder so it cannot be @Nullable",
           property);
     }
     TypeElement barTypeElement = MoreTypes.asTypeElement(barTypeMirror);
@@ -229,8 +230,8 @@ class PropertyBuilderClassifier {
     if (build == null || build.getModifiers().contains(Modifier.STATIC)) {
       errorReporter.reportError(
           method,
-          "Method looks like a property builder, but it returns %s which does not have a"
-              + " non-static build() method",
+          "[AutoValueBuilderNotBuildable] Method looks like a property builder, but it returns %s"
+              + " which does not have a non-static build() method",
           barBuilderTypeElement);
       return Optional.empty();
     }
@@ -241,7 +242,8 @@ class PropertyBuilderClassifier {
     if (!MoreTypes.equivalence().equivalent(barTypeMirror, buildType)) {
       errorReporter.reportError(
           method,
-          "Property builder for %s has type %s whose build() method returns %s instead of %s",
+          "[AutoValueBuilderWrongType] Property builder for %s has type %s whose build() method"
+              + " returns %s instead of %s",
           property,
           barBuilderTypeElement,
           buildType,
@@ -254,9 +256,9 @@ class PropertyBuilderClassifier {
     if (!maybeBuilderMaker.isPresent()) {
       errorReporter.reportError(
           method,
-          "Method looks like a property builder, but its type %s does not have a public"
-              + " constructor and %s does not have a static builder() or newBuilder() method that"
-              + " returns %s",
+          "[AutoValueCantMakePropertyBuilder] Method looks like a property builder, but its type"
+              + " %s does not have a public constructor and %s does not have a static builder() or"
+              + " newBuilder() method that returns %s",
           barBuilderTypeElement,
           barTypeElement,
           barBuilderTypeElement);


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Add `[tags]` to AutoValue error messages. This will enable them to be correlated so that we can potentially see which ones are commonest.

RELNOTES=AutoValue error messages now have short `[tags]` so they can be correlated by tools.

86f540d3d6a2fbb7102c3667c7aa1e7ee325d580