### PR TITLE
Update to latest GWT.

### DIFF
--- a/value/pom.xml
+++ b/value/pom.xml
@@ -78,7 +78,6 @@
     <module>annotations</module>
     <module>processor</module>
     <module>src/it/functional</module>
-    <module>src/it/gwtserializer</module>
   </modules>
 
   <distributionManagement>
@@ -208,6 +207,15 @@
     </pluginManagement>
   </build>
   <profiles>
+    <profile>
+      <id>gwt-test-only-post-java8</id>
+      <activation>
+        <jdk>[11,)</jdk>
+      </activation>
+      <modules>
+        <module>src/it/gwtserializer</module>
+      </modules>
+    </profile>
     <profile>
       <id>sonatype-oss-release</id>
       <build>

--- a/value/src/it/functional/pom.xml
+++ b/value/src/it/functional/pom.xml
@@ -57,7 +57,7 @@
     <dependency>
       <groupId>org.gwtproject</groupId>
       <artifactId>gwt-user</artifactId>
-      <version>2.11.0</version>
+      <version>2.12.0</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/value/src/it/gwtserializer/pom.xml
+++ b/value/src/it/gwtserializer/pom.xml
@@ -36,7 +36,7 @@
       <dependency>
         <groupId>org.gwtproject</groupId>
         <artifactId>gwt</artifactId>
-        <version>2.11.0</version>
+        <version>2.12.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Only run GWT tests when JDK > 8, because they don't work with JDK 8 anymore.