### PR TITLE
Fix broken link

### DIFF
--- a/value/userguide/index.md
+++ b/value/userguide/index.md
@@ -36,7 +36,7 @@ code almost any aspect of your class exactly the way you want it.
 appropriate than AutoValue. Likewise, if you are using a version of Java that
 has [records](https://docs.oracle.com/en/java/javase/16/language/records.html),
 then those are usually more appropriate. You can still use
-[AutoBuilder](userguide/autobuilder.md)--> to make builders for data classes or
+[AutoBuilder](autobuilder.md) --> to make builders for data classes or
 records.
 
 This page will walk you through how to use AutoValue. Looking for a little more


### PR DESCRIPTION
This document and the target link are in the same folder. Currently the final link target contains duplicate "userguide" segment, leading to 404.