### PR TITLE
Upgrade Gradle Test Kit to 7.2

### DIFF
--- a/value/src/it/functional/pom.xml
+++ b/value/src/it/functional/pom.xml
@@ -93,7 +93,7 @@
     <dependency>
       <groupId>dev.gradleplugins</groupId>
       <artifactId>gradle-test-kit</artifactId>
-      <version>6.8.3</version>
+      <version>7.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
It isn't exactly necessary to upgrade Gradle Test Kit to the latest
version as Gradle Test Kit as with normal Java dependencies. The Gradle
Test Kit JARs contains plumbing used to execute a Gradle build within as
part of testing scenarios. The JARs are usually generated by the Gradle
distribution at runtime. As the classes are released with each new
Gradle version, they may not change between versions. The
`dev.gradleplugins` project rerelease the Gradle Test Kit JARs to be used outside of a Gradle build and with a different Gradle
version. Unfortunately, we keep the Gradle distribution versioning
which leads to confusion about the "latest" version. Generally,
using the latest version is safe but keep in mind the Gradle Test Kit
JARs depend on the Gradle API, Groovy and Kotlin. If your project has a
strong opinion on the version of those dependencies, you will need to
resolve the version conflict. Note that Groovy and Kotlin dependencies
are mostly for the DSL part of Gradle, which is unlikely to leak in Test
Kit but could via the implementation of the classes.

See https://github.com/gradle-plugins/toolbox/issues/51 and https://github.com/gradle-plugins/gradle-api/commit/34cb7f38429b7980e9c0c4396971df4fb42dcf8b

Only the new version (7.2) for [Gradle API](https://repo1.maven.org/maven2/dev/gradleplugins/gradle-api/7.2/gradle-api-7.2.pom) and [Gradle Test Kit](https://repo1.maven.org/maven2/dev/gradleplugins/gradle-test-kit/7.2/gradle-test-kit-7.2.pom) has the fix for the POM.xml. If older versions are required, we can re-release an updated version. Don't hesitate to open additional issues regarding POM.xml issues, users usually use Gradle to resolve the dependencies, your feedback is very useful.