### PR TITLE
Enhanced `MoreTypesIsTypeOfTest`, and Fixed `MoreTypes.isType()` for primitives

### DIFF
--- a/common/src/main/java/com/google/auto/common/MoreTypes.java
+++ b/common/src/main/java/com/google/auto/common/MoreTypes.java
@@ -820,6 +820,11 @@ public final class MoreTypes {
     }
 
     @Override
+    public Boolean visitPrimitive(PrimitiveType type, Void p) {
+      return true;
+    }
+
+    @Override
     public Boolean visitArray(ArrayType array, Void p) {
       return true;
     }

--- a/common/src/main/java/com/google/auto/common/MoreTypes.java
+++ b/common/src/main/java/com/google/auto/common/MoreTypes.java
@@ -820,11 +820,6 @@ public final class MoreTypes {
     }
 
     @Override
-    public Boolean visitPrimitive(PrimitiveType type, Void p) {
-      return true;
-    }
-
-    @Override
     public Boolean visitArray(ArrayType array, Void p) {
       return true;
     }

--- a/common/src/test/java/com/google/auto/common/MoreTypesIsTypeOfTest.java
+++ b/common/src/test/java/com/google/auto/common/MoreTypesIsTypeOfTest.java
@@ -42,12 +42,12 @@ public class MoreTypesIsTypeOfTest {
 
   @Rule public CompilationRule compilationRule = new CompilationRule();
 
-  private Elements eltUtils;
+  private Elements elementUtils;
   private Types typeUtils;
 
   @Before
   public void setUp() {
-    this.eltUtils = compilationRule.getElements();
+    this.elementUtils = compilationRule.getElements();
     this.typeUtils = compilationRule.getTypes();
   }
 
@@ -179,8 +179,8 @@ public class MoreTypesIsTypeOfTest {
     }
   }
 
-  // Utility method(s) for this test.
+  /* Utility method(s) */
   private TypeElement getTypeElementFor(Class<?> clazz) {
-    return eltUtils.getTypeElement(clazz.getCanonicalName());
+    return elementUtils.getTypeElement(clazz.getCanonicalName());
   }
 }

--- a/common/src/test/java/com/google/auto/common/MoreTypesIsTypeOfTest.java
+++ b/common/src/test/java/com/google/auto/common/MoreTypesIsTypeOfTest.java
@@ -15,198 +15,171 @@
  */
 package com.google.auto.common;
 
-import static com.google.common.collect.Iterables.getOnlyElement;
 import static com.google.common.truth.Truth.assertWithMessage;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import com.google.common.collect.Iterables;
+import com.google.common.collect.ImmutableList;
 import com.google.testing.compile.CompilationRule;
-import javax.lang.model.element.Element;
+import java.util.List;
+import java.util.SortedMap;
 import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.Elements;
