### PR TITLE
AutoFactory fix truth and compile-testing incompatibility

### DIFF
--- a/factory/pom.xml
+++ b/factory/pom.xml
@@ -38,7 +38,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.version>1.8</java.version>
     <guava.version>28.2-jre</guava.version>
-    <truth.version>1.0.1</truth.version>
+    <truth.version>0.45</truth.version>
   </properties>
 
   <scm>
@@ -119,6 +119,11 @@
       <groupId>javax.inject</groupId>
       <artifactId>javax.inject</artifactId>
       <version>1</version>
+    </dependency>
+    <dependency>
+      <groupId>javax.annotation</groupId>
+      <artifactId>javax.annotation-api</artifactId>
+      <version>1.3.2</version>
     </dependency>
     <!-- test dependencies -->
     <dependency>


### PR DESCRIPTION
* compile-testing 0.18 needs truth 0.44 (0.46 has breaking change)
* add javax.annotation-api for being able to compile generated
@Generated annotation

Fixes #891