### PR TITLE
Adds support for @AutoFactory(inject=true) which injects types directly

### DIFF
--- a/factory/src/main/java/com/google/auto/factory/AutoFactory.java
+++ b/factory/src/main/java/com/google/auto/factory/AutoFactory.java
@@ -65,6 +65,12 @@ public @interface AutoFactory {
   boolean allowSubclasses() default false;
 
   /**
+   * Whether the provided types should be injected directly instead of using Provider<T>.
+   * This allows using with frameworks such as Weld that don't depend on Provider<T> for injection.
+   */
+  boolean inject() default false;
+
+  /**
    * Specifies that an annotation should be used to determine how to annotate generated AutoFactory
    * classes. For example, suppose you have this annotation:
    * <pre>

--- a/factory/src/main/java/com/google/auto/factory/processor/AutoFactoryDeclaration.java
+++ b/factory/src/main/java/com/google/auto/factory/processor/AutoFactoryDeclaration.java
@@ -75,6 +75,8 @@ abstract class AutoFactoryDeclaration {
 
   abstract ImmutableMap<String, AnnotationValue> valuesMap();
 
+  abstract boolean inject();
+
   PackageAndClass getFactoryName() {
     String packageName = getPackage(targetType()).getQualifiedName().toString();
     if (className().isPresent()) {
@@ -188,6 +190,9 @@ abstract class AutoFactoryDeclaration {
       AnnotationValue allowSubclassesValue = checkNotNull(values.get("allowSubclasses"));
       boolean allowSubclasses = AnnotationValues.asBoolean(allowSubclassesValue);
 
+      AnnotationValue injectValue = checkNotNull(values.get("inject"));
+      boolean inject = AnnotationValues.asBoolean(injectValue);
+
       return Optional.<AutoFactoryDeclaration>of(
           new AutoValue_AutoFactoryDeclaration(
               getAnnotatedType(element),
@@ -198,7 +203,8 @@ abstract class AutoFactoryDeclaration {
               implementingTypes,
               allowSubclasses,
               mirror,
-              ImmutableMap.copyOf(values)));
+              ImmutableMap.copyOf(values),
+              inject));
     }
 
     private static TypeElement getAnnotatedType(Element element) {

--- a/factory/src/main/java/com/google/auto/factory/processor/FactoryWriter.java
+++ b/factory/src/main/java/com/google/auto/factory/processor/FactoryWriter.java
@@ -129,8 +129,8 @@ final class FactoryWriter {
     for (ProviderField provider : providerFields) {
       ++argumentNumber;
       TypeName typeName = resolveTypeName(provider.key().type().get()).box();
-      TypeName providerType =
-          ParameterizedTypeName.get(ClassName.get(injectApi.provider()), typeName);
+      TypeName providerType = descriptor.declaration().inject() ? typeName : ParameterizedTypeName.get(ClassName.get(injectApi.provider()), typeName);
+
       factory.addField(providerType, provider.name(), PRIVATE, FINAL);
       if (provider.key().qualifier().isPresent()) {
         // only qualify the constructor parameter
@@ -188,7 +188,7 @@ final class FactoryWriter {
             // Providers are checked for nullness in the Factory's constructor.
             checkNotNull = false;
           } else {
-            argument = CodeBlock.of("$L.get()", argument);
+            argument = descriptor.declaration().inject() ? CodeBlock.of("$L", argument) : CodeBlock.of("$L.get()", argument);
           }
         }
         if (checkNotNull) {

--- a/factory/src/test/java/com/google/auto/factory/processor/AutoFactoryProcessorTest.java
+++ b/factory/src/test/java/com/google/auto/factory/processor/AutoFactoryProcessorTest.java
@@ -571,6 +571,14 @@ public class AutoFactoryProcessorTest {
             "tests.CustomAnnotationsFactory", "expected/CustomAnnotationsFactory.java"));
   }
 
+  @Test
+  public void injectAnnotation() {
+    goldenTest(
+        ImmutableList.of("good/SimpleClassInject.java"),
+        ImmutableMap.of(
+            "tests.SimpleClassInjectFactory", "expected/SimpleClassInjectFactory.java"));
+  }
+
   private JavaFileObject loadExpectedFile(String resourceName) {
     try {
       List<String> sourceLines = Resources.readLines(Resources.getResource(resourceName), UTF_8);

--- a/factory/src/test/resources/expected/SimpleClassInjectFactory.java
+++ b/factory/src/test/resources/expected/SimpleClassInjectFactory.java
@@ -1,0 +1,28 @@
+package tests;
+
+import javax.annotation.processing.Generated;
+import javax.inject.Inject;
+
+@Generated(
+    value = "com.google.auto.factory.processor.AutoFactoryProcessor",
+    comments = "https://github.com/google/auto/tree/main/factory"
+)
+public final class SimpleClassInjectFactory {
+  private final String twoProvider;
+
+  @Inject
+  public SimpleClassInjectFactory(String twoProvider) {
+    this.twoProvider = checkNotNull(twoProvider, 1, 1);
+  }
+
+  public SimpleClassInject create(String one) {
+    return new SimpleClassInject(checkNotNull(one, 1, 2), checkNotNull(twoProvider, 2, 2));
+  }
+
+  private static <T> T checkNotNull(T reference, int argumentNumber, int argumentCount) {
+    if (reference == null) {
+      throw new NullPointerException("@AutoFactory method argument is null but is not marked @Nullable. Argument " + argumentNumber + " of " + argumentCount);
+    }
+    return reference;
+  }
+}

--- a/factory/src/test/resources/good/SimpleClassInject.java
+++ b/factory/src/test/resources/good/SimpleClassInject.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2013 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package tests;
+
+import com.google.auto.factory.AutoFactory;
+import com.google.auto.factory.Provided;
+
+@AutoFactory(inject = true)
+public class SimpleClassInject {
+  private final String one;
+  private final String two;
+
+  public SimpleClassInject(String one, @Provided String two) {
+    this.one = one;
+    this.two = two;
+  }
+}


### PR DESCRIPTION
This makes it so that AutoFactory can be used with frameworks such as Weld which relies on @Produces annotations instead of Provider<T>.

This addresses the concern in https://github.com/google/auto/issues/318.