### PR TITLE
Copy javax and jakarta @Qualifier onto generated AutoFactory params

### DIFF
--- a/factory/src/main/java/com/google/auto/factory/processor/InjectApi.java
+++ b/factory/src/main/java/com/google/auto/factory/processor/InjectApi.java
@@ -18,12 +18,14 @@ package com.google.auto.factory.processor;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static java.util.stream.Collectors.joining;
 
+import com.google.auto.common.MoreElements;
 import com.google.auto.common.MoreTypes;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import java.util.AbstractMap.SimpleEntry;
+import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
@@ -41,6 +43,9 @@ abstract class InjectApi {
 
   private static final ImmutableList<String> PREFIXES_IN_ORDER =
       ImmutableList.of("jakarta.inject.", "javax.inject.");
+
+  private static final ImmutableSet<String> QUALIFIER_ANNOTATIONS =
+      ImmutableSet.of("javax.inject.Qualifier", "jakarta.inject.Qualifier");
 
   static InjectApi from(Elements elementUtils, @Nullable String apiPrefix) {
     ImmutableList<String> apiPackages =
@@ -63,6 +68,23 @@ abstract class InjectApi {
   boolean isProvider(TypeMirror type) {
     return type.getKind().equals(TypeKind.DECLARED)
         && MoreTypes.asTypeElement(type).equals(provider());
+  }
+
+  /**
+   * True if {@code annotation} is meta-annotated with {@code javax.inject.Qualifier} or {@code
+   * jakarta.inject.Qualifier}.
+   *
+   * <p>Both are recognized even when generated code uses only one inject package. Otherwise, if
+   * {@code jakarta.inject} is preferred for {@code Inject}/{@code Provider} types, a {@code
+   * javax.inject.Qualifier} on a {@code @Provided} parameter would be dropped from the generated
+   * factory constructor.
+   */
+  static boolean isQualifier(AnnotationMirror annotation) {
+    return MoreElements.asType(annotation.getAnnotationType().asElement())
+        .getAnnotationMirrors()
+        .stream()
+        .map(meta -> MoreElements.asType(meta.getAnnotationType().asElement()))
+        .anyMatch(type -> QUALIFIER_ANNOTATIONS.contains(type.getQualifiedName().toString()));
   }
 
   private static ImmutableMap<String, TypeElement> apiMap(

--- a/factory/src/main/java/com/google/auto/factory/processor/InjectApi.java
+++ b/factory/src/main/java/com/google/auto/factory/processor/InjectApi.java
@@ -15,10 +15,10 @@
  */
 package com.google.auto.factory.processor;
 
+import static com.google.auto.common.MoreElements.isAnnotationPresent;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static java.util.stream.Collectors.joining;
 
-import com.google.auto.common.MoreElements;
 import com.google.auto.common.MoreTypes;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
@@ -41,11 +41,14 @@ abstract class InjectApi {
 
   abstract TypeElement qualifier();
 
+  /**
+   * Every {@code Qualifier} type present on the processor classpath, from {@code javax.inject}
+   * and/or {@code jakarta.inject}.
+   */
+  abstract ImmutableSet<TypeElement> qualifierTypes();
+
   private static final ImmutableList<String> PREFIXES_IN_ORDER =
       ImmutableList.of("jakarta.inject.", "javax.inject.");
-
-  private static final ImmutableSet<String> QUALIFIER_ANNOTATIONS =
-      ImmutableSet.of("javax.inject.Qualifier", "jakarta.inject.Qualifier");
 
   static InjectApi from(Elements elementUtils, @Nullable String apiPrefix) {
     ImmutableList<String> apiPackages =
@@ -56,7 +59,8 @@ abstract class InjectApi {
       TypeElement provider = apiMap.get("Provider");
       TypeElement qualifier = apiMap.get("Qualifier");
       if (inject != null && provider != null && qualifier != null) {
-        return new AutoValue_InjectApi(inject, provider, qualifier);
+        return new AutoValue_InjectApi(
+            inject, provider, qualifier, qualifierTypesOnClasspath(elementUtils));
       }
     }
     String classes = "{" + String.join(",", API_CLASSES) + "}";
@@ -71,20 +75,30 @@ abstract class InjectApi {
   }
 
   /**
-   * True if {@code annotation} is meta-annotated with {@code javax.inject.Qualifier} or {@code
-   * jakarta.inject.Qualifier}.
+   * True if {@code annotation} is meta-annotated with a {@code Qualifier} type that is on the
+   * processor classpath ({@code javax.inject.Qualifier} and/or {@code jakarta.inject.Qualifier}).
    *
-   * <p>Both are recognized even when generated code uses only one inject package. Otherwise, if
-   * {@code jakarta.inject} is preferred for {@code Inject}/{@code Provider} types, a {@code
-   * javax.inject.Qualifier} on a {@code @Provided} parameter would be dropped from the generated
-   * factory constructor.
+   * <p>Generated code still uses only {@link #inject()}, {@link #provider()}, and {@link
+   * #qualifier()} from the one preferred inject API. Qualifier detection must recognize both
+   * packages; otherwise a {@code javax.inject.Qualifier} on a {@code @Provided} parameter is dropped
+   * when {@code jakarta.inject} is preferred.
    */
-  static boolean isQualifier(AnnotationMirror annotation) {
-    return MoreElements.asType(annotation.getAnnotationType().asElement())
-        .getAnnotationMirrors()
-        .stream()
-        .map(meta -> MoreElements.asType(meta.getAnnotationType().asElement()))
-        .anyMatch(type -> QUALIFIER_ANNOTATIONS.contains(type.getQualifiedName().toString()));
+  boolean isQualifier(AnnotationMirror annotation) {
+    return qualifierTypes().stream()
+        .anyMatch(
+            qualifierType ->
+                isAnnotationPresent(annotation.getAnnotationType().asElement(), qualifierType));
+  }
+
+  private static ImmutableSet<TypeElement> qualifierTypesOnClasspath(Elements elementUtils) {
+    ImmutableSet.Builder<TypeElement> qualifierTypes = ImmutableSet.builder();
+    for (String prefix : PREFIXES_IN_ORDER) {
+      TypeElement qualifierType = apiMap(elementUtils, prefix).get("Qualifier");
+      if (qualifierType != null) {
+        qualifierTypes.add(qualifierType);
+      }
+    }
+    return qualifierTypes.build();
   }
 
   private static ImmutableMap<String, TypeElement> apiMap(

--- a/factory/src/main/java/com/google/auto/factory/processor/Key.java
+++ b/factory/src/main/java/com/google/auto/factory/processor/Key.java
@@ -66,7 +66,7 @@ abstract class Key {
     // TODO(gak): check for only one qualifier rather than using the first
     Optional<AnnotationMirror> qualifier =
         annotations.stream()
-            .filter(InjectApi::isQualifier)
+            .filter(injectApi::isQualifier)
             .findFirst();
 
     TypeMirror keyType =

--- a/factory/src/main/java/com/google/auto/factory/processor/Key.java
+++ b/factory/src/main/java/com/google/auto/factory/processor/Key.java
@@ -15,7 +15,6 @@
  */
 package com.google.auto.factory.processor;
 
-import static com.google.auto.common.MoreElements.isAnnotationPresent;
 import static com.google.auto.factory.processor.Mirrors.unwrapOptionalEquivalence;
 import static com.google.auto.factory.processor.Mirrors.wrapOptionalInEquivalence;
 
@@ -67,10 +66,7 @@ abstract class Key {
     // TODO(gak): check for only one qualifier rather than using the first
     Optional<AnnotationMirror> qualifier =
         annotations.stream()
-            .filter(
-                annotation ->
-                    isAnnotationPresent(
-                        annotation.getAnnotationType().asElement(), injectApi.qualifier()))
+            .filter(InjectApi::isQualifier)
             .findFirst();
 
     TypeMirror keyType =

--- a/factory/src/test/java/com/google/auto/factory/processor/AutoFactoryProcessorTest.java
+++ b/factory/src/test/java/com/google/auto/factory/processor/AutoFactoryProcessorTest.java
@@ -563,6 +563,96 @@ public class AutoFactoryProcessorTest {
             "tests.ParameterAnnotationsFactory", "expected/ParameterAnnotationsFactory.java"));
   }
 
+  /**
+   * If {@code jakarta.inject} is preferred, {@code javax.inject.Qualifier} annotations on
+   * {@code @Provided} parameters must still be copied onto the generated factory constructor.
+   *
+   * <p>Golden-file tests rewrite {@code javax.inject} to {@code jakarta.inject} in sources, so they
+   * do not cover this mixed case. See <a href="https://github.com/google/auto/issues/1884">issue
+   * 1884</a>.
+   */
+  @Test
+  public void javaxQualifierPropagatedWhenJakartaInjectIsPreferred() {
+    assume().that(config.expectedPackage).isEqualTo(InjectPackage.JAKARTA);
+    assume().that(config.packagesOnClasspath).contains(InjectPackage.JAVAX);
+    JavaFileObject qualifier =
+        JavaFileObjects.forSourceLines(
+            "tests.MyQualifier",
+            "package tests;",
+            "",
+            "import static java.lang.annotation.RetentionPolicy.RUNTIME;",
+            "",
+            "import java.lang.annotation.Documented;",
+            "import java.lang.annotation.Retention;",
+            "import javax.inject.Qualifier;",
+            "",
+            "@Documented",
+            "@Qualifier",
+            "@Retention(RUNTIME)",
+            "public @interface MyQualifier {}");
+    JavaFileObject factoryClass =
+        JavaFileObjects.forSourceLines(
+            "tests.QualifiedProvided",
+            "package tests;",
+            "",
+            "import com.google.auto.factory.AutoFactory;",
+            "import com.google.auto.factory.Provided;",
+            "",
+            "@AutoFactory",
+            "final class QualifiedProvided {",
+            "  QualifiedProvided(@Provided @MyQualifier int value) {}",
+            "}");
+    Compilation compilation = config.javac().compile(qualifier, factoryClass);
+    assertThat(compilation).succeededWithoutWarnings();
+    assertThat(compilation)
+        .generatedSourceFile("tests.QualifiedProvidedFactory")
+        .contentsAsUtf8String()
+        .contains("@MyQualifier Provider<Integer> valueProvider");
+  }
+
+  /**
+   * If {@code javax.inject} is selected while {@code jakarta.inject} is also present, {@code
+   * jakarta.inject.Qualifier} annotations on {@code @Provided} parameters must still be copied.
+   */
+  @Test
+  public void jakartaQualifierPropagatedWhenJavaxInjectIsSelected() {
+    assume().that(config.expectedPackage).isEqualTo(InjectPackage.JAVAX);
+    assume().that(config.packagesOnClasspath).contains(InjectPackage.JAKARTA);
+    JavaFileObject qualifier =
+        JavaFileObjects.forSourceLines(
+            "tests.MyQualifier",
+            "package tests;",
+            "",
+            "import static java.lang.annotation.RetentionPolicy.RUNTIME;",
+            "",
+            "import java.lang.annotation.Documented;",
+            "import java.lang.annotation.Retention;",
+            "import jakarta.inject.Qualifier;",
+            "",
+            "@Documented",
+            "@Qualifier",
+            "@Retention(RUNTIME)",
+            "public @interface MyQualifier {}");
+    JavaFileObject factoryClass =
+        JavaFileObjects.forSourceLines(
+            "tests.QualifiedProvided",
+            "package tests;",
+            "",
+            "import com.google.auto.factory.AutoFactory;",
+            "import com.google.auto.factory.Provided;",
+            "",
+            "@AutoFactory",
+            "final class QualifiedProvided {",
+            "  QualifiedProvided(@Provided @MyQualifier int value) {}",
+            "}");
+    Compilation compilation = config.javac().compile(qualifier, factoryClass);
+    assertThat(compilation).succeededWithoutWarnings();
+    assertThat(compilation)
+        .generatedSourceFile("tests.QualifiedProvidedFactory")
+        .contentsAsUtf8String()
+        .contains("@MyQualifier Provider<Integer> valueProvider");
+  }
+
   @Test
   public void customAnnotations() {
     goldenTest(


### PR DESCRIPTION
## Summary
- AutoFactory 1.1.0 chooses `jakarta.inject` whenever it is on the classpath, and then treated an annotation as a qualifier only if it was meta-annotated with **that** API's `@Qualifier`.
- Dagger / existing code still commonly uses `javax.inject.Qualifier`. Those annotations were dropped from generated factory constructors (`Provider<Integer>` instead of `@MyQualifier Provider<Integer>`), which is [issue #1884](https://github.com/google/auto/issues/1884).
- Qualifier detection now accepts either `javax.inject.Qualifier` or `jakarta.inject.Qualifier`, independent of which package is used for generated `@Inject` / `Provider`.

Fixes #1884

## Test plan
- [x] `mvn test` in `factory/` — `AutoFactoryProcessorTest` 185 tests, 0 failures (new mixed javax/jakarta cases included)
- [x] `mvn verify` in `factory/` — unit tests + invoker IT `functional` passed
- [ ] Reviewer: compile an `@AutoFactory` class with `@Provided @MyQualifier` where `@MyQualifier` is `javax.inject.Qualifier` and both inject APIs are on the processor classpath; generated constructor should keep `@MyQualifier` on the `Provider` parameter