### PR TITLE
MoreTypes fixes and improvements

### DIFF
--- a/common/src/main/java/com/google/auto/common/MoreTypes.java
+++ b/common/src/main/java/com/google/auto/common/MoreTypes.java
@@ -312,9 +312,7 @@ public final class MoreTypes {
     // The javac implementation of ExecutableType, at least in some versions, does not take thrown
     // exceptions into account in its equals implementation, so avoid this optimization for
     // ExecutableType.
-    @SuppressWarnings("TypesEquals")
-    boolean equal = a.equals(b);
-    if (equal && !(a instanceof ExecutableType)) {
+    if (a.equals(b) && !(a.getKind() == TypeKind.EXECUTABLE)) {
       return true;
     }
     EqualVisitorParam p = new EqualVisitorParam();
@@ -341,10 +339,9 @@ public final class MoreTypes {
 
   private static boolean equalLists(
       List<? extends TypeMirror> a, List<? extends TypeMirror> b, Set<ComparedElements> visiting) {
-    int size = a.size();
-    if (size != b.size()) {
+    if (a.size() != b.size())
       return false;
-    }
+
     // Use iterators in case the Lists aren't RandomAccess
     Iterator<? extends TypeMirror> aIterator = a.iterator();
     Iterator<? extends TypeMirror> bIterator = b.iterator();

--- a/common/src/main/java/com/google/auto/common/MoreTypes.java
+++ b/common/src/main/java/com/google/auto/common/MoreTypes.java
@@ -139,24 +139,32 @@ public final class MoreTypes {
       this.bArguments = bArguments;
     }
 
+    protected boolean canEqual(Object o) {
+      return o instanceof ComparedElements;
+    }
+
     @Override
     public boolean equals(@Nullable Object o) {
-      if (o instanceof ComparedElements) {
-        ComparedElements that = (ComparedElements) o;
-        int nArguments = aArguments.size();
-        if (!this.a.equals(that.a) || !this.b.equals(that.b) || nArguments != bArguments.size()) {
-          // The arguments must be the same size, but we check anyway.
-          return false;
-        }
-        for (int i = 0; i < nArguments; i++) {
-          if (aArguments.get(i) != bArguments.get(i)) {
-            return false;
-          }
-        }
-        return true;
-      } else {
+      if ( !(o instanceof ComparedElements) ) return false;
+      ComparedElements that = (ComparedElements) o;
+      if ( !that.canEqual(this) ) return false;
+
+      int nArguments = this.aArguments.size();
+      if ( nArguments != that.aArguments.size() ) return false;
+      // The arguments must be the same size, but we check anyway.
+      if ( nArguments != this.bArguments.size() || nArguments != that.bArguments.size() ) return false;
+
+      if ( !this.a.equals(that.a) || !this.b.equals(that.b) )
         return false;
+
+      for (int i = 0; i < nArguments; i++) {
+        if ( !this.aArguments.get(i).toString().equals( that.aArguments.get(i).toString() ) )
+          return false;
+        if ( !this.bArguments.get(i).toString().equals( that.bArguments.get(i).toString() ) )
+          return false;
       }
+
+      return true;
     }
 
     @Override


### PR DESCRIPTION
The branch contains three commits.

The first two, each fixes a small bug.
- Fixing the implementation of `equals()` of `ComparedElements`.
- The incorrect use of `instanceof`, which was replaced with `getKind()`.

The third one is my suggestion for increasing the readability of the code. Mainly, I find the use of the word _visiting_ confusing/incorrect.

The commit messages provide detailed explanations.