+import javax.lang.model.util.Types;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/**
- * Tests {@link MoreTypes#isTypeOf}.
- */
+/** Tests {@link MoreTypes#isTypeOf(Class, TypeMirror)}. */
 @RunWith(JUnit4.class)
 public class MoreTypesIsTypeOfTest {
 
   @Rule public CompilationRule compilationRule = new CompilationRule();
 
-  private Elements elements;
+  private Elements eltUtils;
+  private Types typeUtils;
 
   @Before
   public void setUp() {
-    this.elements = compilationRule.getElements();
+    this.eltUtils = compilationRule.getElements();
+    this.typeUtils = compilationRule.getTypes();
   }
-
-  private interface TestType {}
 
   @Test
-  public void isTypeOf_declaredType() {
-    assertTrue(MoreTypes.isType(typeElementFor(TestType.class).asType()));
-    assertWithMessage("mirror represents the TestType")
-        .that(MoreTypes.isTypeOf(TestType.class, typeElementFor(TestType.class).asType()))
-        .isTrue();
-    assertWithMessage("mirror does not represent a String")
-        .that(MoreTypes.isTypeOf(String.class, typeElementFor(TestType.class).asType()))
-        .isFalse();
+  public void isTypeOf_primitiveAndBoxedPrimitiveTypes() {
+    class PrimitiveTypeInfo {
+      final Class<?> CLASS_TYPE;
+      final Class<?> BOXED_CLASS_TYPE;
+      final TypeKind TYPE_KIND;
+
+      PrimitiveTypeInfo(Class<?> classType, Class<?> boxedClassType, TypeKind typeKind) {
+        this.CLASS_TYPE = classType;
+        this.BOXED_CLASS_TYPE = boxedClassType;
+        this.TYPE_KIND = typeKind;
+      }
+    }
+    final List<PrimitiveTypeInfo> primitivesTypeInfo =
+        ImmutableList.of(
+            new PrimitiveTypeInfo(Byte.TYPE, Byte.class, TypeKind.BYTE),
+            new PrimitiveTypeInfo(Short.TYPE, Short.class, TypeKind.SHORT),
+            new PrimitiveTypeInfo(Integer.TYPE, Integer.class, TypeKind.INT),
+            new PrimitiveTypeInfo(Long.TYPE, Long.class, TypeKind.LONG),
+            new PrimitiveTypeInfo(Float.TYPE, Float.class, TypeKind.FLOAT),
+            new PrimitiveTypeInfo(Double.TYPE, Double.class, TypeKind.DOUBLE),
+            new PrimitiveTypeInfo(Boolean.TYPE, Boolean.class, TypeKind.BOOLEAN),
+            new PrimitiveTypeInfo(Character.TYPE, Character.class, TypeKind.CHAR));
+
+    for (int ki = 0; ki < 2; ki++) { // ki = 0: primitives, ki = 1: boxed primitives
+      for (int i = 0; i < primitivesTypeInfo.size(); i++) { // For the Class<?> arg
+        Class<?> clazz =
+            (ki == 0)
+                ? primitivesTypeInfo.get(i).CLASS_TYPE
+                : primitivesTypeInfo.get(i).BOXED_CLASS_TYPE;
+
+        for (int kj = 0; kj < 2; kj++) { // kj = 0: primitives, kj = 1: boxed primitives
+          for (int j = 0; j < primitivesTypeInfo.size(); j++) { // For the TypeMirror arg
+            TypeKind typeKind = primitivesTypeInfo.get(j).TYPE_KIND;
+            TypeMirror typeMirror =
+                (kj == 0)
+                    ? typeUtils.getPrimitiveType(typeKind)
+                    : typeUtils.boxedClass(typeUtils.getPrimitiveType(typeKind)).asType();
+
+            String message =
+                "Mirror:\t" + typeMirror.toString() + "\nClass:\t" + clazz.getCanonicalName();
+            if (ki == kj && i == j) {
+              assertWithMessage(message).that(MoreTypes.isTypeOf(clazz, typeMirror)).isTrue();
+            } else {
+              assertWithMessage(message).that(MoreTypes.isTypeOf(clazz, typeMirror)).isFalse();
+            }
+          }
+        }
+      }
+    }
   }
 
-  private interface ArrayType {
-    String[] array();
+  @Test
+  public void isTypeOf_voidAndPseudoVoidTypes() {
+    TypeMirror voidType = typeUtils.getNoType(TypeKind.VOID);
+    TypeMirror pseudoVoidType = getTypeElementFor(Void.class).asType();
+
+    assertWithMessage("Mirror:\t" + voidType + "\nClass:\t" + Void.TYPE.getCanonicalName())
+        .that(MoreTypes.isTypeOf(Void.TYPE, voidType))
+        .isTrue();
+    assertWithMessage("Mirror:\t" + pseudoVoidType + "\nClass:\t" + Void.TYPE.getCanonicalName())
+        .that(MoreTypes.isTypeOf(Void.TYPE, pseudoVoidType))
+        .isFalse();
+
+    assertWithMessage("Mirror:\t" + voidType + "\nClass:\t" + Void.class.getCanonicalName())
+        .that(MoreTypes.isTypeOf(Void.class, voidType))
+        .isFalse();
+    assertWithMessage("Mirror:\t" + pseudoVoidType + "\nClass:\t" + Void.class.getCanonicalName())
+        .that(MoreTypes.isTypeOf(Void.class, pseudoVoidType))
+        .isTrue();
   }
 
   @Test
   public void isTypeOf_arrayType() {
-    assertTrue(MoreTypes.isType(typeElementFor(ArrayType.class).asType()));
-    TypeMirror type = extractReturnTypeFromHolder(typeElementFor(ArrayType.class));
-    assertWithMessage("array mirror represents an array Class object")
+    TypeMirror type = typeUtils.getArrayType(getTypeElementFor(String.class).asType());
+    assertWithMessage("Mirror:\t" + type + "\nClass:\t" + String[].class.getCanonicalName())
         .that(MoreTypes.isTypeOf(String[].class, type))
+        .isTrue();
+    assertWithMessage("Mirror:\t" + type + "\nClass:\t" + Integer[].class.getCanonicalName())
+        .that(MoreTypes.isTypeOf(Integer[].class, type))
+        .isFalse();
+    assertWithMessage("Mirror:\t" + type + "\nClass:\t" + int[].class.getCanonicalName())
+        .that(MoreTypes.isTypeOf(int[].class, type))
+        .isFalse();
+
+    type = typeUtils.getArrayType(typeUtils.getPrimitiveType(TypeKind.INT));
+    assertWithMessage("Mirror:\t" + type + "\nClass:\t" + String[].class.getCanonicalName())
+        .that(MoreTypes.isTypeOf(String[].class, type))
+        .isFalse();
+    assertWithMessage("Mirror:\t" + type + "\nClass:\t" + Integer[].class.getCanonicalName())
+        .that(MoreTypes.isTypeOf(Integer[].class, type))
+        .isFalse();
+    assertWithMessage("Mirror:\t" + type + "\nClass:\t" + int[].class.getCanonicalName())
+        .that(MoreTypes.isTypeOf(int[].class, type))
         .isTrue();
   }
 
-  private interface PrimitiveBoolean {
-    boolean method();
+  private interface TestType {
+    @SuppressWarnings("unused")
+    <T extends SortedMap<Number, String>> T method0();
   }
 
   @Test
-  public void isTypeOf_primitiveBoolean() {
-    assertTrue(MoreTypes.isType(typeElementFor(PrimitiveBoolean.class).asType()));
-    TypeMirror type = extractReturnTypeFromHolder(typeElementFor(PrimitiveBoolean.class));
-    assertWithMessage("mirror of a boolean").that(MoreTypes.isTypeOf(Boolean.TYPE, type)).isTrue();
-  }
-
-  private interface PrimitiveByte {
-    byte method();
-  }
-
-  @Test
-  public void isTypeOf_primitiveByte() {
-    assertTrue(MoreTypes.isType(typeElementFor(PrimitiveByte.class).asType()));
-    TypeMirror type = extractReturnTypeFromHolder(typeElementFor(PrimitiveByte.class));
-    assertWithMessage("mirror of a byte").that(MoreTypes.isTypeOf(Byte.TYPE, type)).isTrue();
-  }
-
-  private interface PrimitiveChar {
-    char method();
-  }
-
-  @Test
-  public void isTypeOf_primitiveChar() {
-    assertTrue(MoreTypes.isType(typeElementFor(PrimitiveChar.class).asType()));
-    TypeMirror type = extractReturnTypeFromHolder(typeElementFor(PrimitiveChar.class));
-    assertWithMessage("mirror of a char").that(MoreTypes.isTypeOf(Character.TYPE, type)).isTrue();
-  }
-
-  private interface PrimitiveDouble {
-    double method();
-  }
-
-  @Test
-  public void isTypeOf_primitiveDouble() {
-    assertTrue(MoreTypes.isType(typeElementFor(PrimitiveDouble.class).asType()));
-    TypeMirror type = extractReturnTypeFromHolder(typeElementFor(PrimitiveDouble.class));
-    assertWithMessage("mirror of a double").that(MoreTypes.isTypeOf(Double.TYPE, type)).isTrue();
-  }
-
-  private interface PrimitiveFloat {
-    float method();
-  }
-
-  @Test
-  public void isTypeOf_primitiveFloat() {
-    assertTrue(MoreTypes.isType(typeElementFor(PrimitiveFloat.class).asType()));
-    TypeMirror type = extractReturnTypeFromHolder(typeElementFor(PrimitiveFloat.class));
-    assertWithMessage("mirror of a float").that(MoreTypes.isTypeOf(Float.TYPE, type)).isTrue();
-  }
-
-  private interface PrimitiveInt {
-    int method();
-  }
-
-  @Test
-  public void isTypeOf_primitiveInt() {
-    assertTrue(MoreTypes.isType(typeElementFor(PrimitiveInt.class).asType()));
-    TypeMirror type = extractReturnTypeFromHolder(typeElementFor(PrimitiveInt.class));
-    assertWithMessage("mirror of a int").that(MoreTypes.isTypeOf(Integer.TYPE, type)).isTrue();
-  }
-
-  private interface PrimitiveLong {
-    long method();
-  }
-
-  @Test
-  public void isTypeOf_primitiveLong() {
-    assertTrue(MoreTypes.isType(typeElementFor(PrimitiveLong.class).asType()));
-    TypeMirror type = extractReturnTypeFromHolder(typeElementFor(PrimitiveLong.class));
-    assertWithMessage("mirror of a long").that(MoreTypes.isTypeOf(Long.TYPE, type)).isTrue();
-  }
-
-  private interface PrimitiveShort {
-    short method();
-  }
-
-  @Test
-  public void isTypeOf_primitiveShort() {
-    assertTrue(MoreTypes.isType(typeElementFor(PrimitiveShort.class).asType()));
-    TypeMirror type = extractReturnTypeFromHolder(typeElementFor(PrimitiveShort.class));
-    assertWithMessage("mirror of a short").that(MoreTypes.isTypeOf(Short.TYPE, type)).isTrue();
-  }
-
-  private interface PrimitiveVoid {
-    void method();
-  }
-
-  @Test
-  public void isTypeOf_primitiveVoid() {
-    assertTrue(MoreTypes.isType(typeElementFor(PrimitiveVoid.class).asType()));
-    TypeMirror primitive = extractReturnTypeFromHolder(typeElementFor(PrimitiveVoid.class));
-    assertWithMessage("mirror of a void").that(MoreTypes.isTypeOf(Void.TYPE, primitive)).isTrue();
-  }
-
-  private interface DeclaredVoid {
-    Void method();
-  }
-
-  @Test
-  public void isTypeOf_declaredVoid() {
-    assertTrue(MoreTypes.isType(typeElementFor(DeclaredVoid.class).asType()));
-    TypeMirror declared = extractReturnTypeFromHolder(typeElementFor(DeclaredVoid.class));
-    assertWithMessage("mirror of a void").that(MoreTypes.isTypeOf(Void.class, declared)).isTrue();
+  public void isTypeOf_declaredType() {
+    TypeMirror TestTypeTypeMirror = getTypeElementFor(TestType.class).asType();
+    assertTrue(MoreTypes.isType(TestTypeTypeMirror));
+    assertWithMessage(
+            "Mirror:\t" + TestTypeTypeMirror + "\nClass:\t" + TestType.class.getCanonicalName())
+        .that(MoreTypes.isTypeOf(TestType.class, TestTypeTypeMirror))
+        .isTrue();
+    assertWithMessage(
+            "Mirror:\t" + TestTypeTypeMirror + "\nClass:\t" + String.class.getCanonicalName())
+        .that(MoreTypes.isTypeOf(String.class, TestTypeTypeMirror))
+        .isFalse();
   }
 
   @Test
   public void isTypeOf_fail() {
     assertFalse(
-        MoreTypes.isType(
-            getOnlyElement(typeElementFor(DeclaredVoid.class).getEnclosedElements()).asType()));
-    TypeMirror method =
-        getOnlyElement(typeElementFor(DeclaredVoid.class).getEnclosedElements()).asType();
+        MoreTypes.isType(getTypeElementFor(TestType.class).getEnclosedElements().get(0).asType()));
+    TypeMirror methodType = getTypeElementFor(TestType.class).getEnclosedElements().get(0).asType();
     try {
-      MoreTypes.isTypeOf(String.class, method);
+      MoreTypes.isTypeOf(List.class, methodType);
       fail();
     } catch (IllegalArgumentException expected) {
     }
   }
 
-  // Utility methods for this test.
-
-  private TypeMirror extractReturnTypeFromHolder(TypeElement typeElement) {
-    Element element = Iterables.getOnlyElement(typeElement.getEnclosedElements());
-    TypeMirror arrayType = MoreElements.asExecutable(element).getReturnType();
-    return arrayType;
-  }
-
-  private TypeElement typeElementFor(Class<?> clazz) {
-    return elements.getTypeElement(clazz.getCanonicalName());
+  // Utility method(s) for this test.
+  private TypeElement getTypeElementFor(Class<?> clazz) {
+    return eltUtils.getTypeElement(clazz.getCanonicalName());
   }
 }

--- a/common/src/test/java/com/google/auto/common/MoreTypesIsTypeOfTest.java
+++ b/common/src/test/java/com/google/auto/common/MoreTypesIsTypeOfTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
 import com.google.testing.compile.CompilationRule;
 import java.util.List;
 import java.util.SortedMap;
@@ -74,24 +75,24 @@ public class MoreTypesIsTypeOfTest {
             new PrimitiveTypeInfo(Boolean.TYPE, Boolean.class, TypeKind.BOOLEAN),
             new PrimitiveTypeInfo(Character.TYPE, Character.class, TypeKind.CHAR));
 
-    for (int ki = 0; ki < 2; ki++) { // ki = 0: primitives, ki = 1: boxed primitives
+    for (boolean isBoxedI : new boolean[] {false, true}) {
       for (int i = 0; i < primitivesTypeInfo.size(); i++) { // For the Class<?> arg
         Class<?> clazz =
-            (ki == 0)
-                ? primitivesTypeInfo.get(i).CLASS_TYPE
-                : primitivesTypeInfo.get(i).BOXED_CLASS_TYPE;
+            isBoxedI
+                ? primitivesTypeInfo.get(i).BOXED_CLASS_TYPE
+                : primitivesTypeInfo.get(i).CLASS_TYPE;
 
-        for (int kj = 0; kj < 2; kj++) { // kj = 0: primitives, kj = 1: boxed primitives
+        for (boolean isBoxedJ : new boolean[] {false, true}) {
           for (int j = 0; j < primitivesTypeInfo.size(); j++) { // For the TypeMirror arg
             TypeKind typeKind = primitivesTypeInfo.get(j).TYPE_KIND;
             TypeMirror typeMirror =
-                (kj == 0)
-                    ? typeUtils.getPrimitiveType(typeKind)
-                    : typeUtils.boxedClass(typeUtils.getPrimitiveType(typeKind)).asType();
+                isBoxedJ
+                    ? typeUtils.boxedClass(typeUtils.getPrimitiveType(typeKind)).asType()
+                    : typeUtils.getPrimitiveType(typeKind);
 
             String message =
                 "Mirror:\t" + typeMirror.toString() + "\nClass:\t" + clazz.getCanonicalName();
-            if (ki == kj && i == j) {
+            if (isBoxedI == isBoxedJ && i == j) {
               assertWithMessage(message).that(MoreTypes.isTypeOf(clazz, typeMirror)).isTrue();
             } else {
               assertWithMessage(message).that(MoreTypes.isTypeOf(clazz, typeMirror)).isFalse();
@@ -168,9 +169,9 @@ public class MoreTypesIsTypeOfTest {
 
   @Test
   public void isTypeOf_fail() {
-    assertFalse(
-        MoreTypes.isType(getTypeElementFor(TestType.class).getEnclosedElements().get(0).asType()));
-    TypeMirror methodType = getTypeElementFor(TestType.class).getEnclosedElements().get(0).asType();
+    TypeMirror methodType =
+        Iterables.getOnlyElement(getTypeElementFor(TestType.class).getEnclosedElements()).asType();
+    assertFalse(MoreTypes.isType(methodType));
     try {
       MoreTypes.isTypeOf(List.class, methodType);
       fail();


### PR DESCRIPTION
### First Commit, Enhanced `MoreTypesIsTypeOfTest`
The two main enhancements are:
1. The current approach for retrieving the desired `TypeMirror` is not ideal. Currently, an interface with an unused method for the sole purpose of extracting the return type of that method is defined, and then the type is extracted. I have used `Types` instead to get the desired `TypeMirror`.
2. The tests are the proper superset of previous tests; therefore, testing more scenarios. (and the code is more compact)

Additionally, I have a further suggestion, which I have not yet created a PR for, for extending `isTypeOf()` to work for hierarchical type, type arguments, and wildcards as well. If this PR is accepted, it would be easier for me to include my new suggestion unit tests later.

### Second Commit, Fixed `MoreTypes.isType()` for primitives
Please correct me if I am wrong. I believe that primitives cannot be referenced by `Class`; therefore, `isType()` should not return true for them. I have corrected this mistake.
