### PR TITLE
Fix binary name computation for default-package classes in the KSP processor

### DIFF
--- a/service/processor_ksp/src/main/kotlin/com/google/auto/service/processor/AutoServiceKspProcessor.kt
+++ b/service/processor_ksp/src/main/kotlin/com/google/auto/service/processor/AutoServiceKspProcessor.kt
@@ -246,6 +246,9 @@ class AutoServiceKspProcessor(val environment: SymbolProcessorEnvironment) : Sym
     }
 
     private fun KSClassDeclaration.getBinaryName(qualifiedName: String): String {
+      if (packageName.asString().isEmpty()) {
+        return qualifiedName.replace('.', '$')
+      }
       val packageSeparatorIndex = packageName.asString().length + 1 // plus the '.'
       val nameAfterPackage = qualifiedName.substring(packageSeparatorIndex)
       return "${packageName.asString()}.${nameAfterPackage.replace('.', '$')}"

--- a/service/processor_ksp/src/main/kotlin/com/google/auto/service/processor/AutoServiceKspProcessor.kt
+++ b/service/processor_ksp/src/main/kotlin/com/google/auto/service/processor/AutoServiceKspProcessor.kt
@@ -191,7 +191,7 @@ class AutoServiceKspProcessor(val environment: SymbolProcessorEnvironment) : Sym
       val lines = impls.map { it.binaryName }
       generator
         .createNewFileByPath(
-          dependencies = Dependencies(aggregating = false, sources = sourceFiles),
+          dependencies = Dependencies(aggregating = true, sources = sourceFiles),
           path = filePath,
           extensionName = "",
         )


### PR DESCRIPTION
The KSP processor was added a couple of weeks ago, and I found two things in it while reading it against the APT version.

1. Binary names for classes in the default package are wrong. getBinaryName always strips '<package>.' from the qualified name, but for a root-package class there is no such prefix, so it drops the first character and leaves a stray dot: a provider Foo ends up written as .oo in the service file. The Java AutoServiceProcessor handles the unnamed package explicitly (it just returns the class name), so the KSP side should do the same. This only bites people who put providers in the default package, which is rare, but the generated file is just wrong when it happens.

2. The generated META-INF/services/<interface> file is an aggregating output but is declared isolating (aggregating=false). Each file collects every @AutoService provider of that interface anywhere in the module, so a provider in a brand-new source file changes it. With aggregating=false, KSP won't invalidate the file when an unrelated new source is added, so on an incremental build a newly added provider never shows up in the service file. Setting aggregating=true tells KSP to regenerate it whenever there's new input.

No test added: the KSP test harness (room3) needs a full KSP/Kotlin compile that I couldn't run in my environment, and the existing tests only cover packaged classes. Both changes are behaviour-preserving for the common packaged case.