### PR TITLE
Add FIELD target to @Provided

### DIFF
--- a/factory/src/main/java/com/google/auto/factory/Provided.java
+++ b/factory/src/main/java/com/google/auto/factory/Provided.java
@@ -15,7 +15,7 @@
  */
 package com.google.auto.factory;
 
-import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.*;
 
 import java.lang.annotation.Target;
 
@@ -25,5 +25,5 @@ import java.lang.annotation.Target;
  *
  * @author Gregory Kick
  */
-@Target(PARAMETER)
+@Target(PARAMETER, FIELD)
 public @interface Provided {}


### PR DESCRIPTION
This way we can just use Lombok to generate Constructors.
Example:
 ```
@AutoFactory
@RequiredArgsConstructor
public class Permission {
    @Provided
    private final UserCacheFactory userCacheFactory;
    private final String name;
    private final int access;
}
```
vs
```
@AutoFactory
public class Permission {
    private final UserCacheFactory userCacheFactory;
    private final String name;
    private final int access;
    public Permission(@Provided UserCacheFactory userCacheFactory, 
                      String name, int access) {
        this.userCacheFactory = userCacheFactory;
        this.name = name;
        this.access = access;
    }
}
```