### PR TITLE
Implicitly exclude Kotlin `@Metadata` annotations from `@CopyAnnotations`

### DIFF
--- a/value/src/main/java/com/google/auto/value/processor/AutoValueishProcessor.java
+++ b/value/src/main/java/com/google/auto/value/processor/AutoValueishProcessor.java
@@ -932,8 +932,25 @@ abstract class AutoValueishProcessor extends AbstractProcessor {
   ImmutableList<String> copiedClassAnnotations(TypeElement type) {
     // Only copy annotations from a class if it has @AutoValue.CopyAnnotations.
     if (hasAnnotationMirror(type, COPY_ANNOTATIONS_NAME)) {
-      Set<String> excludedAnnotations =
-          union(getExcludedAnnotationClassNames(type), getAnnotationsMarkedWithInherited(type));
+      Set<String> excludedAnnotations = ImmutableSet.<String>builder()
+          .addAll(
+              union(getExcludedAnnotationClassNames(type), getAnnotationsMarkedWithInherited(type)))
+          //
+          // Kotlin classes have an intrinsic @Metadata annotation generated
+          // onto them by kotlinc. This annotation is specific to the annotated
+          // class and should not be implicitly copied. Doing so can mislead
+          // static analysis or metaprogramming tooling that reads the data
+          // contained in these annotations.
+          //
+          // It may be surprising to see AutoValue classes written in Kotlin
+          // when they could be written as Kotlin data classes, but this can
+          // come up in cases where consumers rely on AutoValue features or
+          // extensions that are not available in data classes.
+          //
+          // See: https://github.com/google/auto/issues/1087
+          //
+          .add(ClassNames.KOTLIN_METADATA_NAME)
+          .build();
 
       return copyAnnotations(type, type, excludedAnnotations);
     } else {

--- a/value/src/main/java/com/google/auto/value/processor/AutoValueishProcessor.java
+++ b/value/src/main/java/com/google/auto/value/processor/AutoValueishProcessor.java
@@ -933,8 +933,8 @@ abstract class AutoValueishProcessor extends AbstractProcessor {
     // Only copy annotations from a class if it has @AutoValue.CopyAnnotations.
     if (hasAnnotationMirror(type, COPY_ANNOTATIONS_NAME)) {
       Set<String> excludedAnnotations = ImmutableSet.<String>builder()
-          .addAll(
-              union(getExcludedAnnotationClassNames(type), getAnnotationsMarkedWithInherited(type)))
+          .addAll(getExcludedAnnotationClassNames(type))
+          .addAll(getAnnotationsMarkedWithInherited(type))
           //
           // Kotlin classes have an intrinsic @Metadata annotation generated
           // onto them by kotlinc. This annotation is specific to the annotated

--- a/value/src/main/java/com/google/auto/value/processor/ClassNames.java
+++ b/value/src/main/java/com/google/auto/value/processor/ClassNames.java
@@ -30,4 +30,5 @@ final class ClassNames {
   static final String AUTO_VALUE_BUILDER_NAME = AUTO_VALUE_NAME + ".Builder";
   static final String AUTO_BUILDER_NAME = AUTO_VALUE_PACKAGE_NAME + "AutoBuilder";
   static final String COPY_ANNOTATIONS_NAME = AUTO_VALUE_NAME + ".CopyAnnotations";
+  static final String KOTLIN_METADATA_NAME = "kotlin.Metadata";
 }

--- a/value/src/test/java/com/google/auto/value/processor/AutoValueCompilationTest.java
+++ b/value/src/test/java/com/google/auto/value/processor/AutoValueCompilationTest.java
@@ -3407,7 +3407,7 @@ public class AutoValueCompilationTest {
     assertThat(compilation)
         .generatedSourceFile("foo.bar.AutoValue_Test")
         .contentsAsUtf8String()
-        .doesNotContain("@Metadata");
+        .doesNotContain("kotlin.Metadata");
   }
 
   private String sorted(String... imports) {

--- a/value/src/test/java/com/google/auto/value/processor/AutoValueCompilationTest.java
+++ b/value/src/test/java/com/google/auto/value/processor/AutoValueCompilationTest.java
@@ -3372,6 +3372,44 @@ public class AutoValueCompilationTest {
     }
   }
 
+  // This is a regression test for the problem described in
+  // https://github.com/google/auto/issues/1087.
+  @Test
+  public void kotlinMetadataAnnotationsAreImplicitlyExcludedFromCopying() {
+    JavaFileObject metadata =
+        JavaFileObjects.forSourceLines(
+            "kotlin.Metadata",
+            "package kotlin;",
+            "",
+            "public @interface Metadata {",
+            "}");
+    JavaFileObject test =
+        JavaFileObjects.forSourceLines(
+            "foo.bar.Test",
+            "package foo.bar;",
+            "",
+            "import com.google.auto.value.AutoValue;",
+            "import kotlin.Metadata;",
+            "",
+            "@AutoValue.CopyAnnotations",
+            "@Metadata",
+            "@AutoValue",
+            "public abstract class Test {",
+            "  public abstract String string();",
+            "}");
+    AutoValueProcessor autoValueProcessor = new AutoValueProcessor();
+    Compilation compilation =
+        javac()
+            .withProcessors(autoValueProcessor)
+            .withOptions("-Xlint:-processing", "-implicit:none")
+            .compile(test, metadata);
+    assertThat(compilation).succeededWithoutWarnings();
+    assertThat(compilation)
+        .generatedSourceFile("foo.bar.AutoValue_Test")
+        .contentsAsUtf8String()
+        .doesNotContain("@Metadata");
+  }
+
   private String sorted(String... imports) {
     return Arrays.stream(imports).sorted().collect(joining("\n"));
   }


### PR DESCRIPTION
Resolves #1087