### PR TITLE
Add method name to getterMustMatch error

### DIFF
--- a/value/src/main/java/com/google/auto/value/processor/BuilderMethodClassifier.java
+++ b/value/src/main/java/com/google/auto/value/processor/BuilderMethodClassifier.java
@@ -374,8 +374,9 @@ abstract class BuilderMethodClassifier<E extends Element> {
       // propertyNameToSetters can't be null when we call put on it below.
       errorReporter.reportError(
           method,
-          "[%sBuilderWhatProp] Method does not correspond to %s",
+          "[%sBuilderWhatProp] Method %s does not correspond to %s",
           autoWhat(),
+          methodName,
           getterMustMatch());
       checkForFailedJavaBean(method);
       return;

--- a/value/src/test/java/com/google/auto/value/processor/AutoBuilderCompilationTest.java
+++ b/value/src/test/java/com/google/auto/value/processor/AutoBuilderCompilationTest.java
@@ -647,8 +647,8 @@ public final class AutoBuilderCompilationTest {
     assertThat(compilation).failed();
     assertThat(compilation)
         .hadErrorContaining(
-            "[AutoBuilderBuilderWhatProp] Method three does not correspond to a parameter of Baz(int one,"
-                + " int two)")
+            "[AutoBuilderBuilderWhatProp] Method three does not correspond to "
+                + "a parameter of Baz(int one, int two)")
         .inFile(javaFileObject)
         .onLineContaining("three(int x)");
   }

--- a/value/src/test/java/com/google/auto/value/processor/AutoBuilderCompilationTest.java
+++ b/value/src/test/java/com/google/auto/value/processor/AutoBuilderCompilationTest.java
@@ -647,7 +647,7 @@ public final class AutoBuilderCompilationTest {
     assertThat(compilation).failed();
     assertThat(compilation)
         .hadErrorContaining(
-            "[AutoBuilderBuilderWhatProp] Method does not correspond to a parameter of Baz(int one,"
+            "[AutoBuilderBuilderWhatProp] Method three does not correspond to a parameter of Baz(int one,"
                 + " int two)")
         .inFile(javaFileObject)
         .onLineContaining("three(int x)");

--- a/value/src/test/java/com/google/auto/value/processor/AutoValueCompilationTest.java
+++ b/value/src/test/java/com/google/auto/value/processor/AutoValueCompilationTest.java
@@ -1767,7 +1767,7 @@ public class AutoValueCompilationTest {
             .withProcessors(new AutoValueProcessor(), new AutoValueBuilderProcessor())
             .compile(javaFileObject);
     assertThat(compilation)
-        .hadErrorContaining("Method does not correspond to a property method of foo.bar.Item")
+        .hadErrorContaining("Method setTitle does not correspond to a property method of foo.bar.Item")
         .inFile(javaFileObject)
         .onLineContaining("Builder setTitle(String title)");
     assertThat(compilation)
@@ -1801,7 +1801,7 @@ public class AutoValueCompilationTest {
             .withProcessors(new AutoValueProcessor(), new AutoValueBuilderProcessor())
             .compile(javaFileObject);
     assertThat(compilation)
-        .hadErrorContaining("Method does not correspond to a property method of foo.bar.Baz")
+        .hadErrorContaining("Method blim does not correspond to a property method of foo.bar.Baz")
         .inFile(javaFileObject)
         .onLineContaining("Builder blim(int x)");
   }
@@ -2514,7 +2514,7 @@ public class AutoValueCompilationTest {
             .withProcessors(new AutoValueProcessor(), new AutoValueBuilderProcessor())
             .compile(javaFileObject);
     assertThat(compilation)
-        .hadErrorContaining("Method does not correspond to a property method of foo.bar.Baz")
+        .hadErrorContaining("Method whut does not correspond to a property method of foo.bar.Baz")
         .inFile(javaFileObject)
         .onLineContaining("void whut(String x)");
   }


### PR DESCRIPTION
This adds the offending method name to the `getterMustMatch` error message. This makes it much less ambiguous to debug. e.g. `Method createdAt does not correspond to a property of MyBuilder`.