### PR TITLE
Point AutoValue invoker at value/src/it for functional tests

### DIFF
--- a/value/processor/pom.xml
+++ b/value/processor/pom.xml
@@ -42,6 +42,8 @@
   <properties>
     <auto-service.version>1.1.1</auto-service.version>
     <errorprone.version>2.50.0</errorprone.version>
+    <!-- annotations is test-scoped on this module; invoker:install defaults to runtime. -->
+    <invoker.install.scope>test</invoker.install.scope>
   </properties>
 
   <dependencies>
@@ -208,8 +210,14 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-invoker-plugin</artifactId>
         <configuration>
-          <!-- ITs live under value/src/it, not processor/src/it (see #1558). -->
+          <!-- ITs live under value/src/it, not processor/src/it (see #1558).
+               Only functional is an invoker project (eclipse profile pass via
+               invoker.properties). gwtserializer is a reactor module under the
+               java-11-and-after profile, not an invoker IT. -->
           <projectsDirectory>${project.parent.basedir}/src/it</projectsDirectory>
+          <pomIncludes>
+            <pomInclude>functional/pom.xml</pomInclude>
+          </pomIncludes>
         </configuration>
       </plugin>
       <plugin>

--- a/value/processor/pom.xml
+++ b/value/processor/pom.xml
@@ -207,6 +207,10 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-invoker-plugin</artifactId>
+        <configuration>
+          <!-- ITs live under value/src/it, not processor/src/it (see #1558). -->
+          <projectsDirectory>${project.parent.basedir}/src/it</projectsDirectory>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/value/processor/pom.xml
+++ b/value/processor/pom.xml
@@ -42,8 +42,6 @@
   <properties>
     <auto-service.version>1.1.1</auto-service.version>
     <errorprone.version>2.50.0</errorprone.version>
-    <!-- annotations is test-scoped on this module; invoker:install defaults to runtime. -->
-    <invoker.install.scope>test</invoker.install.scope>
   </properties>
 
   <dependencies>
@@ -218,6 +216,12 @@
           <pomIncludes>
             <pomInclude>functional/pom.xml</pomInclude>
           </pomIncludes>
+          <!-- annotations is test-scoped here so default install.scope=runtime
+               would skip it; do not raise install.scope to test (pulls
+               compile-testing -> com.sun:tools, missing from Central). -->
+          <extraArtifacts>
+            <extraArtifact>com.google.auto.value:auto-value-annotations:${project.version}</extraArtifact>
+          </extraArtifacts>
         </configuration>
       </plugin>
       <plugin>

--- a/value/src/it/functional/pom.xml
+++ b/value/src/it/functional/pom.xml
@@ -182,11 +182,29 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>3.5.6</version>
+        <!-- gradle-test-kit pulls JUnit Jupiter onto the test classpath; Surefire then
+             auto-selects JUnitPlatformProvider and reports Tests run: 0 for these JUnit 4
+             tests (AutoValueTest et al). Pin the JUnit 4 provider. See #1558. -->
+        <dependencies>
+          <dependency>
+            <groupId>org.apache.maven.surefire</groupId>
+            <artifactId>surefire-junit4</artifactId>
+            <version>3.5.6</version>
+          </dependency>
+        </dependencies>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
         <version>3.5.6</version>
+        <!-- Same JUnit 4 pin as surefire: GradleIT is JUnit 4. -->
+        <dependencies>
+          <dependency>
+            <groupId>org.apache.maven.surefire</groupId>
+            <artifactId>surefire-junit4</artifactId>
+            <version>3.5.6</version>
+          </dependency>
+        </dependencies>
         <configuration>
           <systemPropertyVariables>
             <autoValueVersion>${project.version}</autoValueVersion>

--- a/value/src/it/functional/pom.xml
+++ b/value/src/it/functional/pom.xml
@@ -70,15 +70,6 @@
       <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
-    <!-- Surefire 3.6 always uses Jupiter; Vintage runs these JUnit 4 tests
-         (AutoValueTest et al.) when gradle-test-kit pulls Jupiter onto the
-         classpath. See #1558 / google/auto#2135. -->
-    <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
-      <version>5.13.4</version>
-      <scope>test</scope>
-    </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava-testlib</artifactId>
@@ -190,16 +181,12 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.6.0</version>
-        <!-- Surefire 3.6 always uses Jupiter (no junit4 provider). With
-             gradle-test-kit pulling Jupiter onto the classpath, JUnit 4 suites
-             (AutoValueTest et al.) run via junit-vintage-engine. See #1558. -->
+        <version>3.5.6</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>3.6.0</version>
-        <!-- Same Vintage path as surefire: GradleIT is JUnit 4. -->
+        <version>3.5.6</version>
         <configuration>
           <systemPropertyVariables>
             <autoValueVersion>${project.version}</autoValueVersion>

--- a/value/src/it/functional/pom.xml
+++ b/value/src/it/functional/pom.xml
@@ -70,6 +70,15 @@
       <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
+    <!-- Surefire 3.6 always uses Jupiter; Vintage runs these JUnit 4 tests
+         (AutoValueTest et al.) when gradle-test-kit pulls Jupiter onto the
+         classpath. See #1558 / google/auto#2135. -->
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <version>5.13.4</version>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava-testlib</artifactId>
@@ -181,30 +190,16 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.5.6</version>
-        <!-- gradle-test-kit pulls JUnit Jupiter onto the test classpath; Surefire then
-             auto-selects JUnitPlatformProvider and reports Tests run: 0 for these JUnit 4
-             tests (AutoValueTest et al). Pin the JUnit 4 provider. See #1558. -->
-        <dependencies>
-          <dependency>
-            <groupId>org.apache.maven.surefire</groupId>
-            <artifactId>surefire-junit4</artifactId>
-            <version>3.5.6</version>
-          </dependency>
-        </dependencies>
+        <version>3.6.0</version>
+        <!-- Surefire 3.6 always uses Jupiter (no junit4 provider). With
+             gradle-test-kit pulling Jupiter onto the classpath, JUnit 4 suites
+             (AutoValueTest et al.) run via junit-vintage-engine. See #1558. -->
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>3.5.6</version>
-        <!-- Same JUnit 4 pin as surefire: GradleIT is JUnit 4. -->
-        <dependencies>
-          <dependency>
-            <groupId>org.apache.maven.surefire</groupId>
-            <artifactId>surefire-junit4</artifactId>
-            <version>3.5.6</version>
-          </dependency>
-        </dependencies>
+        <version>3.6.0</version>
+        <!-- Same Vintage path as surefire: GradleIT is JUnit 4. -->
         <configuration>
           <systemPropertyVariables>
             <autoValueVersion>${project.version}</autoValueVersion>


### PR DESCRIPTION
## Summary
- The `maven-invoker-plugin` on `value/processor` defaulted to `processor/src/it`, so the functional IT projects under `value/src/it` (and the eclipse profile pass from `invoker.properties`) never ran.
- Set `projectsDirectory` to `${project.parent.basedir}/src/it` so invoker picks them up again.

Fixes #1558

## Test plan
- [ ] `mvn -pl value/processor -am verify` (or the repo `build-pom.xml` verify job) runs the functional invoker projects