### PR TITLE
Small fixes for AnnotationValues

### DIFF
--- a/common/src/main/java/com/google/auto/common/AnnotationValues.java
+++ b/common/src/main/java/com/google/auto/common/AnnotationValues.java
@@ -152,6 +152,11 @@ public final class AnnotationValues {
               },
               null);
         }
+
+        @Override
+        public String toString() {
+          return "AnnotationValues.equivalence()";
+        }
       };
 
   /**

--- a/common/src/main/java/com/google/auto/common/AnnotationValues.java
+++ b/common/src/main/java/com/google/auto/common/AnnotationValues.java
@@ -348,7 +348,7 @@ public final class AnnotationValues {
 
     @Override
     public ImmutableList<T> defaultAction(Object o, Void unused) {
-      throw new IllegalStateException("Expected an array, got instead: " + o);
+      throw new IllegalArgumentException("Expected an array, got instead: " + o);
     }
 
     @Override


### PR DESCRIPTION
1. First Commit
I believe the thrown exception type (`IllegalStateException`) present in the `defaultAction()` of `ArrayVisitor` is incorrect. For two reasons, first, I do not find it semantically sound, and second, based on the Javadocs of the methods using the `ArrayVisitor`. I have changed it to `IllegalArgumentException` type.

2. Second Commit
The `toString()` is missing from the `Equivalence` of `AnnotationValues`; for consistency, I have added it.