### PR TITLE
Common:: Minor Improvements

### DIFF
--- a/common/src/main/java/com/google/auto/common/BasicAnnotationProcessor.java
+++ b/common/src/main/java/com/google/auto/common/BasicAnnotationProcessor.java
@@ -17,6 +17,7 @@ package com.google.auto.common;
 
 import static com.google.auto.common.MoreElements.asExecutable;
 import static com.google.auto.common.MoreElements.asPackage;
+import static com.google.auto.common.MoreElements.isAnnotationPresent;
 import static com.google.auto.common.MoreStreams.toImmutableMap;
 import static com.google.auto.common.MoreStreams.toImmutableSet;
 import static com.google.auto.common.SuperficialValidation.validateElement;
@@ -362,12 +363,6 @@ public abstract class BasicAnnotationProcessor extends AbstractProcessor {
         annotatedElements.put(annotationType, element);
       }
     }
-  }
-
-  private static boolean isAnnotationPresent(Element element, TypeElement annotationType) {
-    return element.getAnnotationMirrors().stream()
-        .anyMatch(
-            mirror -> MoreTypes.asTypeElement(mirror.getAnnotationType()).equals(annotationType));
   }
 
   /**

--- a/common/src/main/java/com/google/auto/common/Overrides.java
+++ b/common/src/main/java/com/google/auto/common/Overrides.java
@@ -25,6 +25,7 @@ import com.google.common.collect.Maps;
 import java.util.List;
 import java.util.Map;
 import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
@@ -295,8 +296,8 @@ abstract class Overrides {
 
       @Override
       public TypeMirror visitTypeVariable(TypeVariable t, Void p) {
-        Element element = typeUtils.asElement(t);
-        if (element instanceof TypeParameterElement) {
+        Element element = t.asElement();
+        if (element.getKind() == ElementKind.TYPE_PARAMETER) {
           TypeParameterElement e = (TypeParameterElement) element;
           if (typeBindings.containsKey(e)) {
             return visit(typeBindings.get(e));

--- a/common/src/test/java/com/google/auto/common/BasicAnnotationProcessorTest.java
+++ b/common/src/test/java/com/google/auto/common/BasicAnnotationProcessorTest.java
@@ -79,7 +79,7 @@ public class BasicAnnotationProcessorTest {
 
     @Override
     protected Iterable<? extends Step> steps() {
-      return ImmutableSet.of(
+      return ImmutableList.of(
           new Step() {
             @Override
             public ImmutableSet<? extends Element> process(
@@ -126,7 +126,7 @@ public class BasicAnnotationProcessorTest {
   public static class GeneratesCodeProcessor extends BaseAnnotationProcessor {
     @Override
     protected Iterable<? extends Step> steps() {
-      return ImmutableSet.of(
+      return ImmutableList.of(
           new Step() {
             @Override
             public ImmutableSet<? extends Element> process(
@@ -150,7 +150,7 @@ public class BasicAnnotationProcessorTest {
 
     @Override
     protected Iterable<? extends Step> steps() {
-      return ImmutableSet.of(
+      return ImmutableList.of(
           new Step() {
             @Override
             public ImmutableSet<Element> process(
@@ -177,7 +177,7 @@ public class BasicAnnotationProcessorTest {
 
     @Override
     protected Iterable<? extends Step> steps() {
-      return ImmutableSet.of(
+      return ImmutableList.of(
           new Step() {
             @Override
             public ImmutableSet<Element> process(
@@ -202,7 +202,7 @@ public class BasicAnnotationProcessorTest {
 
     @Override
     protected Iterable<? extends Step> steps() {
-      return ImmutableSet.of(
+      return ImmutableList.of(
           new Step() {
             @Override
             public ImmutableSet<Element> process(


### PR DESCRIPTION
### Three minor changes are proposed.
1. In `BasicAnnotationProcessor`, method `isAnnotationPresent()` is removed and `MoreElements.isAnnotationProcessor()` is used instead.
2. In `BasicAnnotationProcessorTest`, I find it more natural (as conveyed by the name as well) that `steps` have order. Consequently, I replace `ImmutableSet` with `ImmutableList` as the type of the `Iterable`.
3. In `Overrides`, `Element` kind is checked with `instanceof` operator; however, the official document states that it should not be done in this way. I used `getKind()` method instead.